### PR TITLE
test: 💍 separate the two expectations into different tests to reduce ci flakiness on affirmation tests

### DIFF
--- a/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
@@ -433,6 +433,6 @@ describe('modifyInstructionAffirmation procedure', () => {
         senderLegAmount: new BigNumber(0),
         totalLegAmount: new BigNumber(1),
       });
-    });
+    }, 10000); // extend timeout, this case tends to exceed 5 seconds in CI
   });
 });

--- a/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
@@ -378,29 +378,28 @@ describe('modifyInstructionAffirmation procedure', () => {
   });
 
   describe('prepareStorage', () => {
+    const fromDid = 'fromDid';
+    const toDid = 'toDid';
+
+    let from = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: true });
+    let to = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: true });
+    const amount = new BigNumber(1);
+    const asset = entityMockUtils.getAssetInstance({ ticker: 'SOME_ASSET' });
+
     it('should return the portfolios for which to modify affirmation status', async () => {
       const proc = procedureMockUtils.getInstance<
         ModifyInstructionAffirmationParams,
         Instruction,
         Storage
       >(mockContext);
+
       const boundFunc = prepareStorage.bind(proc);
-
-      const fromDid = 'fromDid';
-      const toDid = 'toDid';
-
-      let from = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: true });
-      let to = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: true });
-      const amount = new BigNumber(1);
-      const asset = entityMockUtils.getAssetInstance({ ticker: 'SOME_ASSET' });
-
       entityMockUtils.configureMocks({
         instructionOptions: {
           getLegs: { data: [{ from, to, amount, asset }], next: null },
         },
       });
-
-      let result = await boundFunc({
+      const result = await boundFunc({
         id: new BigNumber(1),
         operation: InstructionAffirmationOperation.Affirm,
       });
@@ -413,7 +412,16 @@ describe('modifyInstructionAffirmation procedure', () => {
         senderLegAmount: new BigNumber(1),
         totalLegAmount: new BigNumber(1),
       });
+    });
 
+    it('should return the portfolios  for which to modify affirmation status when there is no sender legs', async () => {
+      const proc = procedureMockUtils.getInstance<
+        ModifyInstructionAffirmationParams,
+        Instruction,
+        Storage
+      >(mockContext);
+
+      const boundFunc = prepareStorage.bind(proc);
       from = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });
       to = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: false });
 
@@ -423,7 +431,7 @@ describe('modifyInstructionAffirmation procedure', () => {
         },
       });
 
-      result = await boundFunc({
+      const result = await boundFunc({
         id: new BigNumber(1),
         operation: InstructionAffirmationOperation.Affirm,
       });
@@ -433,6 +441,6 @@ describe('modifyInstructionAffirmation procedure', () => {
         senderLegAmount: new BigNumber(0),
         totalLegAmount: new BigNumber(1),
       });
-    }, 10000); // extend timeout, this case tends to exceed 5 seconds in CI
+    });
   });
 });


### PR DESCRIPTION
### Description

I've been noticing my PR test runs have been flaky due to a particular test case.

For now I doubled the time for it to hopefully prevent the flakiness.

### Breaking Changes

N/A

### JIRA Link

[DA-380](https://polymath.atlassian.net/browse/DA-380)

### Checklist

- [ ] Updated the Readme.md (if required) ?
