### PR TITLE
feat: 🎸 support splitting batches

### DIFF
--- a/src/api/procedures/createTransactionBatch.ts
+++ b/src/api/procedures/createTransactionBatch.ts
@@ -109,15 +109,17 @@ export function prepareStorage<ReturnValues extends unknown[]>(
 
     const { transformer = identity, resolver } = spec;
 
+    const endIndex = transactions.length;
+
     /*
-     * we pass the subset of events to the resolver that only correspond to the
+     * We pass the subset of events to the resolver that only correspond to the
      * transactions added in this iteration, and pass the result through the transformer, if any
      */
     resolvers.push(async (receipt: ISubmittableResult) => {
       let value;
 
       if (isResolverFunction(resolver)) {
-        value = await resolver(sliceBatchReceipt(receipt, startIndex, transactions.length));
+        value = await resolver(sliceBatchReceipt(receipt, startIndex, endIndex));
       } else {
         value = resolver;
       }

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -357,9 +357,11 @@ export function isIdentityRole(role: Role): role is IdentityRole {
 /**
  * Return whether value is a PolymeshTransaction
  */
-export function isPolymeshTransaction<ReturnValue, TransformedReturnValue, Args extends unknown[]>(
-  value: unknown
-): value is PolymeshTransaction<ReturnValue, TransformedReturnValue, Args> {
+export function isPolymeshTransaction<
+  ReturnValue,
+  TransformedReturnValue = ReturnValue,
+  Args extends unknown[] = unknown[]
+>(value: unknown): value is PolymeshTransaction<ReturnValue, TransformedReturnValue, Args> {
   return value instanceof PolymeshTransaction;
 }
 
@@ -368,8 +370,8 @@ export function isPolymeshTransaction<ReturnValue, TransformedReturnValue, Args 
  */
 export function isPolymeshTransactionBatch<
   ReturnValue,
-  TransformedReturnValue,
-  Args extends unknown[][]
+  TransformedReturnValue = ReturnValue,
+  Args extends unknown[][] = unknown[][]
 >(value: unknown): value is PolymeshTransactionBatch<ReturnValue, TransformedReturnValue, Args> {
   return value instanceof PolymeshTransactionBatch;
 }


### PR DESCRIPTION
Add a `splitTransactions` method to the `PolymeshTransactionBatch` class
that returns all individual transactions in the batch. This method is
useful when the caller is being subsidized, since batches do not support
subsidies

### Description

This PR adds a `splitTransactions` method to the `PolymeshTransactionBatch` class that returns all individual transactions in the batch. This method is useful when the caller is being subsidized, since batches do not support subsidies

### JIRA Link

https://polymath.atlassian.net/browse/DA-162?atlOrigin=eyJpIjoiODBiNzUyYjQ2YmM2NDI2YmE2YWE4ZmYxM2Y3YzlmZDIiLCJwIjoiaiJ9

### Checklist

- [ ] Updated the Readme.md (if required) ?
