### PR TITLE
feat: 🎸 release elimination of transaction queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This document assumes you are already familiar with [Security Tokens](https://th
 
 ### Technical Pre-requisites
 
-In order to use the Polymath SDK, you must install [node](https://nodejs.org/) \(version 10\) and [npm](https://www.npmjs.com/). The library is written in [typescript](https://www.typescriptlang.org/), but can also be used in plain javascript. This document will assume you are using typescript, but the translation to javascript is very simple.
+In order to use the Polymath SDK, you must install [node](https://nodejs.org/) \(version 14\) and [npm](https://www.npmjs.com/). The library is written in [typescript](https://www.typescriptlang.org/), but can also be used in plain javascript. This document will assume you are using typescript, but the translation to javascript is very simple.
 
 ### Documentation
 


### PR DESCRIPTION
triggers release of latest alpha as the previous merge had older commits
skipped be semver bot

Feat/da 148 eliminate transaction queues (#785)

* feat: remove Transaction Queues

The `TransactionQueue` class has been removed. Most of its methods have been moved over to
`PolymeshTransaction` and `PolymeshTransactionBatch`. Methods that returned a `TransactionQueue`
(all endpoints that write to the blockchain, such as `sdk.assets.registerTicker`) now return
either a `PolymeshTransaction` or `PolymeshTransactionBatch`. This means that all operations
in the SDK are now atomic and not prone to race conditions or half-states

- The `onProcessedByMiddleware` method has been moved to `PolymeshTransaction` and
  `PolymeshTransactionBase`
- The `Fees` interface now contains a `total` property which is the sum of `free`
  and `locked`
- The `PayingAccountType` enum now includes a `Caller` member, to represent cases
  where the calling Account has to pay for a transaction’s fees

* perf: ⚡️ use a single call to fetch latest finalized block

* chore: 🤖 implement a way of discriminating batch events

* feat: 🎸 Allow passing of `nonce` as part of `ProcedureOptions`

* refactor: 💡 Remove unnecessary nonce value from txSpec

* feat: 🎸 Add `currentNonce` method to `Account`

* chore: 🤖 Allow async values for nonce

* Update src/types/index.ts

* feat: support merging transactions into batches

* feat: 🎸 expose the `MapTxWithData` type

* docs: ✏️ improve rendered documentation to handle code snippets

* test: 💍 use proper type in assertion

* feat: 🎸 support splitting batches

* fix: 🐛 carry manual fees over when simplifying a batch

Add a `splitTransactions` method to the `PolymeshTransactionBatch` class
that returns all individual transactions in the batch. This method is
useful when the caller is being subsidized, since batches do not support
subsidies

When a procedure that normally produces batches produced a single
transaction, we weren't passing manual fee data over

- Add an `sdk.createTransactionBatch` endpoint that takes an array of SDK transactions and returns
  them all batched in a single transaction. The result of running this batch is an array of the
  results of each transaction in the same order
- Fix documentation to reflect the fact that transaction queues no longer exist
- Improve transaction fee calculation algorithm to avoid edge cases where estimated fees were
  different than the actual fees
- Expose `getProtocolFees` from `PolymeshTransaction` and `PolymeshTransactionBatch`
- Expose the `GenericPolymeshTransaction` type
  (returned by most endpoints that create transactions)

BREAKING CHANGES:

- Remove the `inputArgs` property from `PolymeshTransaction`. Replaced by the `args`
  property. Arguments for `PolymeshTransaction` and `PolymeshTransactionBatch` are now
  available at any point in time (previously they could depend on the result of a previous
  transaction in the queue)
- Remove the `isCritical` property from both `PolymeshTransaction` and `PolymeshTransactionBatch`.
  It no longer makes sense without Transaction Queues
- Change the `run` method in `PolymeshTransaction` and `PolymeshTransactionBatch` to work similarly
  to the `run` method in `TransactionQueue`. The method will check if the caller account has
  enough balance for fees, the transaction will be run and its status updated. The method returns
  a Promise that resolves to the result of running the transaction. For example, calling `run` on
  the transaction returned by `asset.registerTicker` will return a Promise that resolves to a
  `TickerReservation` entity
- Change the argument received by the callback passed to `onStatusChange` to
  `PolymeshTransactionBase`. If type refinement is required, the `isPolymeshTransaction`
  and `isPolymeshTransactionBatch` typeguards can be used (they can be imported from `types`)
- Change the return type of `getFees` in `PolymeshTransaction` and `PolymeshTransactionBatch`
  to `PayingAccountFees`, which contains details about the Account that will pay for the fees,
  its remaining balance (before paying), and the fees themselves
- Remove the `getPayingAccount` method from `PolymeshTransaction` and `PolymeshTransactionBatch`.
  Its result is now contained in `getFees`
- Change the `PayingAccount` type to now only contain `allowance: BigNumber` when `type` is
  `Subsidy`. For `Caller` and `Other`, there is no `allowance`
- Rename `getFees` to `getTotalFees` in `PolymeshTransaction` and `PolymeshTransactionBatch`
