### PR TITLE
fix: 🐛 improve the typing of `splitTransactions`

### DIFF
--- a/src/base/PolymeshTransactionBatch.ts
+++ b/src/base/PolymeshTransactionBatch.ts
@@ -156,10 +156,10 @@ export class PolymeshTransactionBatch<
    * console.log(`New Asset created! Ticker: ${ticker}`);
    * ```
    */
-  public splitTransactions(): [
-    ...PolymeshTransaction<void>[],
-    PolymeshTransaction<ReturnValue, TransformedReturnValue>
-  ] {
+  public splitTransactions(): (
+    | PolymeshTransaction<void>
+    | PolymeshTransaction<ReturnValue, TransformedReturnValue>
+  )[] {
     const { signingAddress, signer, context } = this;
     const { transactions, resolver, transformer } =
       PolymeshTransactionBatch.toTransactionSpec(this);
@@ -228,10 +228,7 @@ export class PolymeshTransactionBatch<
       }) as (() => Promise<TransformedReturnValue>) | (() => Promise<void>);
 
       return newTransaction;
-    }) as [
-      ...PolymeshTransaction<void>[],
-      PolymeshTransaction<ReturnValue, TransformedReturnValue>
-    ];
+    });
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1536,7 +1536,9 @@ export type GenericPolymeshTransaction<ProcedureReturnValue, ReturnValue> =
   | PolymeshTransactionBatch<ProcedureReturnValue, ReturnValue>;
 
 export type TransactionArray<ReturnValues extends readonly [...unknown[]]> = {
-  [K in keyof ReturnValues]: GenericPolymeshTransaction<ReturnValues[K], ReturnValues[K]>;
+  // The type has to be any here to account for procedures with transformed return values
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [K in keyof ReturnValues]: GenericPolymeshTransaction<any, ReturnValues[K]>;
 };
 
 /**


### PR DESCRIPTION
### Description

The original types weren't being properly reflected by the compiler, resulting in an array of only 2 transactions always. Also, when batching transactions that had a transformed return value, the compiler was throwing errors. Since we don't care about the original return value, only the transformed one, using `any` is acceptable (`unknown` resulted in errors as well)

### Checklist

- [ ] Updated the Readme.md (if required) ?
