### PR TITLE
fix: 🐛 stop requiring tx permissions for joining identities

### DIFF
--- a/src/api/procedures/__tests__/consumeJoinIdentityAuthorization.ts
+++ b/src/api/procedures/__tests__/consumeJoinIdentityAuthorization.ts
@@ -327,9 +327,6 @@ describe('consumeJoinSignerAuthorization procedure', () => {
       let result = await boundFunc(args);
       expect(result).toEqual({
         roles: true,
-        permissions: {
-          transactions: [TxTags.identity.JoinIdentityAsKey],
-        },
       });
 
       args.accept = false;

--- a/src/api/procedures/consumeJoinIdentityAuthorization.ts
+++ b/src/api/procedures/consumeJoinIdentityAuthorization.ts
@@ -101,12 +101,13 @@ export async function getAuthorization(
 
   let roles = calledByTarget;
 
+  /*
+   * when accepting a JoinIdentity request, you don't need permissions (and can't have them by definition),
+   *   you just need to be the target
+   */
   if (accept) {
     return {
       roles,
-      permissions: {
-        transactions: [TxTags.identity.JoinIdentityAsKey],
-      },
     };
   }
 


### PR DESCRIPTION
This PR removes a bug introduced when refactoring permissions. Accepting an Identity invitation shouldn't require any transaction permissions, since the target account cannot possibly have an Identity to have permissions over