### PR TITLE
fix: 🐛 fix bug where only the default signer was used

### DIFF
--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -339,8 +339,8 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
 
       const procedureResult = await prepareTransactionsPromise;
 
-      const signingAddress = context.getSigningAddress();
-      const signer = context.getExternalSigner();
+      const signingAddress = ctx.getSigningAddress();
+      const signer = ctx.getExternalSigner();
 
       const spec = {
         ...procedureResult,


### PR DESCRIPTION
### Description

in Procedure `prepare` method, the passed in, non modified `context` was
used, when `ctx` was supposed to be used instead

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

[DA-405](https://github.com/PolymeshAssociation/polymesh-sdk/pull/831#issuecomment-1227689597)

### Checklist

- [ ] Updated the Readme.md (if required) ?
