### PR TITLE
feat: 🎸 allow specifying transaction mortality

### DIFF
--- a/src/api/procedures/__tests__/createTransactionBatch.ts
+++ b/src/api/procedures/__tests__/createTransactionBatch.ts
@@ -141,6 +141,7 @@ describe('createTransactionBatch procedure', () => {
             resolver: 1,
             signingAddress: 'someAddress',
             signer: {} as PolkadotSigner,
+            mortality: { immortal: false },
           },
           mockContext
         ),
@@ -152,6 +153,7 @@ describe('createTransactionBatch procedure', () => {
             transformer: (val): number => val * 2,
             signingAddress: 'someAddress',
             signer: {} as PolkadotSigner,
+            mortality: { immortal: false },
           },
           mockContext
         ),

--- a/src/base/PolymeshTransaction.ts
+++ b/src/base/PolymeshTransaction.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 
 import { Context, PolymeshTransactionBase } from '~/internal';
 import { TxTag, TxTags } from '~/types';
-import { PolymeshTx, TransactionSigningData, TransactionSpec } from '~/types/internal';
+import { PolymeshTx, TransactionConstructionData, TransactionSpec } from '~/types/internal';
 import { transactionToTxTag } from '~/utils/conversion';
 
 /**
@@ -74,7 +74,7 @@ export class PolymeshTransaction<
    */
   constructor(
     transactionSpec: TransactionSpec<ReturnValue, Args, TransformedReturnValue> &
-      TransactionSigningData,
+      TransactionConstructionData,
     context: Context
   ) {
     const { args = [], feeMultiplier, transaction, fee, paidForBy, ...rest } = transactionSpec;

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -263,8 +263,7 @@ export abstract class PolymeshTransactionBase<
     const { signingAddress, signer, mortality, context } = this;
 
     const nonce = context.getNonce().toNumber();
-    // era represents how many blocks the transaction should be valid for
-    const era = mortality.immortal ? 0 : mortality.blocksToLive?.toNumber();
+    const era = mortality.immortal ? 0 : undefined;
 
     this.updateStatus(TransactionStatus.Unapproved);
 

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -12,6 +12,7 @@ import { Query } from '~/middleware/types';
 import {
   ErrorCode,
   GenericPolymeshTransaction,
+  MortalityProcedureOpt,
   PayingAccount,
   PayingAccountFees,
   PayingAccountType,
@@ -22,7 +23,7 @@ import {
   BaseTransactionSpec,
   isResolverFunction,
   MaybeResolverFunction,
-  TransactionSigningData,
+  TransactionConstructionData,
 } from '~/types/internal';
 import { Ensured } from '~/types/utils';
 import { balanceToBigNumber, hashToString, u32ToBigNumber } from '~/utils/conversion';
@@ -125,6 +126,13 @@ export abstract class PolymeshTransactionBase<
   /**
    * @hidden
    *
+   * Mortality of the transactions
+   */
+  protected mortality: MortalityProcedureOpt;
+
+  /**
+   * @hidden
+   *
    * object that performs the payload signing logic
    */
   protected signer: PolkadotSigner;
@@ -158,12 +166,13 @@ export abstract class PolymeshTransactionBase<
    */
   constructor(
     transactionSpec: BaseTransactionSpec<ReturnValue, TransformedReturnValue> &
-      TransactionSigningData,
+      TransactionConstructionData,
     context: Context
   ) {
-    const { resolver, transformer, signingAddress, signer, paidForBy } = transactionSpec;
+    const { resolver, transformer, signingAddress, signer, paidForBy, mortality } = transactionSpec;
 
     this.signingAddress = signingAddress;
+    this.mortality = mortality;
     this.signer = signer;
     this.context = context;
     this.paidForBy = paidForBy;
@@ -251,79 +260,93 @@ export abstract class PolymeshTransactionBase<
    *   throwing any pertinent errors
    */
   private async internalRun(): Promise<ISubmittableResult> {
-    const { signingAddress, signer, context } = this;
+    const { signingAddress, signer, mortality, context } = this;
+
     const nonce = context.getNonce().toNumber();
+    // era represents how many blocks the transaction should be valid for
+    const era = mortality.immortal ? 0 : mortality.blocksToLive?.toNumber();
+
     this.updateStatus(TransactionStatus.Unapproved);
 
     return new Promise((resolve, reject) => {
       const txWithArgs = this.composeTx();
       let settingBlockData = Promise.resolve();
-      const gettingUnsub = txWithArgs.signAndSend(signingAddress, { nonce, signer }, receipt => {
-        const { status } = receipt;
-        let isLastCallback = false;
-        let unsubscribing = Promise.resolve();
-        let extrinsicFailedEvent;
 
-        // isCompleted === isFinalized || isInBlock || isError
-        if (receipt.isCompleted) {
-          if (receipt.isInBlock) {
-            const blockHash = status.asInBlock;
+      const gettingUnsub = txWithArgs.signAndSend(
+        signingAddress,
+        { nonce, signer, era },
+        receipt => {
+          const { status } = receipt;
+          let isLastCallback = false;
+          let unsubscribing = Promise.resolve();
+          let extrinsicFailedEvent;
+
+          // isCompleted implies status is one of: isFinalized, isInBlock isError
+          if (receipt.isCompleted) {
+            if (receipt.isInBlock) {
+              const blockHash = status.asInBlock;
+
+              /*
+               * this must be done to ensure that the block hash and number are set before the success event
+               *   is emitted, and at the same time. We do not resolve or reject the containing promise until this
+               *   one resolves
+               */
+              settingBlockData = defusePromise(
+                this.context.polymeshApi.rpc.chain.getBlock(blockHash).then(({ block }) => {
+                  this.blockHash = hashToString(blockHash);
+                  this.blockNumber = u32ToBigNumber(block.header.number.unwrap());
+
+                  // we know that the index has to be set by the time the transaction is included in a block
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  this.txIndex = new BigNumber(receipt.txIndex!);
+                })
+              );
+
+              // if the extrinsic failed due to an on-chain error, we should handle it in a special way
+              [extrinsicFailedEvent] = filterEventRecords(
+                receipt,
+                'system',
+                'ExtrinsicFailed',
+                true
+              );
+
+              // extrinsic failed so we can unsubscribe
+              isLastCallback = !!extrinsicFailedEvent;
+            } else {
+              // isFinalized || isError so we know we can unsubscribe
+              isLastCallback = true;
+            }
+
+            if (isLastCallback) {
+              unsubscribing = gettingUnsub.then(unsub => {
+                unsub();
+              });
+            }
 
             /*
-             * this must be done to ensure that the block hash and number are set before the success event
-             *   is emitted, and at the same time. We do not resolve or reject the containing promise until this
-             *   one resolves
+             * Promise chain that handles all sub-promises in this pass through the signAndSend callback.
+             * Primarily for consistent error handling
              */
-            settingBlockData = defusePromise(
-              this.context.polymeshApi.rpc.chain.getBlock(blockHash).then(({ block }) => {
-                this.blockHash = hashToString(blockHash);
-                this.blockNumber = u32ToBigNumber(block.header.number.unwrap());
+            let finishing = Promise.resolve();
 
-                // we know that the index has to be set by the time the transaction is included in a block
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                this.txIndex = new BigNumber(receipt.txIndex!);
-              })
-            );
+            if (extrinsicFailedEvent) {
+              const { data } = extrinsicFailedEvent;
 
-            // if the extrinsic failed due to an on-chain error, we should handle it in a special way
-            [extrinsicFailedEvent] = filterEventRecords(receipt, 'system', 'ExtrinsicFailed', true);
+              finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
+                this.handleExtrinsicFailure(resolve, reject, data[0]);
+              });
+            } else if (receipt.isFinalized) {
+              finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
+                this.handleExtrinsicSuccess(resolve, reject, receipt);
+              });
+            } else if (receipt.isError) {
+              reject(new PolymeshError({ code: ErrorCode.TransactionAborted }));
+            }
 
-            // extrinsic failed so we can unsubscribe
-            isLastCallback = !!extrinsicFailedEvent;
-          } else {
-            // isFinalized || isError so we know we can unsubscribe
-            isLastCallback = true;
+            finishing.catch((err: Error) => reject(err));
           }
-
-          if (isLastCallback) {
-            unsubscribing = gettingUnsub.then(unsub => {
-              unsub();
-            });
-          }
-
-          /*
-           * Promise chain that handles all sub-promises in this pass through the signAndSend callback.
-           * Primarily for consistent error handling
-           */
-          let finishing = Promise.resolve();
-
-          if (extrinsicFailedEvent) {
-            const { data } = extrinsicFailedEvent;
-
-            finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
-              this.handleExtrinsicFailure(resolve, reject, data[0]);
-            });
-          } else if (receipt.isFinalized) {
-            finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
-              this.handleExtrinsicSuccess(resolve, reject, receipt);
-            });
-          } else if (receipt.isError) {
-            reject(new PolymeshError({ code: ErrorCode.TransactionAborted }));
-          }
-
-          finishing.catch((err: Error) => reject(err));
         }
-      });
+      );
 
       gettingUnsub
         .then(() => {

--- a/src/base/PolymeshTransactionBatch.ts
+++ b/src/base/PolymeshTransactionBatch.ts
@@ -10,7 +10,7 @@ import {
   isResolverFunction,
   MapTxDataWithFees,
   MapTxWithArgs,
-  TransactionSigningData,
+  TransactionConstructionData,
 } from '~/types/internal';
 import { transactionToTxTag, u32ToBigNumber } from '~/utils/conversion';
 import { filterEventRecords, mergeReceipts } from '~/utils/internal';
@@ -55,7 +55,7 @@ export class PolymeshTransactionBatch<
    */
   constructor(
     transactionSpec: BatchTransactionSpec<ReturnValue, Args, TransformedReturnValue> &
-      TransactionSigningData,
+      TransactionConstructionData,
     context: Context
   ) {
     const { transactions, ...rest } = transactionSpec;
@@ -160,7 +160,8 @@ export class PolymeshTransactionBatch<
     | PolymeshTransaction<void>
     | PolymeshTransaction<ReturnValue, TransformedReturnValue>
   )[] {
-    const { signingAddress, signer, context } = this;
+    const { signingAddress, signer, mortality, context } = this;
+
     const { transactions, resolver, transformer } =
       PolymeshTransactionBatch.toTransactionSpec(this);
 
@@ -175,6 +176,7 @@ export class PolymeshTransactionBatch<
         signingAddress,
         transaction,
         args,
+        mortality,
       };
 
       let newTransaction;

--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -275,6 +275,11 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
   ): Promise<GenericPolymeshTransaction<ReturnValue, TransformedReturnValue>> {
     try {
       const { args: procArgs, transformer } = args;
+
+      const mortality = opts?.mortality || {
+        immortal: false,
+      };
+
       const ctx = await this.setup(procArgs, context, opts);
 
       // parallelize the async calls
@@ -346,6 +351,7 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
         ...procedureResult,
         signer,
         signingAddress,
+        mortality,
         transformer,
       };
 

--- a/src/base/__tests__/PolymeshTransaction.ts
+++ b/src/base/__tests__/PolymeshTransaction.ts
@@ -22,6 +22,7 @@ describe('Polymesh Transaction class', () => {
     signingAddress: 'signingAddress',
     signer: 'signer' as PolkadotSigner,
     fee: new BigNumber(100),
+    mortality: { immortal: true },
   };
 
   afterEach(() => {

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -579,30 +579,6 @@ describe('Polymesh Transaction Base class', () => {
         expect.any(Function)
       );
     });
-
-    it('should call signAndSend with the blocksToLive when given a mortal mortality option', async () => {
-      const transaction = dsMockUtils.createTxMock('staking', 'bond');
-      const args = tuple('FOO');
-      const txWithArgsMock = transaction(...args);
-
-      const tx = new PolymeshTransaction(
-        {
-          ...txSpec,
-          mortality: { immortal: false, blocksToLive: new BigNumber(7) },
-          transaction,
-          args,
-          resolver: undefined,
-        },
-        context
-      );
-
-      await tx.run();
-      expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
-        txSpec.signingAddress,
-        expect.objectContaining({ era: 7 }),
-        expect.any(Function)
-      );
-    });
   });
 
   describe('method: onStatusChange', () => {

--- a/src/base/__tests__/PolymeshTransactionBatch.ts
+++ b/src/base/__tests__/PolymeshTransactionBatch.ts
@@ -30,6 +30,7 @@ describe('Polymesh Transaction Batch class', () => {
   const txSpec = {
     signingAddress: 'signingAddress',
     signer: 'signer' as PolkadotSigner,
+    mortality: { immortal: false } as const,
   };
 
   afterEach(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1443,7 +1443,34 @@ export interface ProcedureOpts {
    * @note the passed value can be either the nonce itself or a function that returns the nonce. This allows, for example, passing a closure that increases the returned value every time it's called, or a function that fetches the nonce from the chain or a different source
    */
   nonce?: BigNumber | Promise<BigNumber> | (() => BigNumber | Promise<BigNumber>);
+
+  /**
+   * This option allows for transactions that never expire, aka "immortal". By default, a transaction is only valid for approximately 5 minutes (250 blocks) after its construction. Allows for transaction construction to be decoupled from its submission, such as requiring manual approval for the signing or providing "at least once" guarantees.
+   *
+   * More information can be found [here](https://wiki.polkadot.network/docs/build-protocol-info#transaction-mortality). Note the Polymesh chain will **never** reap Accounts, so the risk of a replay attack is mitigated.
+   */
+  mortality?: MortalityProcedureOpt;
 }
+
+/**
+ * This transaction will never expire
+ */
+export interface ImmortalProcedureOptValue {
+  readonly immortal: true;
+}
+
+/**
+ * This transaction will be rejected if not included after a while (at most a few hours, by default 5 minutes). Not passing `blocksToLive` is equivalent to the default behavior
+ */
+export interface MortalProcedureOptValue {
+  readonly immortal: false;
+  /**
+   * Either the default or an "immortal" transaction should work for most use cases. If you insist on setting this value, it should not exceed the chain's `BlockHashCount` (250). A block should be produced every 6 seconds.
+   */
+  readonly blocksToLive?: BigNumber;
+}
+
+export type MortalityProcedureOpt = ImmortalProcedureOptValue | MortalProcedureOptValue;
 
 export interface CreateTransactionBatchProcedureMethod {
   <ReturnValues extends readonly [...unknown[]]>(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1460,14 +1460,10 @@ export interface ImmortalProcedureOptValue {
 }
 
 /**
- * This transaction will be rejected if not included after a while (at most a few hours, by default 5 minutes). Not passing `blocksToLive` is equivalent to the default behavior
+ * This transaction will be rejected if not included in a block after several minutes
  */
 export interface MortalProcedureOptValue {
   readonly immortal: false;
-  /**
-   * Either the default or an "immortal" transaction should work for most use cases. If you insist on setting this value, it should not exceed the chain's `BlockHashCount` (250). A block should be produced every 6 seconds.
-   */
-  readonly blocksToLive?: BigNumber;
 }
 
 export type MortalityProcedureOpt = ImmortalProcedureOptValue | MortalProcedureOptValue;

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -30,6 +30,7 @@ import {
   ClaimType,
   InputStatClaim,
   KnownAssetType,
+  MortalityProcedureOpt,
   PermissionGroupType,
   Role,
   SignerValue,
@@ -221,15 +222,22 @@ export type GenericTransactionSpec<ReturnValue> =
   | BatchTransactionSpec<ReturnValue, unknown[][]>
   | TransactionSpec<ReturnValue, unknown[]>;
 
-export interface TransactionSigningData {
+/**
+ * Additional information for constructing the final transaction
+ */
+export interface TransactionConstructionData {
   /**
-   * Account that will sign the transaction
+   * address of the key that will sign the transaction
    */
   signingAddress: string;
   /**
    * object that handles the payload signing logic
    */
   signer: PolkadotSigner;
+  /**
+   * how long the transaction should be valid for
+   */
+  mortality: MortalityProcedureOpt;
 }
 
 export interface AuthTarget {


### PR DESCRIPTION


### Description

Introduces a new ProdecureOpt to allow a user to specify transaction mortality. A user can now specify imortal transactions, or for a specific number of blocks the transaction should be valid for

### Breaking Changes

None

### JIRA Link

[DA-416](https://polymesh.atlassian.net/browse/DA-416)

### Checklist

- [ ] Updated the Readme.md (if required) ?
