### PR TITLE
docs: ✏️ fix doc warnings for multiSig + StatType

### DIFF
--- a/src/api/client/AccountManagement.ts
+++ b/src/api/client/AccountManagement.ts
@@ -218,7 +218,7 @@ export class AccountManagement {
   }
 
   /**
-   * Return an Account instance from an address. If the Account has multiSig signers, the returned value will be a {@link api/entities/MultiSig/MultiSig!MultiSig} instance
+   * Return an Account instance from an address. If the Account has multiSig signers, the returned value will be a {@link api/entities/MultiSig!MultiSig} instance
    */
   public async getAccount(args: { address: string }): Promise<Account | MultiSig> {
     const {

--- a/src/api/entities/Asset/TransferRestrictions/TransferRestrictionBase.ts
+++ b/src/api/entities/Asset/TransferRestrictions/TransferRestrictionBase.ts
@@ -29,9 +29,9 @@ import {
   SetCountTransferRestrictionsParams,
   SetPercentageTransferRestrictionsParams,
   SetRestrictionsParams,
+  StatType,
   TransferRestrictionType,
 } from '~/types';
-import { StatType } from '~/types/internal';
 import {
   scopeIdToString,
   stringToTickerKey,

--- a/src/api/entities/Asset/TransferRestrictions/__tests__/TransferRestrictionBase.ts
+++ b/src/api/entities/Asset/TransferRestrictions/__tests__/TransferRestrictionBase.ts
@@ -16,9 +16,9 @@ import {
   SetClaimPercentageTransferRestrictionsParams,
   SetCountTransferRestrictionsParams,
   SetPercentageTransferRestrictionsParams,
+  StatType,
   TransferRestrictionType,
 } from '~/types';
-import { StatType } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
 import { Count } from '../Count';

--- a/src/api/entities/MultiSig/index.ts
+++ b/src/api/entities/MultiSig/index.ts
@@ -59,7 +59,7 @@ export class MultiSig extends Account {
   }
 
   /**
-   * Given an ID, fetch a { @link api/entities/MultiSig/MultiSigProposal!MultiSigProposal } for this MultiSig
+   * Given an ID, fetch a { @link api/entities/MultiSigProposal!MultiSigProposal } for this MultiSig
    *
    * @throws if the MultiSigProposal is not found
    */
@@ -81,7 +81,7 @@ export class MultiSig extends Account {
   }
 
   /**
-   * Return all { @link api/entities/MultiSig/MultiSigProposal!MultiSigProposal } for this MultiSig Account
+   * Return all { @link api/entities/MultiSigProposal!MultiSigProposal } for this MultiSig Account
    */
   public async getProposals(): Promise<MultiSigProposal[]> {
     const {

--- a/src/api/procedures/__tests__/addAssetStat.ts
+++ b/src/api/procedures/__tests__/addAssetStat.ts
@@ -22,9 +22,10 @@ import {
   CountryCode,
   ErrorCode,
   StatClaimType,
+  StatType,
   TxTags,
 } from '~/types';
-import { PolymeshTx, StatType, TickerKey } from '~/types/internal';
+import { PolymeshTx, TickerKey } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(

--- a/src/api/procedures/__tests__/addTransferRestriction.ts
+++ b/src/api/procedures/__tests__/addTransferRestriction.ts
@@ -25,11 +25,12 @@ import {
   CountryCode,
   ErrorCode,
   StatJurisdictionClaimInput,
+  StatType,
   TransferRestriction,
   TransferRestrictionType,
   TxTags,
 } from '~/types';
-import { PolymeshTx, StatType, TickerKey } from '~/types/internal';
+import { PolymeshTx, TickerKey } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(

--- a/src/api/procedures/__tests__/createAsset.ts
+++ b/src/api/procedures/__tests__/createAsset.ts
@@ -32,10 +32,11 @@ import {
   RoleType,
   SecurityIdentifier,
   SecurityIdentifierType,
+  StatType,
   TickerReservationStatus,
   TxTags,
 } from '~/types';
-import { InternalAssetType, PolymeshTx, StatType, TickerKey } from '~/types/internal';
+import { InternalAssetType, PolymeshTx, TickerKey } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(

--- a/src/api/procedures/__tests__/removeAssetStat.ts
+++ b/src/api/procedures/__tests__/removeAssetStat.ts
@@ -20,9 +20,10 @@ import {
   ErrorCode,
   RemoveAssetStatParams,
   StatClaimType,
+  StatType,
   TxTags,
 } from '~/types';
-import { PolymeshTx, StatType, TickerKey } from '~/types/internal';
+import { PolymeshTx, TickerKey } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(

--- a/src/api/procedures/__tests__/setTransferRestrictions.ts
+++ b/src/api/procedures/__tests__/setTransferRestrictions.ts
@@ -27,11 +27,12 @@ import {
   ClaimType,
   ErrorCode,
   Identity,
+  StatType,
   TransferRestriction,
   TransferRestrictionType,
   TxTags,
 } from '~/types';
-import { PolymeshTx, StatType, TickerKey } from '~/types/internal';
+import { PolymeshTx, TickerKey } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(

--- a/src/api/procedures/addAssetStat.ts
+++ b/src/api/procedures/addAssetStat.ts
@@ -1,6 +1,6 @@
 import { Asset, PolymeshError, Procedure } from '~/internal';
-import { AddAssetStatParams, ErrorCode, TxTags } from '~/types';
-import { BatchTransactionSpec, ProcedureAuthorization, StatType } from '~/types/internal';
+import { AddAssetStatParams, ErrorCode, StatType, TxTags } from '~/types';
+import { BatchTransactionSpec, ProcedureAuthorization } from '~/types/internal';
 import {
   claimCountStatInputToStatUpdates,
   claimIssuerToMeshClaimIssuer,

--- a/src/api/procedures/removeAssetStat.ts
+++ b/src/api/procedures/removeAssetStat.ts
@@ -5,13 +5,8 @@ import {
 } from '@polkadot/types/lookup';
 
 import { Asset, PolymeshError, Procedure } from '~/internal';
-import { ErrorCode, RemoveAssetStatParams, StatClaimIssuer, TxTags } from '~/types';
-import {
-  ExtrinsicParams,
-  ProcedureAuthorization,
-  StatType,
-  TransactionSpec,
-} from '~/types/internal';
+import { ErrorCode, RemoveAssetStatParams, StatClaimIssuer, StatType, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import { QueryReturnType } from '~/types/utils';
 import {
   claimIssuerToMeshClaimIssuer,

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -43,12 +43,12 @@ import {
   SecurityIdentifier,
   Signer,
   StatClaimIssuer,
+  StatType,
   TransactionArray,
   TransactionPermissions,
   TxGroup,
   VenueType,
 } from '~/types';
-import { StatType } from '~/types/internal';
 import { Modify } from '~/types/utils';
 
 export type AddRestrictionParams<T> = Omit<

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -195,11 +195,12 @@ import {
   ProtocolFees,
   ResultSet,
   SignerType,
+  StatType,
   SubsidyWithAllowance,
   TxTags,
   UnsubCallback,
 } from '~/types';
-import { Consts, Extrinsics, GraphqlQuery, PolymeshTx, Queries, StatType } from '~/types/internal';
+import { Consts, Extrinsics, GraphqlQuery, PolymeshTx, Queries } from '~/types/internal';
 import { ArgsType, Mutable, tuple } from '~/types/utils';
 import { STATE_RUNTIME_VERSION_CALL, SYSTEM_VERSION_RPC_CALL } from '~/utils/constants';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,6 @@ import {
   PolymeshTransaction,
   PolymeshTransactionBatch,
 } from '~/internal';
-import { StatType } from '~/types/internal';
 import { Modify } from '~/types/utils';
 
 export * from '~/generated/types';
@@ -331,6 +330,23 @@ export type InputStatType =
       claimIssuer: StatClaimIssuer;
     };
 
+/**
+ * Represents the StatType from the `statistics` module.
+ *
+ * @note the chain doesn't use "Scoped" types, but they are needed here to discriminate the input instead of having an optional input
+ */
+export enum StatType {
+  Count = 'Count',
+  Balance = 'Balance',
+  /**
+   * ScopedCount is an SDK only type, on chain it is `Count` with a claimType option present
+   */
+  ScopedCount = 'ScopedCount',
+  /**
+   * ScopedPercentage is an SDK only type, on chain it is `Balance` with a claimType option present
+   */
+  ScopedBalance = 'ScopedBalance',
+}
 export interface IdentityWithClaims {
   identity: Identity;
   claims: ClaimData[];

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -319,24 +319,6 @@ export type PermissionGroupIdentifier = PermissionGroupType | { custom: BigNumbe
 
 export type InternalAssetType = KnownAssetType | { Custom: CustomAssetTypeId };
 
-/**
- * Represents the StatType from the `statistics` module.
- *
- * @note the chain doesn't use "Scoped" types, but they are needed here to discriminate the input instead of having an optional input
- */
-export enum StatType {
-  Count = 'Count',
-  Balance = 'Balance',
-  /**
-   * ScopedCount is an SDK only type, on chain it is `Count` with a claimType option present
-   */
-  ScopedCount = 'ScopedCount',
-  /**
-   * ScopedPercentage is an SDK only type, on chain it is `Balance` with a claimType option present
-   */
-  ScopedBalance = 'ScopedBalance',
-}
-
 export interface TickerKey {
   Ticker: PolymeshPrimitivesTicker;
 }

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -124,6 +124,7 @@ import {
   Signer,
   SignerType,
   SignerValue,
+  StatType,
   TargetTreatment,
   TransferError,
   TransferRestriction,
@@ -134,7 +135,7 @@ import {
   TxTags,
   VenueType,
 } from '~/types';
-import { InstructionStatus, PermissionGroupIdentifier, StatType } from '~/types/internal';
+import { InstructionStatus, PermissionGroupIdentifier } from '~/types/internal';
 import { tuple } from '~/types/utils';
 import { DUMMY_ACCOUNT_ID, MAX_BALANCE, MAX_DECIMALS, MAX_TICKER_LENGTH } from '~/utils/constants';
 import * as internalUtils from '~/utils/internal';

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -31,11 +31,11 @@ import {
   PermissionedAccount,
   ProcedureMethod,
   RemoveAssetStatParams,
+  StatType,
   SubCallback,
   TransferRestrictionType,
   TxTags,
 } from '~/types';
-import { StatType } from '~/types/internal';
 import { tuple } from '~/types/utils';
 import { MAX_TICKER_LENGTH } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -210,6 +210,7 @@ import {
   SignerValue,
   SingleClaimCondition,
   StatClaimType,
+  StatType,
   TargetTreatment,
   Tier,
   TransactionPermissions,
@@ -238,7 +239,6 @@ import {
   ScheduleSpec,
   StatClaimInputType,
   StatClaimIssuer,
-  StatType,
   TickerKey,
 } from '~/types/internal';
 import { tuple } from '~/types/utils';

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -59,6 +59,7 @@ import {
   ProcedureOpts,
   RemoveAssetStatParams,
   Scope,
+  StatType,
   SubCallback,
   TransferRestriction,
   TransferRestrictionType,
@@ -71,7 +72,6 @@ import {
   MapTxWithArgs,
   PolymeshTx,
   StatClaimIssuer,
-  StatType,
   TxWithArgs,
 } from '~/types/internal';
 import { HumanReadableType, ProcedureFunc, UnionOfProcedureFuncs } from '~/types/utils';


### PR DESCRIPTION
cleans up doc gen warnings around multiSig references and StatType not being exposed in the docs

### Description

I moved the MultiSig files late in the PR process, but forgot about the @link refs to it. This PR cleans up the warnings.

It also exposes `StatType` for transfer restrictions, as this is used to discriminate the input types. Although the user doesn't need this (we set it in the namespace), TSDocs warned about it not being shown. 

### Breaking Changes

N/A

### JIRA Link

N/A (I noticed this when doing DA-407)

### Checklist

- [ ] Updated the Readme.md (if required) ?
