### PR TITLE
chore: 🤖 use api.at(<blockhash>) for querying old blocks

### DIFF
--- a/src/api/procedures/setTransferRestrictions.ts
+++ b/src/api/procedures/setTransferRestrictions.ts
@@ -137,7 +137,6 @@ function transformInput(
 
     restriction.exemptedIdentities?.forEach(exemption => {
       const key = claimType || 'None';
-      console.log('claimType in exempted loop', claimType, 'key: ', key);
       const id = asIdentity(exemption, context);
       addExemptionIfNotPresent(id, inputExemptions, key);
     });

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -8,7 +8,7 @@ import { didsWithClaims, heartbeat } from '~/middleware/queries';
 import { claimsQuery, heartbeatQuery } from '~/middleware/queriesV2';
 import { ClaimTypeEnum, IdentityWithClaimsResult } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
-import { createMockAccountId } from '~/testUtils/mocks/dataSources';
+import { createMockAccountId, getAtStub } from '~/testUtils/mocks/dataSources';
 import {
   ClaimType,
   CorporateActionKind,
@@ -823,7 +823,9 @@ describe('Context class', () => {
 
       expect(result).toEqual(mockResult);
 
+      context.isArchiveNode = true;
       result = await context.getProtocolFees({ tags, blockHash: '0x000' });
+      sinon.assert.calledOnce(getAtStub());
       expect(result).toEqual(mockResult);
     });
   });

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -996,6 +996,7 @@ function initApi(): void {
   initConsts();
   initQueryMulti();
 
+  mockInstanceContainer.apiInstance.at = sinon.stub().resolves(mockInstanceContainer.apiInstance);
   apiPromiseCreateStub = sinon.stub();
   MockApiPromiseClass.create = apiPromiseCreateStub.resolves(mockInstanceContainer.apiInstance);
 }
@@ -1294,7 +1295,6 @@ export function createQueryStub<
   if (!runtimeModule[query]) {
     stub = sinon.stub() as unknown as QueryStub;
     stub.entries = sinon.stub();
-    stub.entriesAt = sinon.stub();
     stub.entriesPaged = sinon.stub();
     stub.at = sinon.stub();
     stub.multi = sinon.stub();
@@ -1315,7 +1315,6 @@ export function createQueryStub<
   ]);
   stub.entries.resolves(entryResults);
   stub.entriesPaged.resolves(entryResults);
