### PR TITLE
feat: 🎸 Export `MetadataEntry` from `types`

### DIFF
--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -12,6 +12,7 @@ import {
   Identity as IdentityClass,
   Instruction as InstructionClass,
   KnownPermissionGroup as KnownPermissionGroupClass,
+  MetadataEntry as MetadataEntryClass,
   MultiSig as MultiSigClass,
   NumberedPortfolio as NumberedPortfolioClass,
   Offering as OfferingClass,
@@ -35,6 +36,7 @@ export type Instruction = InstructionClass;
 export type KnownPermissionGroup = KnownPermissionGroupClass;
 export type NumberedPortfolio = NumberedPortfolioClass;
 export type Asset = AssetClass;
+export type MetadataEntry = MetadataEntryClass;
 export type Offering = OfferingClass;
 export type TickerReservation = TickerReservationClass;
 export type Venue = VenueClass;


### PR DESCRIPTION
### Description

Exports `MetadataEntry` from `api/entities/types`, so that SDK consumers can import it from `types` instead of `internal`

### Breaking Changes

NA

### JIRA Link

[DA-426](https://polymesh.atlassian.net/browse/DA-426)

### Checklist

- [ ] Updated the Readme.md (if required) ?
