### PR TITLE
feat: 🎸 add result to successfully ran transactions

### DIFF
--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -655,9 +655,9 @@ export abstract class PolymeshTransactionBase<
 
   /**
    * returns the transaction result - this is the same value as the Promise run returns
-   * @note it is generally preferable to `await` the `Promise` returned by { @link base/PolymeshTransactionBase!PolymeshTransactionBase.run | transaction.run() } over reading this property
+   * @note it is generally preferable to `await` the `Promise` returned by { @link base/PolymeshTransactionBase!PolymeshTransactionBase.run | transaction.run() } instead of reading this property
    *
-   * @throws if the is { @link base/PolymeshTransactionBase!PolymeshTransactionBase.isSuccess | transaction.isSuccess } is false — be sure to check before accessing
+   * @throws if the { @link base/PolymeshTransactionBase!PolymeshTransactionBase.isSuccess | transaction.isSuccess } property is false — be sure to check that before accessing!
    */
   get result(): TransformedReturnValue {
     if (this.isSuccess) {

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -149,6 +149,12 @@ export abstract class PolymeshTransactionBase<
 
   /**
    * @hidden
+   * the result that was returned from this transaction after being successfully ran
+   */
+  private _result: TransformedReturnValue | undefined;
+
+  /**
+   * @hidden
    */
   constructor(
     transactionSpec: BaseTransactionSpec<ReturnValue, TransformedReturnValue> &
@@ -199,9 +205,10 @@ export abstract class PolymeshTransactionBase<
         value = resolver;
       }
 
+      this._result = await transformer(value);
       this.updateStatus(TransactionStatus.Succeeded);
 
-      return transformer(value);
+      return this._result;
     } catch (err) {
       const error: PolymeshError = err;
 
@@ -644,6 +651,32 @@ export abstract class PolymeshTransactionBase<
         },
       });
     }
+  }
+
+  /**
+   * returns the transaction result - this is the same value as the Promise run returns
+   * @note it is generally preferable to `await` the `Promise` returned by { @link base/PolymeshTransactionBase!PolymeshTransactionBase.run | transaction.run() } over reading this property
+   *
+   * @throws if the is { @link base/PolymeshTransactionBase!PolymeshTransactionBase.isSuccess | transaction.isSuccess } is false — be sure to check before accessing
+   */
+  get result(): TransformedReturnValue {
+    if (this.isSuccess) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return this._result!;
+    } else {
+      throw new PolymeshError({
+        code: ErrorCode.General,
+        message:
+          'The result of the transaction was checked before it has been completed. property `result` should only be read if transaction `isSuccess` property is true',
+      });
+    }
+  }
+
+  /**
+   * returns true if transaction has completed successfully
+   */
+  get isSuccess(): boolean {
+    return this.status === TransactionStatus.Succeeded;
   }
 
   /**

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 
 import {
   Context,
+  PolymeshError,
   PolymeshTransaction,
   PolymeshTransactionBase,
   PolymeshTransactionBatch,
@@ -15,7 +16,7 @@ import { fakePromise, fakePromises } from '~/testUtils';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
 import { MockTxStatus } from '~/testUtils/mocks/dataSources';
 import { Mocked } from '~/testUtils/types';
-import { PayingAccountType, TransactionStatus, TxTags } from '~/types';
+import { ErrorCode, PayingAccountType, TransactionStatus, TxTags } from '~/types';
 import { tuple } from '~/types/utils';
 import * as utilsConversionModule from '~/utils/conversion';
 
@@ -891,6 +892,87 @@ describe('Polymesh Transaction Base class', () => {
       (tx as any).emitter.emit('ProcessedByMiddleware');
 
       sinon.assert.callCount(listenerStub, 1);
+    });
+  });
+
+  describe('getter: result', () => {
+    it('should return a result if the transaction was successful', async () => {
+      const transaction = dsMockUtils.createTxStub('asset', 'registerTicker');
+      const resolver = (): number => 1;
+      const transformer = (): number => 2;
+      const args = tuple('FOO');
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver,
+          transformer,
+        },
+        context
+      );
+
+      await tx.run();
+
+      expect(tx.result).toEqual(2);
+    });
+
+    it('should throw an error is the transaction was not successful', () => {
+      const transaction = dsMockUtils.createTxStub('asset', 'registerTicker');
+      const args = tuple('FOO');
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver: undefined,
+        },
+        context
+      );
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.General,
+        message:
+          'The result of the transaction was checked before it has been completed. property `result` should only be read if transaction `isSuccess` property is true',
+      });
+
+      expect(() => tx.result).toThrowError(expectedError);
+    });
+  });
+
+  describe('getter: isSuccess', () => {
+    it('should be true if the transaction status is TransactionStatus.Success', async () => {
+      const transaction = dsMockUtils.createTxStub('asset', 'registerTicker');
+      const args = tuple('FOO');
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver: undefined,
+        },
+        context
+      );
+
+      await tx.run();
+
+      expect(tx.isSuccess).toEqual(true);
+    });
+
+    it('should be false otherwise', () => {
+      const transaction = dsMockUtils.createTxStub('asset', 'registerTicker');
+      const args = tuple('FOO');
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver: undefined,
+        },
+        context
+      );
+
+      expect(tx.isSuccess).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
### Description

Adds a getter `result` to PolymeshTransactionBase class. this will have the result resolved from run() so it can be accessed later

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

✅ Closes: [DA-407](https://polymesh.atlassian.net/browse/DA-407)

### Checklist

- [ ] Updated the Readme.md (if required) ?