-  stub.entriesAt.resolves(entryResults);
 
   if (opts?.multi) {
     stub.multi.resolves(opts.multi);
@@ -1551,6 +1550,14 @@ export function getMiddlewareApiV2(): ApolloClient<NormalizedCacheObject> &
  */
 export function getCreateTypeStub(): SinonStub {
   return mockInstanceContainer.apiInstance.createType as SinonStub;
+}
+
+/**
+ * @hidden
+ * Retrieve the stub of the at method
+ */
+export function getAtStub(): SinonStub {
+  return mockInstanceContainer.apiInstance.at as SinonStub;
 }
 
 /**

--- a/src/types/utils/index.ts
+++ b/src/types/utils/index.ts
@@ -1,4 +1,4 @@
-import { AugmentedQuery } from '@polkadot/api/types';
+import { AugmentedQueries, AugmentedQuery } from '@polkadot/api/types';
 import type { Observable } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
@@ -59,6 +59,29 @@ export type QueryReturnType<T> = T extends AugmentedQuery<'promise', infer Fun>
   ? ReturnType<Fun> extends Observable<infer R>
     ? R
     : never
+  : never;
+
+/**
+ * @hidden
+ *
+ * Extract the polkadot.js query function
+ *
+ * @example `QueryableStorageFunction<'identity', 'authorizations'>` returns
+ * `(
+ *     arg1:
+ *      | PolymeshPrimitivesSecondaryKeySignatory
+ *      | { Identity: any }
+ *      | { Account: any }
+ *      | string
+ *      | Uint8Array,
+ *    arg2: u64 | AnyNumber | Uint8Array
+ *  ) => Observable<Option<PolymeshPrimitivesAuthorization>>`
+ */
+export type QueryFunction<
+  ModuleName extends keyof AugmentedQueries<'promise'>,
+  QueryName extends keyof AugmentedQueries<'promise'>[ModuleName]
+> = AugmentedQueries<'promise'>[ModuleName][QueryName] extends AugmentedQuery<'promise', infer Fun>
+  ? Fun
   : never;
 
 /**

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -15,6 +15,8 @@ import { ClaimScopeTypeEnum } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
 import {
   createMockStatisticsStatClaim,
+  getApiInstance,
+  getAtStub,
   getWebSocketInstance,
   MockCodec,
   MockWebSocket,
@@ -56,6 +58,7 @@ import {
   createProcedureMethod,
   delay,
   filterEventRecords,
+  getApiAtBlock,
   getCheckpointValue,
   getDid,
   getExemptedIds,
@@ -465,7 +468,52 @@ describe('requestPaginated', () => {
   });
 });
 
+describe('getApiAtBlock', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if the node is not archive', () => {
+    const context = dsMockUtils.getContextInstance({
+      isArchiveNode: false,
+    });
+
+    return expect(getApiAtBlock(context, 'blockHash')).rejects.toThrow(
+      'Cannot query previous blocks in a non-archive node'
+    );
+  });
+
+  it('should return corresponding API state at given block', async () => {
+    const context = dsMockUtils.getContextInstance();
+
+    const result = await getApiAtBlock(context, 'blockHash');
+
+    expect(result).toEqual(getApiInstance());
+    sinon.assert.calledOnce(getAtStub());
+  });
+});
+
 describe('requestAtBlock', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
   it('should fetch and return the value at a certain block (current if left empty)', async () => {
     const context = dsMockUtils.getContextInstance({
       isArchiveNode: true,
@@ -479,7 +527,8 @@ describe('requestAtBlock', () => {
     const ticker = 'ticker';
 
     let res = await requestAtBlock(
-      queryStub,
+      'asset',
+      'tickers',
       {
         blockHash,
         args: [ticker],
@@ -487,11 +536,13 @@ describe('requestAtBlock', () => {
       context
     );
 
-    sinon.assert.calledWith(queryStub.at, blockHash, ticker);
+    sinon.assert.calledOnce(getAtStub());
+    sinon.assert.calledWith(queryStub, ticker);
     expect(res).toBe(returnValue);
 
     res = await requestAtBlock(
-      queryStub,
+      'asset',
+      'tickers',
       {
         args: [ticker],
       },
@@ -500,27 +551,6 @@ describe('requestAtBlock', () => {
 
     sinon.assert.calledWith(queryStub, ticker);
     expect(res).toBe(returnValue);
-  });
-
-  it('should throw an error if the node is not archive', () => {
-    const context = dsMockUtils.getContextInstance({
-      isArchiveNode: false,
-    });
-
-    const queryStub = dsMockUtils.createQueryStub('asset', 'tickers', {
-      returnValue: dsMockUtils.createMockU32(new BigNumber(5)),
-    });
-
-    return expect(
-      requestAtBlock(
-        queryStub,
-        {
-          blockHash: 'someBlockHash',
-          args: ['ticker'],
-        },
-        context
-      )
-    ).rejects.toThrow('Cannot query previous blocks in a non-archive node');
   });
 });
 

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -1,5 +1,7 @@
 import {
+  ApiDecoration,
   AugmentedEvent,
+  AugmentedQueries,
   AugmentedQuery,
   AugmentedQueryDoubleMap,
   DropLast,
@@ -70,11 +72,17 @@ import {
   Falsyable,
   MapTxWithArgs,
   PolymeshTx,
+  Queries,
   StatClaimIssuer,
   StatType,
   TxWithArgs,
 } from '~/types/internal';
-import { HumanReadableType, ProcedureFunc, UnionOfProcedureFuncs } from '~/types/utils';
+import {
+  HumanReadableType,
+  ProcedureFunc,
+  QueryFunction,
+  UnionOfProcedureFuncs,
+} from '~/types/utils';
 import {
   DEFAULT_GQL_PAGE_SIZE,
   MAX_TICKER_LENGTH,
@@ -492,30 +500,56 @@ export async function requestPaginated<F extends AnyFunction, T extends AnyTuple
 /**
  * @hidden
  *
+ * Gets Polymesh API instance at a particular block
+ */
+export async function getApiAtBlock(
+  context: Context,
+  blockHash: string | BlockHash
+): Promise<ApiDecoration<'promise'>> {
+  const { polymeshApi, isArchiveNode } = context;
+
+  if (!isArchiveNode) {
+    throw new PolymeshError({
+      code: ErrorCode.DataUnavailable,
+      message: 'Cannot query previous blocks in a non-archive node',
+    });
+  }
+
+  return polymeshApi.at(blockHash);
+}
+
+/**
+ * @hidden
+ *
  * Makes a request to the chain. If a block hash is supplied,
  *   the request will be made at that block. Otherwise, the most recent block will be queried
  */
-export async function requestAtBlock<F extends AnyFunction>(
-  query: AugmentedQuery<'promise', F> | AugmentedQueryDoubleMap<'promise', F>,
+export async function requestAtBlock<
+  ModuleName extends keyof AugmentedQueries<'promise'>,
+  QueryName extends keyof AugmentedQueries<'promise'>[ModuleName]
+>(
+  moduleName: ModuleName,
+  queryName: QueryName,
   opts: {
     blockHash?: string | BlockHash;
-    args: Parameters<F>;
+    args: Parameters<QueryFunction<ModuleName, QueryName>>;
   },
   context: Context
-): Promise<ObsInnerType<ReturnType<F>>> {
+): Promise<ObsInnerType<ReturnType<QueryFunction<ModuleName, QueryName>>>> {
   const { blockHash, args } = opts;
 
+  let query: Queries;
   if (blockHash) {
-    if (!context.isArchiveNode) {
-      throw new PolymeshError({
-        code: ErrorCode.DataUnavailable,
-        message: 'Cannot query previous blocks in a non-archive node',
-      });
-    }
-    return query.at(blockHash, ...args);
+    ({ query } = await getApiAtBlock(context, blockHash));
+  } else {
+    ({ query } = context.polymeshApi);
   }
 
-  return query(...args);
+  const queryMethod = query[moduleName][queryName] as unknown as QueryFunction<
+    typeof moduleName,
+    typeof queryName
+  >;
+  return queryMethod(...args);
 }
 
 /**


### PR DESCRIPTION
### Description

Methods such as `<query>.at(..args)` and `<query>.entriesAt(...args)` were deprecated from Polkadot in favour of first getting a decorated api at any block with `api.at(<blockHash>)` and then using the `query` module within it to get the desired result. This change updates all occurrence to use the latest logic

### Breaking Changes

NA

### JIRA Link

[DA-410](https://polymesh.atlassian.net/browse/DA-410)

### Checklist

- [ ] Updated the Readme.md (if required) ?
