### PR TITLE
feat: 🎸 allow `lifetime` param for mortal procedure opts

### DIFF
--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -579,6 +579,30 @@ describe('Polymesh Transaction Base class', () => {
         expect.any(Function)
       );
     });
+
+    it('should call signAndSend with the lifetime when given a mortal mortality option', async () => {
+      const transaction = dsMockUtils.createTxMock('staking', 'bond');
+      const args = tuple('FOO');
+      const txWithArgsMock = transaction(...args);
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          mortality: { immortal: false, lifetime: new BigNumber(7) },
+          transaction,
+          args,
+          resolver: undefined,
+        },
+        context
+      );
+
+      await tx.run();
+      expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
+        txSpec.signingAddress,
+        expect.objectContaining({ era: 7 }),
+        expect.any(Function)
+      );
+    });
   });
 
   describe('method: onStatusChange', () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1460,10 +1460,17 @@ export interface ImmortalProcedureOptValue {
 }
 
 /**
- * This transaction will be rejected if not included in a block after several minutes
+ * This transaction will be rejected if not included in a block after a while (default: ~5 minutes)
  */
 export interface MortalProcedureOptValue {
   readonly immortal: false;
+  /**
+   * The number of blocks the for which the transaction remains valid. Target block time is 6 seconds. The default should suffice for most use cases
+   *
+   * @note this value will get rounded up to the closest power of 2, e.g. `65` rounds to `128`
+   * @note this value should not exceed 250 (rounds to 256), which is the chain's `BlockHashCount` as the lesser of the two will be used.
+   */
+  readonly lifetime?: BigNumber;
 }
 
 export type MortalityProcedureOpt = ImmortalProcedureOptValue | MortalProcedureOptValue;


### PR DESCRIPTION
### Description

allow user to specify how many blocks a transaction should be valid for. Note the maximum effective value is 250 as of chain v5.1.0, as this is the value of `BlockHashCount`, which is the number of block hashes accesible to the runtime. If the block hash is not found the transaction is assumed expired

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

✅ Closes: [DA-416](https://polymesh.atlassian.net/browse/DA-416)

### Checklist

- [ ] Updated the Readme.md (if required) ?
