### PR TITLE
DA-423 Update type def and min spec and chain version to 5.1.0

### DIFF
--- a/scripts/transactions.json
+++ b/scripts/transactions.json
@@ -63,7 +63,8 @@
     "remove_secondary_keys_old": "remove_secondary_keys_old",
     "placeholder_legacy_set_permission_to_signer": "placeholder_legacy_set_permission_to_signer",
     "add_secondary_keys_with_authorization_old": "add_secondary_keys_with_authorization_old",
-    "set_secondary_key_permissions": "set_secondary_key_permissions"
+    "set_secondary_key_permissions": "set_secondary_key_permissions",
+    "register_custom_claim_type": "register_custom_claim_type"
   },
   "CddServiceProviders": {
     "set_active_members_limit": "set_active_members_limit",
@@ -239,7 +240,8 @@
     "set_asset_metadata_details": "set_asset_metadata_details",
     "register_and_set_local_asset_metadata": "register_and_set_local_asset_metadata",
     "register_asset_metadata_local_type": "register_asset_metadata_local_type",
-    "register_asset_metadata_global_type": "register_asset_metadata_global_type"
+    "register_asset_metadata_global_type": "register_asset_metadata_global_type",
+    "redeem_from_portfolio": "redeem_from_portfolio"
   },
   "CapitalDistribution": {
     "distribute": "distribute",
@@ -340,7 +342,10 @@
     "disallow_venues": "disallow_venues",
     "change_receipt_validity": "change_receipt_validity",
     "execute_scheduled_instruction": "execute_scheduled_instruction",
-    "reschedule_instruction": "reschedule_instruction"
+    "reschedule_instruction": "reschedule_instruction",
+    "update_venue_signers": "update_venue_signers",
+    "add_instruction_with_memo": "add_instruction_with_memo",
+    "add_and_affirm_instruction_with_memo": "add_and_affirm_instruction_with_memo"
   },
   "Statistics": {
     "add_transfer_manager": "add_transfer_manager",

--- a/src/api/entities/MultiSig/index.ts
+++ b/src/api/entities/MultiSig/index.ts
@@ -50,9 +50,15 @@ export class MultiSig extends Account {
       multiSig.multiSigSigners.entries(rawAddress),
       multiSig.multiSigSignsRequired(rawAddress),
     ]);
-    const signers = rawSigners.map(([, signatory]) => {
-      return signerValueToSigner(signatoryToSignerValue(signatory), context);
-    });
+    const signers = rawSigners.map(
+      ([
+        {
+          args: [, signatory],
+        },
+      ]) => {
+        return signerValueToSigner(signatoryToSignerValue(signatory), context);
+      }
+    );
     const requiredSignatures = u64ToBigNumber(rawSignersRequired);
 
     return { signers, requiredSignatures };

--- a/src/api/procedures/__tests__/addInvestorUniquenessClaim.ts
+++ b/src/api/procedures/__tests__/addInvestorUniquenessClaim.ts
@@ -1,5 +1,5 @@
 import {
-  ConfidentialIdentityClaimProofsScopeClaimProof,
+  ConfidentialIdentityV2ClaimProofsScopeClaimProof,
   PolymeshPrimitivesIdentityId,
   PolymeshPrimitivesTicker,
 } from '@polkadot/types/lookup';
@@ -51,7 +51,7 @@ describe('addInvestorUniquenessClaim procedure', () => {
   let stringToInvestorZkProofDataStub: sinon.SinonStub<[string, Context], InvestorZKProofData>;
   let scopeClaimProofToMeshScopeClaimProofStub: sinon.SinonStub<
     [ScopeClaimProof, string, Context],
-    ConfidentialIdentityClaimProofsScopeClaimProof
+    ConfidentialIdentityV2ClaimProofsScopeClaimProof
   >;
   let scopeToMeshScopeStub: sinon.SinonStub<[Scope, Context], MeshScope>;
   let stringToScopeIdStub: sinon.SinonStub<[string, Context], ScopeId>;
@@ -63,7 +63,7 @@ describe('addInvestorUniquenessClaim procedure', () => {
   let rawClaim: MeshClaim;
   let rawClaimV2: MeshClaim;
   let rawProof: InvestorZKProofData;
-  let rawScopeClaimProof: ConfidentialIdentityClaimProofsScopeClaimProof;
+  let rawScopeClaimProof: ConfidentialIdentityV2ClaimProofsScopeClaimProof;
   let rawExpiry: Moment;
 
   beforeAll(() => {

--- a/src/api/procedures/__tests__/inviteExternalAgent.ts
+++ b/src/api/procedures/__tests__/inviteExternalAgent.ts
@@ -1,7 +1,7 @@
 import { PolymeshPrimitivesAuthorizationAuthorizationData } from '@polkadot/types/lookup';
 import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
-import { AgentGroup, Signatory, Ticker } from 'polymesh-types/types';
+import { AgentGroup, IdentityId, Signatory, Ticker } from 'polymesh-types/types';
 import sinon from 'sinon';
 
 import {
@@ -45,6 +45,7 @@ describe('inviteExternalAgent procedure', () => {
   >;
   let signerToStringStub: sinon.SinonStub<[string | Identity | Account], string>;
   let signerValueToSignatoryStub: sinon.SinonStub<[SignerValue, Context], Signatory>;
+  let stringToIdentityIdStub: sinon.SinonStub;
   let ticker: string;
   let asset: Asset;
   let rawTicker: Ticker;
@@ -52,6 +53,7 @@ describe('inviteExternalAgent procedure', () => {
   let target: string;
   let rawSignatory: Signatory;
   let rawAuthorizationData: PolymeshPrimitivesAuthorizationAuthorizationData;
+  let rawIdentityId: IdentityId;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -62,6 +64,7 @@ describe('inviteExternalAgent procedure', () => {
       'authorizationToAuthorizationData'
     );
     signerToStringStub = sinon.stub(utilsConversionModule, 'signerToString');
+    stringToIdentityIdStub = sinon.stub(utilsConversionModule, 'stringToIdentityId');
     signerValueToSignatoryStub = sinon.stub(utilsConversionModule, 'signerValueToSignatory');
     ticker = 'SOME_TICKER';
     rawTicker = dsMockUtils.createMockTicker(ticker);
@@ -74,6 +77,7 @@ describe('inviteExternalAgent procedure', () => {
     rawAuthorizationData = dsMockUtils.createMockAuthorizationData({
       BecomeAgent: [rawTicker, rawAgentGroup],
     });
+    rawIdentityId = dsMockUtils.createMockIdentityId(target);
   });
 
   beforeEach(() => {
@@ -86,6 +90,7 @@ describe('inviteExternalAgent procedure', () => {
     authorizationToAuthorizationDataStub.returns(rawAuthorizationData);
     signerToStringStub.returns(target);
     signerValueToSignatoryStub.returns(rawSignatory);
+    stringToIdentityIdStub.returns(rawIdentityId);
   });
 
   afterEach(() => {
@@ -278,7 +283,7 @@ describe('inviteExternalAgent procedure', () => {
 
     expect(result).toEqual({
       transaction,
-      args: [rawTicker, rawPermissions, rawSignatory],
+      args: [rawTicker, rawPermissions, rawIdentityId, null],
       resolver: expect.any(Function),
     });
   });

--- a/src/api/procedures/inviteExternalAgent.ts
+++ b/src/api/procedures/inviteExternalAgent.ts
@@ -25,6 +25,7 @@ import {
   permissionsLikeToPermissions,
   signerToString,
   signerValueToSignatory,
+  stringToIdentityId,
   stringToTicker,
   transactionPermissionsToExtrinsicPermissions,
   u64ToBigNumber,
@@ -94,8 +95,10 @@ export async function prepareInviteExternalAgent(
     });
   }
 
+  const targetDid = signerToString(target);
+
   const rawSignatory = signerValueToSignatory(
-    { type: SignerType.Identity, value: signerToString(target) },
+    { type: SignerType.Identity, value: targetDid },
     context
   );
 
@@ -129,7 +132,8 @@ export async function prepareInviteExternalAgent(
         args: [
           rawTicker,
           transactionPermissionsToExtrinsicPermissions(transactions, context),
-          rawSignatory,
+          stringToIdentityId(targetDid, context),
+          null,
         ],
         resolver: createGroupAndAuthorizationResolver(targetIdentity),
       };

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -324,6 +324,7 @@ export enum IdentityTx {
   PlaceholderLegacySetPermissionToSigner = 'identity.placeholderLegacySetPermissionToSigner',
   AddSecondaryKeysWithAuthorizationOld = 'identity.addSecondaryKeysWithAuthorizationOld',
   SetSecondaryKeyPermissions = 'identity.setSecondaryKeyPermissions',
+  RegisterCustomClaimType = 'identity.registerCustomClaimType',
 }
 
 export enum CddServiceProvidersTx {
@@ -515,6 +516,7 @@ export enum AssetTx {
   RegisterAndSetLocalAssetMetadata = 'asset.registerAndSetLocalAssetMetadata',
   RegisterAssetMetadataLocalType = 'asset.registerAssetMetadataLocalType',
   RegisterAssetMetadataGlobalType = 'asset.registerAssetMetadataGlobalType',
+  RedeemFromPortfolio = 'asset.redeemFromPortfolio',
 }
 
 export enum CapitalDistributionTx {
@@ -626,6 +628,9 @@ export enum SettlementTx {
   ChangeReceiptValidity = 'settlement.changeReceiptValidity',
   ExecuteScheduledInstruction = 'settlement.executeScheduledInstruction',
   RescheduleInstruction = 'settlement.rescheduleInstruction',
+  UpdateVenueSigners = 'settlement.updateVenueSigners',
+  AddInstructionWithMemo = 'settlement.addInstructionWithMemo',
+  AddAndAffirmInstructionWithMemo = 'settlement.addAndAffirmInstructionWithMemo',
 }
 
 export enum StatisticsTx {

--- a/src/polkadot/augment-api-consts.ts
+++ b/src/polkadot/augment-api-consts.ts
@@ -21,7 +21,6 @@ declare module '@polkadot/api-base/types/consts' {
       assetMetadataValueMaxLength: u32 & AugmentedConst<ApiType>;
       assetNameMaxLength: u32 & AugmentedConst<ApiType>;
       fundingRoundNameMaxLength: u32 & AugmentedConst<ApiType>;
-      maxNumberOfTMExtensionForAsset: u32 & AugmentedConst<ApiType>;
     };
     authorship: {
       /**

--- a/src/polkadot/augment-api-errors.ts
+++ b/src/polkadot/augment-api-errors.ts
@@ -7,17 +7,9 @@ declare module '@polkadot/api-base/types/errors' {
   export interface AugmentedErrors<ApiType extends ApiTypes> {
     asset: {
       /**
-       * When extension already archived.
-       **/
-      AlreadyArchived: AugmentedError<ApiType>;
-      /**
        * The token is already frozen.
        **/
       AlreadyFrozen: AugmentedError<ApiType>;
-      /**
-       * When extension already un-archived.
-       **/
-      AlreadyUnArchived: AugmentedError<ApiType>;
       /**
        * The token has already been created.
        **/
@@ -59,17 +51,9 @@ declare module '@polkadot/api-base/types/errors' {
        **/
       BalanceOverflow: AugmentedError<ApiType>;
       /**
-       * When extension is already added.
-       **/
-      ExtensionAlreadyPresent: AugmentedError<ApiType>;
-      /**
        * Maximum length of the funding round name has been exceeded.
        **/
       FundingRoundNameMaxLengthExceeded: AugmentedError<ApiType>;
-      /**
-       * Given smart extension is not compatible with the asset.
-       **/
-      IncompatibleExtensionVersion: AugmentedError<ApiType>;
       /**
        * The sender balance is not sufficient.
        **/
@@ -98,10 +82,6 @@ declare module '@polkadot/api-base/types/errors' {
        * Investor Uniqueness claims are not allowed for this asset.
        **/
       InvestorUniquenessClaimNotAllowed: AugmentedError<ApiType>;
-      /**
-       * Number of Transfer Manager extensions attached to an asset is equal to MaxNumberOfTMExtensionForAsset.
-       **/
-      MaximumTMExtensionLimitReached: AugmentedError<ApiType>;
       /**
        * Maximum length of asset name has been exceeded.
        **/
@@ -819,6 +799,14 @@ declare module '@polkadot/api-base/types/errors' {
        **/
       CurrentIdentityCannotBeForwarded: AugmentedError<ApiType>;
       /**
+       * The custom claim type trying to be registered already exists.
+       **/
+      CustomClaimTypeAlreadyExists: AugmentedError<ApiType>;
+      /**
+       * The custom claim type does not exist.
+       **/
+      CustomClaimTypeDoesNotExist: AugmentedError<ApiType>;
+      /**
        * A custom scope is too long.
        * It can at most be `32` characters long.
        **/
@@ -1433,6 +1421,14 @@ declare module '@polkadot/api-base/types/errors' {
        **/
       SettleOnPastBlock: AugmentedError<ApiType>;
       /**
+       * Signer is already added to venue.
+       **/
+      SignerAlreadyExists: AugmentedError<ApiType>;
+      /**
+       * Signer is not added to venue.
+       **/
+      SignerDoesNotExist: AugmentedError<ApiType>;
+      /**
        * Sender does not have required permissions.
        **/
       Unauthorized: AugmentedError<ApiType>;
@@ -1452,6 +1448,10 @@ declare module '@polkadot/api-base/types/errors' {
        * Instruction status is unknown
        **/
       UnknownInstruction: AugmentedError<ApiType>;
+      /**
+       * Instruction leg amount can't be zero
+       **/
+      ZeroAmount: AugmentedError<ApiType>;
     };
     staking: {
       /**

--- a/src/polkadot/augment-api-events.ts
+++ b/src/polkadot/augment-api-events.ts
@@ -35,6 +35,7 @@ import type {
   PalletPipsProposalState,
   PalletPipsProposer,
   PalletPipsSnapshottedPip,
+  PalletSettlementInstructionMemo,
   PalletSettlementLeg,
   PalletSettlementSettlementType,
   PalletSettlementVenueType,
@@ -80,7 +81,7 @@ declare module '@polkadot/api-base/types/events' {
     asset: {
       /**
        * Event for creation of the asset.
-       * caller DID/ owner DID, ticker, divisibility, asset type, beneficiary DID, disable investor uniqueness
+       * caller DID/ owner DID, ticker, divisibility, asset type, beneficiary DID, disable investor uniqueness, asset name, identifiers, funding round
        **/
       AssetCreated: AugmentedEvent<
         ApiType,
@@ -90,7 +91,10 @@ declare module '@polkadot/api-base/types/events' {
           bool,
           PolymeshPrimitivesAssetAssetType,
           PolymeshPrimitivesIdentityId,
-          bool
+          bool,
+          Bytes,
+          Vec<PolymeshPrimitivesAssetIdentifier>,
+          Option<Bytes>
         ]
       >;
       /**
@@ -1078,6 +1082,15 @@ declare module '@polkadot/api-base/types/events' {
         [Option<PolymeshPrimitivesIdentityId>, Option<AccountId32>, u64]
       >;
       /**
+       * Accepting Authorization retry limit reached.
+       *
+       * (authorized_identity, authorized_key, auth_id)
+       **/
+      AuthorizationRetryLimitReached: AugmentedEvent<
+        ApiType,
+        [Option<PolymeshPrimitivesIdentityId>, Option<AccountId32>, u64]
+      >;
+      /**
        * Authorization revoked by the authorizer.
        *
        * (authorized_identity, authorized_key, auth_id)
@@ -1117,6 +1130,12 @@ declare module '@polkadot/api-base/types/events' {
         ApiType,
         [PolymeshPrimitivesIdentityId, PolymeshPrimitivesIdentityClaim]
       >;
+      /**
+       * A new CustomClaimType was added.
+       *
+       * (DID, id, Type)
+       **/
+      CustomClaimTypeAdded: AugmentedEvent<ApiType, [PolymeshPrimitivesIdentityId, u32, Bytes]>;
       /**
        * Identity created.
        *
@@ -1745,7 +1764,7 @@ declare module '@polkadot/api-base/types/events' {
       >;
       /**
        * A new instruction has been created
-       * (did, venue_id, instruction_id, settlement_type, trade_date, value_date, legs)
+       * (did, venue_id, instruction_id, settlement_type, trade_date, value_date, legs, memo)
        **/
       InstructionCreated: AugmentedEvent<
         ApiType,
@@ -1756,7 +1775,8 @@ declare module '@polkadot/api-base/types/events' {
           PalletSettlementSettlementType,
           Option<u64>,
           Option<u64>,
-          Vec<PalletSettlementLeg>
+          Vec<PalletSettlementLeg>,
+          Option<PalletSettlementInstructionMemo>
         ]
       >;
       /**
@@ -1836,6 +1856,13 @@ declare module '@polkadot/api-base/types/events' {
       VenuesBlocked: AugmentedEvent<
         ApiType,
         [PolymeshPrimitivesIdentityId, PolymeshPrimitivesTicker, Vec<u64>]
+      >;
+      /**
+       * An existing venue's signers has been updated (did, venue_id, signers, update_type)
+       **/
+      VenueSignersUpdated: AugmentedEvent<
+        ApiType,
+        [PolymeshPrimitivesIdentityId, u64, Vec<AccountId32>, bool]
       >;
       /**
        * An existing venue's type has been updated (did, venue_id, type)

--- a/src/polkadot/augment-api-query.ts
+++ b/src/polkadot/augment-api-query.ts
@@ -55,6 +55,7 @@ import type {
   PalletPipsDepositInfo,
   PalletPipsPip,
   PalletPipsPipsMetadata,
+  PalletPipsProposalState,
   PalletPipsSnapshotMetadata,
   PalletPipsSnapshottedPip,
   PalletPipsVote,
@@ -65,6 +66,7 @@ import type {
   PalletSchedulerScheduledV3,
   PalletSettlementAffirmationStatus,
   PalletSettlementInstruction,
+  PalletSettlementInstructionMemo,
   PalletSettlementLeg,
   PalletSettlementLegStatus,
   PalletSettlementVenue,
@@ -1334,6 +1336,26 @@ declare module '@polkadot/api-base/types/storage' {
        **/
       currentPayer: AugmentedQuery<ApiType, () => Observable<Option<AccountId32>>, []>;
       /**
+       * The next `CustomClaimTypeId`.
+       **/
+      customClaimIdSequence: AugmentedQuery<ApiType, () => Observable<u32>, []>;
+      /**
+       * CustomClaimTypeId -> String constant
+       **/
+      customClaims: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Bytes>,
+        [u32]
+      >;
+      /**
+       * String constant -> CustomClaimTypeId
+       **/
+      customClaimsInverse: AugmentedQuery<
+        ApiType,
+        (arg: Bytes | string | Uint8Array) => Observable<u32>,
+        [Bytes]
+      >;
+      /**
        * A reverse double map to allow finding all keys for an identity.
        **/
       didKeys: AugmentedQuery<
@@ -1455,7 +1477,7 @@ declare module '@polkadot/api-base/types/storage' {
        **/
       multiSigNonce: AugmentedQuery<ApiType, () => Observable<u64>, []>;
       /**
-       * Signers of a multisig. (multisig, signer) => signer.
+       * Signers of a multisig. (multisig, signer) => bool.
        **/
       multiSigSigners: AugmentedQuery<
         ApiType,
@@ -1467,7 +1489,7 @@ declare module '@polkadot/api-base/types/storage' {
             | { Account: any }
             | string
             | Uint8Array
-        ) => Observable<PolymeshPrimitivesSecondaryKeySignatory>,
+        ) => Observable<bool>,
         [AccountId32, PolymeshPrimitivesSecondaryKeySignatory]
       >;
       /**
@@ -1704,6 +1726,15 @@ declare module '@polkadot/api-base/types/storage' {
       proposals: AugmentedQuery<
         ApiType,
         (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<PalletPipsPip>>,
+        [u32]
+      >;
+      /**
+       * Proposal state for a given id.
+       * proposal id -> proposalState
+       **/
+      proposalStates: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<PalletPipsProposalState>>,
         [u32]
       >;
       /**
@@ -2135,6 +2166,14 @@ declare module '@polkadot/api-base/types/storage' {
         [u64, u64]
       >;
       /**
+       * Instruction memo
+       **/
+      instructionMemos: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<Option<U8aFixed>>,
+        [u64]
+      >;
+      /**
        * Tracks redemption of receipts. (signer, receipt_uid) -> receipt_used
        **/
       receiptsUsed: AugmentedQuery<
@@ -2426,6 +2465,18 @@ declare module '@polkadot/api-base/types/storage' {
         ) => Observable<Option<u128>>,
         [u32, AccountId32]
       >;
+      /**
+       * Indices of validators that have offended in the active era and whether they are currently
+       * disabled.
+       *
+       * This value should be a superset of disabled validators since not all offences lead to the
+       * validator being disabled (if there was no slash). This is needed to track the percentage of
+       * validators that have offended in the current era, ensuring a new era is forced if
+       * `OffendingValidatorsThreshold` is reached. The vec is always kept sorted so that we can find
+       * whether a given validator has previously offended using binary search. It gets cleared when
+       * the era ends.
+       **/
+      offendingValidators: AugmentedQuery<ApiType, () => Observable<Vec<ITuple<[u32, bool]>>>, []>;
       /**
        * Where the reward payment should be made. Keyed by stash.
        **/

--- a/src/polkadot/augment-types.ts
+++ b/src/polkadot/augment-types.ts
@@ -1092,7 +1092,6 @@ import type {
   Committee,
   ComplianceRequirement,
   ComplianceRequirementResult,
-  CompressedRistretto,
   Condition,
   ConditionResult,
   ConditionType,
@@ -1114,8 +1113,6 @@ import type {
   ErrorAt,
   EventCounts,
   EventDid,
-  ExtVersion,
-  ExtensionAttributes,
   ExtrinsicPermissions,
   FundingRoundName,
   Fundraiser,
@@ -1129,6 +1126,7 @@ import type {
   IdentityId,
   IdentityRole,
   InactiveMember,
+  InitiateCorporateActionArgs,
   Instruction,
   InstructionId,
   InstructionStatus,
@@ -1143,9 +1141,6 @@ import type {
   LocalCAId,
   MaybeBlock,
   Memo,
-  MetaDescription,
-  MetaUrl,
-  MetaVersion,
   Motion,
   MotionInfoLink,
   MotionTitle,
@@ -1198,9 +1193,6 @@ import type {
   Signatory,
   SkippedCount,
   SlashingSwitch,
-  SmartExtension,
-  SmartExtensionName,
-  SmartExtensionType,
   SnapshotId,
   SnapshotMetadata,
   SnapshotResult,
@@ -1218,8 +1210,6 @@ import type {
   TargetIdentity,
   TargetTreatment,
   Tax,
-  TemplateDetails,
-  TemplateMetadata,
   Ticker,
   TickerRegistration,
   TickerRegistrationConfig,
@@ -1443,7 +1433,6 @@ declare module '@polkadot/types/types/registry' {
     Committee: Committee;
     ComplianceRequirement: ComplianceRequirement;
     ComplianceRequirementResult: ComplianceRequirementResult;
-    CompressedRistretto: CompressedRistretto;
     Condition: Condition;
     ConditionResult: ConditionResult;
     ConditionType: ConditionType;
@@ -1646,7 +1635,6 @@ declare module '@polkadot/types/types/registry' {
     ExitRevert: ExitRevert;
     ExitSucceed: ExitSucceed;
     ExplicitDisputeStatement: ExplicitDisputeStatement;
-    ExtensionAttributes: ExtensionAttributes;
     Extrinsic: Extrinsic;
     ExtrinsicEra: ExtrinsicEra;
     ExtrinsicMetadataLatest: ExtrinsicMetadataLatest;
@@ -1665,7 +1653,6 @@ declare module '@polkadot/types/types/registry' {
     ExtrinsicsWeight: ExtrinsicsWeight;
     ExtrinsicUnknown: ExtrinsicUnknown;
     ExtrinsicV4: ExtrinsicV4;
-    ExtVersion: ExtVersion;
     FeeDetails: FeeDetails;
     Fixed128: Fixed128;
     Fixed64: Fixed64;
@@ -1772,6 +1759,7 @@ declare module '@polkadot/types/types/registry' {
     Index: Index;
     IndicesLookupSource: IndicesLookupSource;
     InitializationData: InitializationData;
+    InitiateCorporateActionArgs: InitiateCorporateActionArgs;
     InstanceDetails: InstanceDetails;
     InstanceId: InstanceId;
     InstanceMetadata: InstanceMetadata;
@@ -1853,9 +1841,6 @@ declare module '@polkadot/types/types/registry' {
     MetadataV13: MetadataV13;
     MetadataV14: MetadataV14;
     MetadataV9: MetadataV9;
-    MetaDescription: MetaDescription;
-    MetaUrl: MetaUrl;
-    MetaVersion: MetaVersion;
     MigrationStatusResult: MigrationStatusResult;
     MmrLeafBatchProof: MmrLeafBatchProof;
     MmrLeafProof: MmrLeafProof;
@@ -2208,9 +2193,6 @@ declare module '@polkadot/types/types/registry' {
     SlotNumber: SlotNumber;
     SlotRange: SlotRange;
     SlotRange10: SlotRange10;
-    SmartExtension: SmartExtension;
-    SmartExtensionName: SmartExtensionName;
-    SmartExtensionType: SmartExtensionType;
     SnapshotId: SnapshotId;
     SnapshotMetadata: SnapshotMetadata;
     SnapshotResult: SnapshotResult;
@@ -2284,8 +2266,6 @@ declare module '@polkadot/types/types/registry' {
     TAssetBalance: TAssetBalance;
     TAssetDepositBalance: TAssetDepositBalance;
     Tax: Tax;
-    TemplateDetails: TemplateDetails;
-    TemplateMetadata: TemplateMetadata;
     Text: Text;
     Ticker: Ticker;
     TickerRegistration: TickerRegistration;

--- a/src/polkadot/lookup.ts
+++ b/src/polkadot/lookup.ts
@@ -226,10 +226,13 @@ export default {
       AuthorizationRevoked: '(Option<PolymeshPrimitivesIdentityId>,Option<AccountId32>,u64)',
       AuthorizationRejected: '(Option<PolymeshPrimitivesIdentityId>,Option<AccountId32>,u64)',
       AuthorizationConsumed: '(Option<PolymeshPrimitivesIdentityId>,Option<AccountId32>,u64)',
+      AuthorizationRetryLimitReached:
+        '(Option<PolymeshPrimitivesIdentityId>,Option<AccountId32>,u64)',
       CddRequirementForPrimaryKeyUpdated: 'bool',
       CddClaimsInvalidated: '(PolymeshPrimitivesIdentityId,u64)',
       SecondaryKeysFrozen: 'PolymeshPrimitivesIdentityId',
       SecondaryKeysUnfrozen: 'PolymeshPrimitivesIdentityId',
+      CustomClaimTypeAdded: '(PolymeshPrimitivesIdentityId,u32,Bytes)',
     },
   },
   /**
@@ -343,6 +346,7 @@ export default {
         '(PolymeshPrimitivesIdentityClaimScope,PolymeshPrimitivesIdentityId,PolymeshPrimitivesCddId)',
       NoData: 'Null',
       InvestorUniquenessV2: 'PolymeshPrimitivesCddId',
+      Custom: '(u32,Option<PolymeshPrimitivesIdentityClaimScope>)',
     },
   },
   /**
@@ -617,7 +621,7 @@ export default {
     ],
   },
   /**
-   * Lookup66: polymesh_primitives::authorization::AuthorizationData<sp_core::crypto::AccountId32>
+   * Lookup68: polymesh_primitives::authorization::AuthorizationData<sp_core::crypto::AccountId32>
    **/
   PolymeshPrimitivesAuthorizationAuthorizationData: {
     _enum: {
@@ -634,7 +638,7 @@ export default {
     },
   },
   /**
-   * Lookup67: polymesh_primitives::agent::AgentGroup
+   * Lookup69: polymesh_primitives::agent::AgentGroup
    **/
   PolymeshPrimitivesAgentAgentGroup: {
     _enum: {
@@ -646,7 +650,7 @@ export default {
     },
   },
   /**
-   * Lookup70: polymesh_common_utilities::traits::group::RawEvent<sp_core::crypto::AccountId32, polymesh_runtime_develop::runtime::Event, pallet_group::Instance2>
+   * Lookup72: polymesh_common_utilities::traits::group::RawEvent<sp_core::crypto::AccountId32, polymesh_runtime_develop::runtime::Event, pallet_group::Instance2>
    **/
   PolymeshCommonUtilitiesGroupRawEventInstance2: {
     _enum: {
@@ -661,11 +665,11 @@ export default {
     },
   },
   /**
-   * Lookup71: pallet_group::Instance2
+   * Lookup73: pallet_group::Instance2
    **/
   PalletGroupInstance2: 'Null',
   /**
-   * Lookup73: pallet_committee::RawEvent<primitive_types::H256, BlockNumber, pallet_committee::Instance1>
+   * Lookup75: pallet_committee::RawEvent<primitive_types::H256, BlockNumber, pallet_committee::Instance1>
    **/
   PalletCommitteeRawEventInstance1: {
     _enum: {
@@ -684,11 +688,11 @@ export default {
     },
   },
   /**
-   * Lookup74: pallet_committee::Instance1
+   * Lookup76: pallet_committee::Instance1
    **/
   PalletCommitteeInstance1: 'Null',
   /**
-   * Lookup77: polymesh_common_utilities::MaybeBlock<BlockNumber>
+   * Lookup79: polymesh_common_utilities::MaybeBlock<BlockNumber>
    **/
   PolymeshCommonUtilitiesMaybeBlock: {
     _enum: {
@@ -697,7 +701,7 @@ export default {
     },
   },
   /**
-   * Lookup78: polymesh_common_utilities::traits::group::RawEvent<sp_core::crypto::AccountId32, polymesh_runtime_develop::runtime::Event, pallet_group::Instance1>
+   * Lookup80: polymesh_common_utilities::traits::group::RawEvent<sp_core::crypto::AccountId32, polymesh_runtime_develop::runtime::Event, pallet_group::Instance1>
    **/
   PolymeshCommonUtilitiesGroupRawEventInstance1: {
     _enum: {
@@ -712,11 +716,11 @@ export default {
     },
   },
   /**
-   * Lookup79: pallet_group::Instance1
+   * Lookup81: pallet_group::Instance1
    **/
   PalletGroupInstance1: 'Null',
   /**
-   * Lookup80: pallet_committee::RawEvent<primitive_types::H256, BlockNumber, pallet_committee::Instance3>
+   * Lookup82: pallet_committee::RawEvent<primitive_types::H256, BlockNumber, pallet_committee::Instance3>
    **/
   PalletCommitteeRawEventInstance3: {
     _enum: {
@@ -735,11 +739,11 @@ export default {
     },
   },
   /**
-   * Lookup81: pallet_committee::Instance3
+   * Lookup83: pallet_committee::Instance3
    **/
   PalletCommitteeInstance3: 'Null',
   /**
-   * Lookup82: polymesh_common_utilities::traits::group::RawEvent<sp_core::crypto::AccountId32, polymesh_runtime_develop::runtime::Event, pallet_group::Instance3>
+   * Lookup84: polymesh_common_utilities::traits::group::RawEvent<sp_core::crypto::AccountId32, polymesh_runtime_develop::runtime::Event, pallet_group::Instance3>
    **/
   PolymeshCommonUtilitiesGroupRawEventInstance3: {
     _enum: {
@@ -754,11 +758,11 @@ export default {
     },
   },
   /**
-   * Lookup83: pallet_group::Instance3
+   * Lookup85: pallet_group::Instance3
    **/
   PalletGroupInstance3: 'Null',
   /**
-   * Lookup84: pallet_committee::RawEvent<primitive_types::H256, BlockNumber, pallet_committee::Instance4>
+   * Lookup86: pallet_committee::RawEvent<primitive_types::H256, BlockNumber, pallet_committee::Instance4>
    **/
   PalletCommitteeRawEventInstance4: {
     _enum: {
@@ -777,11 +781,11 @@ export default {
     },
   },
   /**
-   * Lookup85: pallet_committee::Instance4
+   * Lookup87: pallet_committee::Instance4
    **/
   PalletCommitteeInstance4: 'Null',
   /**
-   * Lookup86: polymesh_common_utilities::traits::group::RawEvent<sp_core::crypto::AccountId32, polymesh_runtime_develop::runtime::Event, pallet_group::Instance4>
+   * Lookup88: polymesh_common_utilities::traits::group::RawEvent<sp_core::crypto::AccountId32, polymesh_runtime_develop::runtime::Event, pallet_group::Instance4>
    **/
   PolymeshCommonUtilitiesGroupRawEventInstance4: {
     _enum: {
@@ -796,11 +800,11 @@ export default {
     },
   },
   /**
-   * Lookup87: pallet_group::Instance4
+   * Lookup89: pallet_group::Instance4
    **/
   PalletGroupInstance4: 'Null',
   /**
-   * Lookup88: pallet_multisig::RawEvent<sp_core::crypto::AccountId32>
+   * Lookup90: pallet_multisig::RawEvent<sp_core::crypto::AccountId32>
    **/
   PalletMultisigRawEvent: {
     _enum: {
@@ -825,7 +829,7 @@ export default {
     },
   },
   /**
-   * Lookup90: polymesh_primitives::secondary_key::Signatory<sp_core::crypto::AccountId32>
+   * Lookup92: polymesh_primitives::secondary_key::Signatory<sp_core::crypto::AccountId32>
    **/
   PolymeshPrimitivesSecondaryKeySignatory: {
     _enum: {
@@ -834,7 +838,7 @@ export default {
     },
   },
   /**
-   * Lookup91: pallet_bridge::RawEvent<sp_core::crypto::AccountId32, BlockNumber>
+   * Lookup93: pallet_bridge::RawEvent<sp_core::crypto::AccountId32, BlockNumber>
    **/
   PalletBridgeRawEvent: {
     _enum: {
@@ -857,7 +861,7 @@ export default {
     },
   },
   /**
-   * Lookup92: pallet_bridge::BridgeTx<sp_core::crypto::AccountId32>
+   * Lookup94: pallet_bridge::BridgeTx<sp_core::crypto::AccountId32>
    **/
   PalletBridgeBridgeTx: {
     nonce: 'u32',
@@ -866,7 +870,7 @@ export default {
     txHash: 'H256',
   },
   /**
-   * Lookup95: pallet_bridge::HandledTxStatus
+   * Lookup97: pallet_bridge::HandledTxStatus
    **/
   PalletBridgeHandledTxStatus: {
     _enum: {
@@ -875,7 +879,7 @@ export default {
     },
   },
   /**
-   * Lookup96: pallet_staking::RawEvent<Balance, sp_core::crypto::AccountId32>
+   * Lookup98: pallet_staking::RawEvent<Balance, sp_core::crypto::AccountId32>
    **/
   PalletStakingRawEvent: {
     _enum: {
@@ -899,19 +903,19 @@ export default {
     },
   },
   /**
-   * Lookup97: pallet_staking::ElectionCompute
+   * Lookup99: pallet_staking::ElectionCompute
    **/
   PalletStakingElectionCompute: {
     _enum: ['OnChain', 'Signed', 'Unsigned'],
   },
   /**
-   * Lookup99: pallet_staking::SlashingSwitch
+   * Lookup101: pallet_staking::SlashingSwitch
    **/
   PalletStakingSlashingSwitch: {
     _enum: ['Validator', 'ValidatorAndNominator', 'None'],
   },
   /**
-   * Lookup100: pallet_offences::pallet::Event
+   * Lookup102: pallet_offences::pallet::Event
    **/
   PalletOffencesEvent: {
     _enum: {
@@ -922,7 +926,7 @@ export default {
     },
   },
   /**
-   * Lookup102: pallet_session::pallet::Event
+   * Lookup104: pallet_session::pallet::Event
    **/
   PalletSessionEvent: {
     _enum: {
@@ -932,7 +936,7 @@ export default {
     },
   },
   /**
-   * Lookup103: pallet_grandpa::pallet::Event
+   * Lookup105: pallet_grandpa::pallet::Event
    **/
   PalletGrandpaEvent: {
     _enum: {
@@ -944,15 +948,15 @@ export default {
     },
   },
   /**
-   * Lookup106: sp_finality_grandpa::app::Public
+   * Lookup108: sp_finality_grandpa::app::Public
    **/
   SpFinalityGrandpaAppPublic: 'SpCoreEd25519Public',
   /**
-   * Lookup107: sp_core::ed25519::Public
+   * Lookup109: sp_core::ed25519::Public
    **/
   SpCoreEd25519Public: '[u8;32]',
   /**
-   * Lookup108: pallet_im_online::pallet::Event<T>
+   * Lookup110: pallet_im_online::pallet::Event<T>
    **/
   PalletImOnlineEvent: {
     _enum: {
@@ -966,15 +970,15 @@ export default {
     },
   },
   /**
-   * Lookup109: pallet_im_online::sr25519::app_sr25519::Public
+   * Lookup111: pallet_im_online::sr25519::app_sr25519::Public
    **/
   PalletImOnlineSr25519AppSr25519Public: 'SpCoreSr25519Public',
   /**
-   * Lookup110: sp_core::sr25519::Public
+   * Lookup112: sp_core::sr25519::Public
    **/
   SpCoreSr25519Public: '[u8;32]',
   /**
-   * Lookup113: pallet_staking::Exposure<sp_core::crypto::AccountId32, Balance>
+   * Lookup115: pallet_staking::Exposure<sp_core::crypto::AccountId32, Balance>
    **/
   PalletStakingExposure: {
     total: 'Compact<u128>',
@@ -982,14 +986,14 @@ export default {
     others: 'Vec<PalletStakingIndividualExposure>',
   },
   /**
-   * Lookup116: pallet_staking::IndividualExposure<sp_core::crypto::AccountId32, Balance>
+   * Lookup118: pallet_staking::IndividualExposure<sp_core::crypto::AccountId32, Balance>
    **/
   PalletStakingIndividualExposure: {
     who: 'AccountId32',
     value: 'Compact<u128>',
   },
   /**
-   * Lookup117: pallet_sudo::RawEvent<sp_core::crypto::AccountId32>
+   * Lookup119: pallet_sudo::RawEvent<sp_core::crypto::AccountId32>
    **/
   PalletSudoRawEvent: {
     _enum: {
@@ -999,7 +1003,7 @@ export default {
     },
   },
   /**
-   * Lookup118: polymesh_common_utilities::traits::asset::RawEvent<Moment, sp_core::crypto::AccountId32>
+   * Lookup120: polymesh_common_utilities::traits::asset::RawEvent<Moment, sp_core::crypto::AccountId32>
    **/
   PolymeshCommonUtilitiesAssetRawEvent: {
     _enum: {
@@ -1010,7 +1014,7 @@ export default {
       Redeemed:
         '(PolymeshPrimitivesIdentityId,PolymeshPrimitivesTicker,PolymeshPrimitivesIdentityId,u128)',
       AssetCreated:
-        '(PolymeshPrimitivesIdentityId,PolymeshPrimitivesTicker,bool,PolymeshPrimitivesAssetAssetType,PolymeshPrimitivesIdentityId,bool)',
+        '(PolymeshPrimitivesIdentityId,PolymeshPrimitivesTicker,bool,PolymeshPrimitivesAssetAssetType,PolymeshPrimitivesIdentityId,bool,Bytes,Vec<PolymeshPrimitivesAssetIdentifier>,Option<Bytes>)',
       IdentifiersUpdated:
         '(PolymeshPrimitivesIdentityId,PolymeshPrimitivesTicker,Vec<PolymeshPrimitivesAssetIdentifier>)',
       DivisibilityChanged: '(PolymeshPrimitivesIdentityId,PolymeshPrimitivesTicker,bool)',
@@ -1047,7 +1051,7 @@ export default {
     },
   },
   /**
-   * Lookup120: polymesh_primitives::asset::AssetType
+   * Lookup122: polymesh_primitives::asset::AssetType
    **/
   PolymeshPrimitivesAssetAssetType: {
     _enum: {
@@ -1065,7 +1069,7 @@ export default {
     },
   },
   /**
-   * Lookup123: polymesh_primitives::asset_identifier::AssetIdentifier
+   * Lookup126: polymesh_primitives::asset_identifier::AssetIdentifier
    **/
   PolymeshPrimitivesAssetIdentifier: {
     _enum: {
@@ -1077,7 +1081,7 @@ export default {
     },
   },
   /**
-   * Lookup128: polymesh_primitives::document::Document
+   * Lookup131: polymesh_primitives::document::Document
    **/
   PolymeshPrimitivesDocument: {
     uri: 'Bytes',
@@ -1087,7 +1091,7 @@ export default {
     filingDate: 'Option<u64>',
   },
   /**
-   * Lookup130: polymesh_primitives::document_hash::DocumentHash
+   * Lookup133: polymesh_primitives::document_hash::DocumentHash
    **/
   PolymeshPrimitivesDocumentHash: {
     _enum: {
@@ -1103,18 +1107,18 @@ export default {
     },
   },
   /**
-   * Lookup139: polymesh_primitives::ethereum::EthereumAddress
+   * Lookup142: polymesh_primitives::ethereum::EthereumAddress
    **/
   PolymeshPrimitivesEthereumEthereumAddress: '[u8;20]',
   /**
-   * Lookup142: polymesh_primitives::asset_metadata::AssetMetadataValueDetail<Moment>
+   * Lookup145: polymesh_primitives::asset_metadata::AssetMetadataValueDetail<Moment>
    **/
   PolymeshPrimitivesAssetMetadataAssetMetadataValueDetail: {
     expire: 'Option<u64>',
     lockStatus: 'PolymeshPrimitivesAssetMetadataAssetMetadataLockStatus',
   },
   /**
-   * Lookup143: polymesh_primitives::asset_metadata::AssetMetadataLockStatus<Moment>
+   * Lookup146: polymesh_primitives::asset_metadata::AssetMetadataLockStatus<Moment>
    **/
   PolymeshPrimitivesAssetMetadataAssetMetadataLockStatus: {
     _enum: {
@@ -1124,7 +1128,7 @@ export default {
     },
   },
   /**
-   * Lookup146: polymesh_primitives::asset_metadata::AssetMetadataSpec
+   * Lookup149: polymesh_primitives::asset_metadata::AssetMetadataSpec
    **/
   PolymeshPrimitivesAssetMetadataAssetMetadataSpec: {
     url: 'Option<Bytes>',
@@ -1132,7 +1136,7 @@ export default {
     typeDef: 'Option<Bytes>',
   },
   /**
-   * Lookup153: pallet_corporate_actions::distribution::Event
+   * Lookup156: pallet_corporate_actions::distribution::Event
    **/
   PalletCorporateActionsDistributionEvent: {
     _enum: {
@@ -1145,18 +1149,18 @@ export default {
     },
   },
   /**
-   * Lookup154: polymesh_primitives::event_only::EventOnly<polymesh_primitives::identity_id::IdentityId>
+   * Lookup157: polymesh_primitives::event_only::EventOnly<polymesh_primitives::identity_id::IdentityId>
    **/
   PolymeshPrimitivesEventOnly: 'PolymeshPrimitivesIdentityId',
   /**
-   * Lookup155: pallet_corporate_actions::CAId
+   * Lookup158: pallet_corporate_actions::CAId
    **/
   PalletCorporateActionsCaId: {
     ticker: 'PolymeshPrimitivesTicker',
     localId: 'u32',
   },
   /**
-   * Lookup157: pallet_corporate_actions::distribution::Distribution
+   * Lookup160: pallet_corporate_actions::distribution::Distribution
    **/
   PalletCorporateActionsDistribution: {
     from: 'PolymeshPrimitivesIdentityIdPortfolioId',
@@ -1169,7 +1173,7 @@ export default {
     expiresAt: 'Option<u64>',
   },
   /**
-   * Lookup159: polymesh_common_utilities::traits::checkpoint::Event
+   * Lookup162: polymesh_common_utilities::traits::checkpoint::Event
    **/
   PolymeshCommonUtilitiesCheckpointEvent: {
     _enum: {
@@ -1183,7 +1187,7 @@ export default {
     },
   },
   /**
-   * Lookup162: polymesh_common_utilities::traits::checkpoint::StoredSchedule
+   * Lookup165: polymesh_common_utilities::traits::checkpoint::StoredSchedule
    **/
   PolymeshCommonUtilitiesCheckpointStoredSchedule: {
     schedule: 'PolymeshPrimitivesCalendarCheckpointSchedule',
@@ -1192,27 +1196,27 @@ export default {
     remaining: 'u32',
   },
   /**
-   * Lookup163: polymesh_primitives::calendar::CheckpointSchedule
+   * Lookup166: polymesh_primitives::calendar::CheckpointSchedule
    **/
   PolymeshPrimitivesCalendarCheckpointSchedule: {
     start: 'u64',
     period: 'PolymeshPrimitivesCalendarCalendarPeriod',
   },
   /**
-   * Lookup164: polymesh_primitives::calendar::CalendarPeriod
+   * Lookup167: polymesh_primitives::calendar::CalendarPeriod
    **/
   PolymeshPrimitivesCalendarCalendarPeriod: {
     unit: 'PolymeshPrimitivesCalendarCalendarUnit',
     amount: 'u64',
   },
   /**
-   * Lookup165: polymesh_primitives::calendar::CalendarUnit
+   * Lookup168: polymesh_primitives::calendar::CalendarUnit
    **/
   PolymeshPrimitivesCalendarCalendarUnit: {
     _enum: ['Second', 'Minute', 'Hour', 'Day', 'Week', 'Month', 'Year'],
   },
   /**
-   * Lookup167: pallet_compliance_manager::Event
+   * Lookup170: pallet_compliance_manager::Event
    **/
   PalletComplianceManagerEvent: {
     _enum: {
@@ -1233,7 +1237,7 @@ export default {
     },
   },
   /**
-   * Lookup168: polymesh_primitives::compliance_manager::ComplianceRequirement
+   * Lookup171: polymesh_primitives::compliance_manager::ComplianceRequirement
    **/
   PolymeshPrimitivesComplianceManagerComplianceRequirement: {
     senderConditions: 'Vec<PolymeshPrimitivesCondition>',
@@ -1241,14 +1245,14 @@ export default {
     id: 'u32',
   },
   /**
-   * Lookup170: polymesh_primitives::condition::Condition
+   * Lookup173: polymesh_primitives::condition::Condition
    **/
   PolymeshPrimitivesCondition: {
     conditionType: 'PolymeshPrimitivesConditionConditionType',
     issuers: 'Vec<PolymeshPrimitivesConditionTrustedIssuer>',
   },
   /**
-   * Lookup171: polymesh_primitives::condition::ConditionType
+   * Lookup174: polymesh_primitives::condition::ConditionType
    **/
   PolymeshPrimitivesConditionConditionType: {
     _enum: {
@@ -1260,7 +1264,7 @@ export default {
     },
   },
   /**
-   * Lookup173: polymesh_primitives::condition::TargetIdentity
+   * Lookup176: polymesh_primitives::condition::TargetIdentity
    **/
   PolymeshPrimitivesConditionTargetIdentity: {
     _enum: {
@@ -1269,14 +1273,14 @@ export default {
     },
   },
   /**
-   * Lookup175: polymesh_primitives::condition::TrustedIssuer
+   * Lookup178: polymesh_primitives::condition::TrustedIssuer
    **/
   PolymeshPrimitivesConditionTrustedIssuer: {
     issuer: 'PolymeshPrimitivesIdentityId',
     trustedFor: 'PolymeshPrimitivesConditionTrustedFor',
   },
   /**
-   * Lookup176: polymesh_primitives::condition::TrustedFor
+   * Lookup179: polymesh_primitives::condition::TrustedFor
    **/
   PolymeshPrimitivesConditionTrustedFor: {
     _enum: {
@@ -1285,26 +1289,27 @@ export default {
     },
   },
   /**
-   * Lookup178: polymesh_primitives::identity_claim::ClaimType
+   * Lookup181: polymesh_primitives::identity_claim::ClaimType
    **/
   PolymeshPrimitivesIdentityClaimClaimType: {
-    _enum: [
-      'Accredited',
-      'Affiliate',
-      'BuyLockup',
-      'SellLockup',
-      'CustomerDueDiligence',
-      'KnowYourCustomer',
-      'Jurisdiction',
-      'Exempted',
-      'Blocked',
-      'InvestorUniqueness',
-      'NoType',
-      'InvestorUniquenessV2',
-    ],
+    _enum: {
+      Accredited: 'Null',
+      Affiliate: 'Null',
+      BuyLockup: 'Null',
+      SellLockup: 'Null',
+      CustomerDueDiligence: 'Null',
+      KnowYourCustomer: 'Null',
+      Jurisdiction: 'Null',
+      Exempted: 'Null',
+      Blocked: 'Null',
+      InvestorUniqueness: 'Null',
+      NoType: 'Null',
+      InvestorUniquenessV2: 'Null',
+      Custom: 'u32',
+    },
   },
   /**
-   * Lookup180: pallet_corporate_actions::Event
+   * Lookup183: pallet_corporate_actions::Event
    **/
   PalletCorporateActionsEvent: {
     _enum: {
@@ -1326,20 +1331,20 @@ export default {
     },
   },
   /**
-   * Lookup181: pallet_corporate_actions::TargetIdentities
+   * Lookup184: pallet_corporate_actions::TargetIdentities
    **/
   PalletCorporateActionsTargetIdentities: {
     identities: 'Vec<PolymeshPrimitivesIdentityId>',
     treatment: 'PalletCorporateActionsTargetTreatment',
   },
   /**
-   * Lookup182: pallet_corporate_actions::TargetTreatment
+   * Lookup185: pallet_corporate_actions::TargetTreatment
    **/
   PalletCorporateActionsTargetTreatment: {
     _enum: ['Include', 'Exclude'],
   },
   /**
-   * Lookup184: pallet_corporate_actions::CorporateAction
+   * Lookup187: pallet_corporate_actions::CorporateAction
    **/
   PalletCorporateActionsCorporateAction: {
     kind: 'PalletCorporateActionsCaKind',
@@ -1350,7 +1355,7 @@ export default {
     withholdingTax: 'Vec<(PolymeshPrimitivesIdentityId,Permill)>',
   },
   /**
-   * Lookup185: pallet_corporate_actions::CAKind
+   * Lookup188: pallet_corporate_actions::CAKind
    **/
   PalletCorporateActionsCaKind: {
     _enum: [
@@ -1362,14 +1367,14 @@ export default {
     ],
   },
   /**
-   * Lookup187: pallet_corporate_actions::RecordDate
+   * Lookup190: pallet_corporate_actions::RecordDate
    **/
   PalletCorporateActionsRecordDate: {
     date: 'u64',
     checkpoint: 'PalletCorporateActionsCaCheckpoint',
   },
   /**
-   * Lookup188: pallet_corporate_actions::CACheckpoint
+   * Lookup191: pallet_corporate_actions::CACheckpoint
    **/
   PalletCorporateActionsCaCheckpoint: {
     _enum: {
@@ -1378,7 +1383,7 @@ export default {
     },
   },
   /**
-   * Lookup193: pallet_corporate_actions::ballot::Event
+   * Lookup196: pallet_corporate_actions::ballot::Event
    **/
   PalletCorporateActionsBallotEvent: {
     _enum: {
@@ -1395,21 +1400,21 @@ export default {
     },
   },
   /**
-   * Lookup194: pallet_corporate_actions::ballot::BallotTimeRange
+   * Lookup197: pallet_corporate_actions::ballot::BallotTimeRange
    **/
   PalletCorporateActionsBallotBallotTimeRange: {
     start: 'u64',
     end: 'u64',
   },
   /**
-   * Lookup195: pallet_corporate_actions::ballot::BallotMeta
+   * Lookup198: pallet_corporate_actions::ballot::BallotMeta
    **/
   PalletCorporateActionsBallotBallotMeta: {
     title: 'Bytes',
     motions: 'Vec<PalletCorporateActionsBallotMotion>',
   },
   /**
-   * Lookup198: pallet_corporate_actions::ballot::Motion
+   * Lookup201: pallet_corporate_actions::ballot::Motion
    **/
   PalletCorporateActionsBallotMotion: {
     title: 'Bytes',
@@ -1417,14 +1422,14 @@ export default {
     choices: 'Vec<Bytes>',
   },
   /**
-   * Lookup204: pallet_corporate_actions::ballot::BallotVote
+   * Lookup207: pallet_corporate_actions::ballot::BallotVote
    **/
   PalletCorporateActionsBallotBallotVote: {
     power: 'u128',
     fallback: 'Option<u16>',
   },
   /**
-   * Lookup207: pallet_pips::RawEvent<sp_core::crypto::AccountId32, BlockNumber>
+   * Lookup210: pallet_pips::RawEvent<sp_core::crypto::AccountId32, BlockNumber>
    **/
   PalletPipsRawEvent: {
     _enum: {
@@ -1454,7 +1459,7 @@ export default {
     },
   },
   /**
-   * Lookup208: pallet_pips::Proposer<sp_core::crypto::AccountId32>
+   * Lookup211: pallet_pips::Proposer<sp_core::crypto::AccountId32>
    **/
   PalletPipsProposer: {
     _enum: {
@@ -1463,13 +1468,13 @@ export default {
     },
   },
   /**
-   * Lookup209: pallet_pips::Committee
+   * Lookup212: pallet_pips::Committee
    **/
   PalletPipsCommittee: {
     _enum: ['Technical', 'Upgrade'],
   },
   /**
-   * Lookup213: pallet_pips::ProposalData
+   * Lookup216: pallet_pips::ProposalData
    **/
   PalletPipsProposalData: {
     _enum: {
@@ -1478,20 +1483,20 @@ export default {
     },
   },
   /**
-   * Lookup214: pallet_pips::ProposalState
+   * Lookup217: pallet_pips::ProposalState
    **/
   PalletPipsProposalState: {
     _enum: ['Pending', 'Rejected', 'Scheduled', 'Failed', 'Executed', 'Expired'],
   },
   /**
-   * Lookup217: pallet_pips::SnapshottedPip
+   * Lookup220: pallet_pips::SnapshottedPip
    **/
   PalletPipsSnapshottedPip: {
     id: 'u32',
     weight: '(bool,u128)',
   },
   /**
-   * Lookup223: polymesh_common_utilities::traits::portfolio::Event
+   * Lookup226: polymesh_common_utilities::traits::portfolio::Event
    **/
   PolymeshCommonUtilitiesPortfolioEvent: {
     _enum: {
@@ -1506,7 +1511,7 @@ export default {
     },
   },
   /**
-   * Lookup227: pallet_protocol_fee::RawEvent<sp_core::crypto::AccountId32>
+   * Lookup230: pallet_protocol_fee::RawEvent<sp_core::crypto::AccountId32>
    **/
   PalletProtocolFeeRawEvent: {
     _enum: {
@@ -1516,11 +1521,11 @@ export default {
     },
   },
   /**
-   * Lookup228: polymesh_primitives::PosRatio
+   * Lookup231: polymesh_primitives::PosRatio
    **/
   PolymeshPrimitivesPosRatio: '(u32,u32)',
   /**
-   * Lookup229: pallet_scheduler::pallet::Event<T>
+   * Lookup232: pallet_scheduler::pallet::Event<T>
    **/
   PalletSchedulerEvent: {
     _enum: {
@@ -1545,13 +1550,13 @@ export default {
     },
   },
   /**
-   * Lookup231: frame_support::traits::schedule::LookupError
+   * Lookup234: frame_support::traits::schedule::LookupError
    **/
   FrameSupportScheduleLookupError: {
     _enum: ['Unknown', 'BadFormat'],
   },
   /**
-   * Lookup232: pallet_settlement::RawEvent<Moment, BlockNumber, sp_core::crypto::AccountId32>
+   * Lookup235: pallet_settlement::RawEvent<Moment, BlockNumber, sp_core::crypto::AccountId32>
    **/
   PalletSettlementRawEvent: {
     _enum: {
@@ -1559,7 +1564,7 @@ export default {
       VenueDetailsUpdated: '(PolymeshPrimitivesIdentityId,u64,Bytes)',
       VenueTypeUpdated: '(PolymeshPrimitivesIdentityId,u64,PalletSettlementVenueType)',
       InstructionCreated:
-        '(PolymeshPrimitivesIdentityId,u64,u64,PalletSettlementSettlementType,Option<u64>,Option<u64>,Vec<PalletSettlementLeg>)',
+        '(PolymeshPrimitivesIdentityId,u64,u64,PalletSettlementSettlementType,Option<u64>,Option<u64>,Vec<PalletSettlementLeg>,Option<PalletSettlementInstructionMemo>)',
       InstructionAffirmed:
         '(PolymeshPrimitivesIdentityId,PolymeshPrimitivesIdentityIdPortfolioId,u64)',
       AffirmationWithdrawn:
@@ -1577,16 +1582,17 @@ export default {
       VenueUnauthorized: '(PolymeshPrimitivesIdentityId,PolymeshPrimitivesTicker,u64)',
       SchedulingFailed: 'SpRuntimeDispatchError',
       InstructionRescheduled: '(PolymeshPrimitivesIdentityId,u64)',
+      VenueSignersUpdated: '(PolymeshPrimitivesIdentityId,u64,Vec<AccountId32>,bool)',
     },
   },
   /**
-   * Lookup235: pallet_settlement::VenueType
+   * Lookup238: pallet_settlement::VenueType
    **/
   PalletSettlementVenueType: {
     _enum: ['Other', 'Distribution', 'Sto', 'Exchange'],
   },
   /**
-   * Lookup237: pallet_settlement::SettlementType<BlockNumber>
+   * Lookup240: pallet_settlement::SettlementType<BlockNumber>
    **/
   PalletSettlementSettlementType: {
     _enum: {
@@ -1595,7 +1601,7 @@ export default {
     },
   },
   /**
-   * Lookup239: pallet_settlement::Leg
+   * Lookup242: pallet_settlement::Leg
    **/
   PalletSettlementLeg: {
     from: 'PolymeshPrimitivesIdentityIdPortfolioId',
@@ -1604,7 +1610,11 @@ export default {
     amount: 'u128',
   },
   /**
-   * Lookup243: polymesh_common_utilities::traits::statistics::Event
+   * Lookup244: pallet_settlement::InstructionMemo
+   **/
+  PalletSettlementInstructionMemo: '[u8;32]',
+  /**
+   * Lookup248: polymesh_common_utilities::traits::statistics::Event
    **/
   PolymeshCommonUtilitiesStatisticsEvent: {
     _enum: {
@@ -1623,7 +1633,7 @@ export default {
     },
   },
   /**
-   * Lookup244: polymesh_primitives::statistics::AssetScope
+   * Lookup249: polymesh_primitives::statistics::AssetScope
    **/
   PolymeshPrimitivesStatisticsAssetScope: {
     _enum: {
@@ -1631,27 +1641,27 @@ export default {
     },
   },
   /**
-   * Lookup246: polymesh_primitives::statistics::StatType
+   * Lookup251: polymesh_primitives::statistics::StatType
    **/
   PolymeshPrimitivesStatisticsStatType: {
     op: 'PolymeshPrimitivesStatisticsStatOpType',
     claimIssuer: 'Option<(PolymeshPrimitivesIdentityClaimClaimType,PolymeshPrimitivesIdentityId)>',
   },
   /**
-   * Lookup247: polymesh_primitives::statistics::StatOpType
+   * Lookup252: polymesh_primitives::statistics::StatOpType
    **/
   PolymeshPrimitivesStatisticsStatOpType: {
     _enum: ['Count', 'Balance'],
   },
   /**
-   * Lookup251: polymesh_primitives::statistics::StatUpdate
+   * Lookup256: polymesh_primitives::statistics::StatUpdate
    **/
   PolymeshPrimitivesStatisticsStatUpdate: {
     key2: 'PolymeshPrimitivesStatisticsStat2ndKey',
     value: 'Option<u128>',
   },
   /**
-   * Lookup252: polymesh_primitives::statistics::Stat2ndKey
+   * Lookup257: polymesh_primitives::statistics::Stat2ndKey
    **/
   PolymeshPrimitivesStatisticsStat2ndKey: {
     _enum: {
@@ -1660,7 +1670,7 @@ export default {
     },
   },
   /**
-   * Lookup253: polymesh_primitives::statistics::StatClaim
+   * Lookup258: polymesh_primitives::statistics::StatClaim
    **/
   PolymeshPrimitivesStatisticsStatClaim: {
     _enum: {
@@ -1670,7 +1680,7 @@ export default {
     },
   },
   /**
-   * Lookup257: polymesh_primitives::transfer_compliance::TransferCondition
+   * Lookup262: polymesh_primitives::transfer_compliance::TransferCondition
    **/
   PolymeshPrimitivesTransferComplianceTransferCondition: {
     _enum: {
@@ -1683,7 +1693,7 @@ export default {
     },
   },
   /**
-   * Lookup259: polymesh_primitives::transfer_compliance::TransferConditionExemptKey
+   * Lookup263: polymesh_primitives::transfer_compliance::TransferConditionExemptKey
    **/
   PolymeshPrimitivesTransferComplianceTransferConditionExemptKey: {
     asset: 'PolymeshPrimitivesStatisticsAssetScope',
@@ -1691,7 +1701,7 @@ export default {
     claimType: 'Option<PolymeshPrimitivesIdentityClaimClaimType>',
   },
   /**
-   * Lookup261: pallet_sto::RawEvent<Moment>
+   * Lookup265: pallet_sto::RawEvent<Moment>
    **/
   PalletStoRawEvent: {
     _enum: {
@@ -1705,7 +1715,7 @@ export default {
     },
   },
   /**
-   * Lookup264: pallet_sto::Fundraiser<Moment>
+   * Lookup268: pallet_sto::Fundraiser<Moment>
    **/
   PalletStoFundraiser: {
     creator: 'PolymeshPrimitivesIdentityId',
@@ -1721,7 +1731,7 @@ export default {
     minimumInvestment: 'u128',
   },
   /**
-   * Lookup266: pallet_sto::FundraiserTier
+   * Lookup270: pallet_sto::FundraiserTier
    **/
   PalletStoFundraiserTier: {
     total: 'u128',
@@ -1729,13 +1739,13 @@ export default {
     remaining: 'u128',
   },
   /**
-   * Lookup267: pallet_sto::FundraiserStatus
+   * Lookup271: pallet_sto::FundraiserStatus
    **/
   PalletStoFundraiserStatus: {
     _enum: ['Live', 'Frozen', 'Closed', 'ClosedEarly'],
   },
   /**
-   * Lookup268: pallet_treasury::RawEvent<Balance, sp_core::crypto::AccountId32>
+   * Lookup272: pallet_treasury::RawEvent<Balance, sp_core::crypto::AccountId32>
    **/
   PalletTreasuryRawEvent: {
     _enum: {
@@ -1747,7 +1757,7 @@ export default {
     },
   },
   /**
-   * Lookup269: pallet_utility::Event
+   * Lookup273: pallet_utility::Event
    **/
   PalletUtilityEvent: {
     _enum: {
@@ -1757,7 +1767,7 @@ export default {
     },
   },
   /**
-   * Lookup273: polymesh_common_utilities::traits::base::Event
+   * Lookup277: polymesh_common_utilities::traits::base::Event
    **/
   PolymeshCommonUtilitiesBaseEvent: {
     _enum: {
@@ -1765,7 +1775,7 @@ export default {
     },
   },
   /**
-   * Lookup275: polymesh_common_utilities::traits::external_agents::Event
+   * Lookup279: polymesh_common_utilities::traits::external_agents::Event
    **/
   PolymeshCommonUtilitiesExternalAgentsEvent: {
     _enum: {
@@ -1782,7 +1792,7 @@ export default {
     },
   },
   /**
-   * Lookup276: polymesh_common_utilities::traits::relayer::RawEvent<sp_core::crypto::AccountId32>
+   * Lookup280: polymesh_common_utilities::traits::relayer::RawEvent<sp_core::crypto::AccountId32>
    **/
   PolymeshCommonUtilitiesRelayerRawEvent: {
     _enum: {
@@ -1793,7 +1803,7 @@ export default {
     },
   },
   /**
-   * Lookup277: pallet_rewards::RawEvent<sp_core::crypto::AccountId32>
+   * Lookup281: pallet_rewards::RawEvent<sp_core::crypto::AccountId32>
    **/
   PalletRewardsRawEvent: {
     _enum: {
@@ -1801,7 +1811,7 @@ export default {
     },
   },
   /**
-   * Lookup278: pallet_contracts::pallet::Event<T>
+   * Lookup282: pallet_contracts::pallet::Event<T>
    **/
   PalletContractsEvent: {
     _enum: {
@@ -1831,11 +1841,11 @@ export default {
     },
   },
   /**
-   * Lookup279: polymesh_contracts::Event
+   * Lookup283: polymesh_contracts::Event
    **/
   PolymeshContractsEvent: 'Null',
   /**
-   * Lookup280: pallet_preimage::pallet::Event<T>
+   * Lookup284: pallet_preimage::pallet::Event<T>
    **/
   PalletPreimageEvent: {
     _enum: {
@@ -1860,7 +1870,7 @@ export default {
     },
   },
   /**
-   * Lookup281: pallet_test_utils::RawEvent<sp_core::crypto::AccountId32>
+   * Lookup285: pallet_test_utils::RawEvent<sp_core::crypto::AccountId32>
    **/
   PalletTestUtilsRawEvent: {
     _enum: {
@@ -1870,11 +1880,11 @@ export default {
     },
   },
   /**
-   * Lookup282: polymesh_primitives::cdd_id::InvestorUid
+   * Lookup286: polymesh_primitives::cdd_id::InvestorUid
    **/
   PolymeshPrimitivesCddIdInvestorUid: '[u8;16]',
   /**
-   * Lookup283: frame_system::Phase
+   * Lookup287: frame_system::Phase
    **/
   FrameSystemPhase: {
     _enum: {
@@ -1884,14 +1894,14 @@ export default {
     },
   },
   /**
-   * Lookup286: frame_system::LastRuntimeUpgradeInfo
+   * Lookup290: frame_system::LastRuntimeUpgradeInfo
    **/
   FrameSystemLastRuntimeUpgradeInfo: {
     specVersion: 'Compact<u32>',
     specName: 'Text',
   },
   /**
-   * Lookup289: frame_system::pallet::Call<T>
+   * Lookup293: frame_system::pallet::Call<T>
    **/
   FrameSystemCall: {
     _enum: {
@@ -1929,7 +1939,7 @@ export default {
     },
   },
   /**
-   * Lookup293: frame_system::limits::BlockWeights
+   * Lookup297: frame_system::limits::BlockWeights
    **/
   FrameSystemLimitsBlockWeights: {
     baseBlock: 'u64',
@@ -1937,7 +1947,7 @@ export default {
     perClass: 'FrameSupportWeightsPerDispatchClassWeightsPerClass',
   },
   /**
-   * Lookup294: frame_support::weights::PerDispatchClass<frame_system::limits::WeightsPerClass>
+   * Lookup298: frame_support::weights::PerDispatchClass<frame_system::limits::WeightsPerClass>
    **/
   FrameSupportWeightsPerDispatchClassWeightsPerClass: {
     normal: 'FrameSystemLimitsWeightsPerClass',
@@ -1945,7 +1955,7 @@ export default {
     mandatory: 'FrameSystemLimitsWeightsPerClass',
   },
   /**
-   * Lookup295: frame_system::limits::WeightsPerClass
+   * Lookup299: frame_system::limits::WeightsPerClass
    **/
   FrameSystemLimitsWeightsPerClass: {
     baseExtrinsic: 'u64',
@@ -1954,13 +1964,13 @@ export default {
     reserved: 'Option<u64>',
   },
   /**
-   * Lookup296: frame_system::limits::BlockLength
+   * Lookup300: frame_system::limits::BlockLength
    **/
   FrameSystemLimitsBlockLength: {
     max: 'FrameSupportWeightsPerDispatchClassU32',
   },
   /**
-   * Lookup297: frame_support::weights::PerDispatchClass<T>
+   * Lookup301: frame_support::weights::PerDispatchClass<T>
    **/
   FrameSupportWeightsPerDispatchClassU32: {
     normal: 'u32',
@@ -1968,14 +1978,14 @@ export default {
     mandatory: 'u32',
   },
   /**
-   * Lookup298: frame_support::weights::RuntimeDbWeight
+   * Lookup302: frame_support::weights::RuntimeDbWeight
    **/
   FrameSupportWeightsRuntimeDbWeight: {
     read: 'u64',
     write: 'u64',
   },
   /**
-   * Lookup299: sp_version::RuntimeVersion
+   * Lookup303: sp_version::RuntimeVersion
    **/
   SpVersionRuntimeVersion: {
     specName: 'Text',
@@ -1988,7 +1998,7 @@ export default {
     stateVersion: 'u8',
   },
   /**
-   * Lookup304: frame_system::pallet::Error<T>
+   * Lookup308: frame_system::pallet::Error<T>
    **/
   FrameSystemError: {
     _enum: [
@@ -2001,11 +2011,11 @@ export default {
     ],
   },
   /**
-   * Lookup307: sp_consensus_babe::app::Public
+   * Lookup311: sp_consensus_babe::app::Public
    **/
   SpConsensusBabeAppPublic: 'SpCoreSr25519Public',
   /**
-   * Lookup310: sp_consensus_babe::digests::NextConfigDescriptor
+   * Lookup314: sp_consensus_babe::digests::NextConfigDescriptor
    **/
   SpConsensusBabeDigestsNextConfigDescriptor: {
     _enum: {
@@ -2017,20 +2027,20 @@ export default {
     },
   },
   /**
-   * Lookup312: sp_consensus_babe::AllowedSlots
+   * Lookup316: sp_consensus_babe::AllowedSlots
    **/
   SpConsensusBabeAllowedSlots: {
     _enum: ['PrimarySlots', 'PrimaryAndSecondaryPlainSlots', 'PrimaryAndSecondaryVRFSlots'],
   },
   /**
-   * Lookup316: sp_consensus_babe::BabeEpochConfiguration
+   * Lookup320: sp_consensus_babe::BabeEpochConfiguration
    **/
   SpConsensusBabeBabeEpochConfiguration: {
     c: '(u64,u64)',
     allowedSlots: 'SpConsensusBabeAllowedSlots',
   },
   /**
-   * Lookup317: pallet_babe::pallet::Call<T>
+   * Lookup321: pallet_babe::pallet::Call<T>
    **/
   PalletBabeCall: {
     _enum: {
@@ -2048,7 +2058,7 @@ export default {
     },
   },
   /**
-   * Lookup318: sp_consensus_slots::EquivocationProof<sp_runtime::generic::header::Header<Number, sp_runtime::traits::BlakeTwo256>, sp_consensus_babe::app::Public>
+   * Lookup322: sp_consensus_slots::EquivocationProof<sp_runtime::generic::header::Header<Number, sp_runtime::traits::BlakeTwo256>, sp_consensus_babe::app::Public>
    **/
   SpConsensusSlotsEquivocationProof: {
     offender: 'SpConsensusBabeAppPublic',
@@ -2057,7 +2067,7 @@ export default {
     secondHeader: 'SpRuntimeHeader',
   },
   /**
-   * Lookup319: sp_runtime::generic::header::Header<Number, sp_runtime::traits::BlakeTwo256>
+   * Lookup323: sp_runtime::generic::header::Header<Number, sp_runtime::traits::BlakeTwo256>
    **/
   SpRuntimeHeader: {
     parentHash: 'H256',
@@ -2067,11 +2077,11 @@ export default {
     digest: 'SpRuntimeDigest',
   },
   /**
-   * Lookup320: sp_runtime::traits::BlakeTwo256
+   * Lookup324: sp_runtime::traits::BlakeTwo256
    **/
   SpRuntimeBlakeTwo256: 'Null',
   /**
-   * Lookup321: sp_session::MembershipProof
+   * Lookup325: sp_session::MembershipProof
    **/
   SpSessionMembershipProof: {
     session: 'u32',
@@ -2079,13 +2089,13 @@ export default {
     validatorCount: 'u32',
   },
   /**
-   * Lookup322: pallet_babe::pallet::Error<T>
+   * Lookup326: pallet_babe::pallet::Error<T>
    **/
   PalletBabeError: {
     _enum: ['InvalidEquivocationProof', 'InvalidKeyOwnershipProof', 'DuplicateOffenceReport'],
   },
   /**
-   * Lookup323: pallet_timestamp::pallet::Call<T>
+   * Lookup327: pallet_timestamp::pallet::Call<T>
    **/
   PalletTimestampCall: {
     _enum: {
@@ -2095,7 +2105,7 @@ export default {
     },
   },
   /**
-   * Lookup326: pallet_indices::pallet::Call<T>
+   * Lookup330: pallet_indices::pallet::Call<T>
    **/
   PalletIndicesCall: {
     _enum: {
@@ -2126,13 +2136,13 @@ export default {
     },
   },
   /**
-   * Lookup327: pallet_indices::pallet::Error<T>
+   * Lookup331: pallet_indices::pallet::Error<T>
    **/
   PalletIndicesError: {
     _enum: ['NotAssigned', 'NotOwner', 'InUse', 'NotTransfer', 'Permanent'],
   },
   /**
-   * Lookup329: pallet_authorship::UncleEntryItem<BlockNumber, primitive_types::H256, sp_core::crypto::AccountId32>
+   * Lookup333: pallet_authorship::UncleEntryItem<BlockNumber, primitive_types::H256, sp_core::crypto::AccountId32>
    **/
   PalletAuthorshipUncleEntryItem: {
     _enum: {
@@ -2141,7 +2151,7 @@ export default {
     },
   },
   /**
-   * Lookup330: pallet_authorship::pallet::Call<T>
+   * Lookup334: pallet_authorship::pallet::Call<T>
    **/
   PalletAuthorshipCall: {
     _enum: {
@@ -2151,7 +2161,7 @@ export default {
     },
   },
   /**
-   * Lookup332: pallet_authorship::pallet::Error<T>
+   * Lookup336: pallet_authorship::pallet::Error<T>
    **/
   PalletAuthorshipError: {
     _enum: [
@@ -2165,7 +2175,7 @@ export default {
     ],
   },
   /**
-   * Lookup334: pallet_balances::BalanceLock<Balance>
+   * Lookup338: pallet_balances::BalanceLock<Balance>
    **/
   PalletBalancesBalanceLock: {
     id: '[u8;8]',
@@ -2173,13 +2183,13 @@ export default {
     reasons: 'PolymeshCommonUtilitiesBalancesReasons',
   },
   /**
-   * Lookup335: polymesh_common_utilities::traits::balances::Reasons
+   * Lookup339: polymesh_common_utilities::traits::balances::Reasons
    **/
   PolymeshCommonUtilitiesBalancesReasons: {
     _enum: ['Fee', 'Misc', 'All'],
   },
   /**
-   * Lookup336: pallet_balances::Call<T>
+   * Lookup340: pallet_balances::Call<T>
    **/
   PalletBalancesCall: {
     _enum: {
@@ -2211,7 +2221,7 @@ export default {
     },
   },
   /**
-   * Lookup338: pallet_balances::Error<T>
+   * Lookup342: pallet_balances::Error<T>
    **/
   PalletBalancesError: {
     _enum: [
@@ -2223,13 +2233,13 @@ export default {
     ],
   },
   /**
-   * Lookup340: pallet_transaction_payment::Releases
+   * Lookup344: pallet_transaction_payment::Releases
    **/
   PalletTransactionPaymentReleases: {
     _enum: ['V1Ancient', 'V2'],
   },
   /**
-   * Lookup342: frame_support::weights::WeightToFeeCoefficient<Balance>
+   * Lookup346: frame_support::weights::WeightToFeeCoefficient<Balance>
    **/
   FrameSupportWeightsWeightToFeeCoefficient: {
     coeffInteger: 'u128',
@@ -2238,27 +2248,27 @@ export default {
     degree: 'u8',
   },
   /**
-   * Lookup343: polymesh_primitives::identity::DidRecord<sp_core::crypto::AccountId32>
+   * Lookup347: polymesh_primitives::identity::DidRecord<sp_core::crypto::AccountId32>
    **/
   PolymeshPrimitivesIdentityDidRecord: {
     primaryKey: 'Option<AccountId32>',
   },
   /**
-   * Lookup345: pallet_identity::types::Claim1stKey
+   * Lookup349: pallet_identity::types::Claim1stKey
    **/
   PalletIdentityClaim1stKey: {
     target: 'PolymeshPrimitivesIdentityId',
     claimType: 'PolymeshPrimitivesIdentityClaimClaimType',
   },
   /**
-   * Lookup346: pallet_identity::types::Claim2ndKey
+   * Lookup350: pallet_identity::types::Claim2ndKey
    **/
   PalletIdentityClaim2ndKey: {
     issuer: 'PolymeshPrimitivesIdentityId',
     scope: 'Option<PolymeshPrimitivesIdentityClaimScope>',
   },
   /**
-   * Lookup348: polymesh_primitives::secondary_key::KeyRecord<sp_core::crypto::AccountId32>
+   * Lookup351: polymesh_primitives::secondary_key::KeyRecord<sp_core::crypto::AccountId32>
    **/
   PolymeshPrimitivesSecondaryKeyKeyRecord: {
     _enum: {
@@ -2268,16 +2278,17 @@ export default {
     },
   },
   /**
-   * Lookup351: polymesh_primitives::authorization::Authorization<sp_core::crypto::AccountId32, Moment>
+   * Lookup354: polymesh_primitives::authorization::Authorization<sp_core::crypto::AccountId32, Moment>
    **/
   PolymeshPrimitivesAuthorization: {
     authorizationData: 'PolymeshPrimitivesAuthorizationAuthorizationData',
     authorizedBy: 'PolymeshPrimitivesIdentityId',
     expiry: 'Option<u64>',
     authId: 'u64',
+    count: 'u32',
   },
   /**
-   * Lookup354: pallet_identity::Call<T>
+   * Lookup357: pallet_identity::Call<T>
    **/
   PalletIdentityCall: {
     _enum: {
@@ -2337,7 +2348,7 @@ export default {
       add_investor_uniqueness_claim: {
         target: 'PolymeshPrimitivesIdentityId',
         claim: 'PolymeshPrimitivesIdentityClaimClaim',
-        proof: 'PolymeshPrimitivesInvestorZkproofDataV1InvestorZKProofData',
+        proof: '[u8;64]',
         expiry: 'Option<u64>',
       },
       gc_add_cdd_claim: {
@@ -2350,7 +2361,7 @@ export default {
         target: 'PolymeshPrimitivesIdentityId',
         scope: 'PolymeshPrimitivesIdentityClaimScope',
         claim: 'PolymeshPrimitivesIdentityClaimClaim',
-        proof: 'ConfidentialIdentityClaimProofsScopeClaimProof',
+        proof: 'ConfidentialIdentityV2ClaimProofsScopeClaimProof',
         expiry: 'Option<u64>',
       },
       revoke_claim_by_index: {
@@ -2373,92 +2384,57 @@ export default {
       remove_secondary_keys: {
         keysToRemove: 'Vec<AccountId32>',
       },
+      register_custom_claim_type: {
+        ty: 'Bytes',
+      },
     },
   },
   /**
-   * Lookup356: polymesh_common_utilities::traits::identity::SecondaryKeyWithAuthV1<sp_core::crypto::AccountId32>
+   * Lookup359: polymesh_common_utilities::traits::identity::SecondaryKeyWithAuthV1<sp_core::crypto::AccountId32>
    **/
   PolymeshCommonUtilitiesIdentitySecondaryKeyWithAuthV1: {
     secondaryKey: 'PolymeshPrimitivesSecondaryKeyV1SecondaryKey',
     authSignature: 'H512',
   },
   /**
-   * Lookup357: polymesh_primitives::secondary_key::v1::SecondaryKey<sp_core::crypto::AccountId32>
+   * Lookup360: polymesh_primitives::secondary_key::v1::SecondaryKey<sp_core::crypto::AccountId32>
    **/
   PolymeshPrimitivesSecondaryKeyV1SecondaryKey: {
     signer: 'PolymeshPrimitivesSecondaryKeySignatory',
     permissions: 'PolymeshPrimitivesSecondaryKeyPermissions',
   },
   /**
-   * Lookup359: polymesh_primitives::investor_zkproof_data::v1::InvestorZKProofData
+   * Lookup363: confidential_identity_v2::claim_proofs::ScopeClaimProof
    **/
-  PolymeshPrimitivesInvestorZkproofDataV1InvestorZKProofData: 'SchnorrkelSignSignature',
-  /**
-   * Lookup360: schnorrkel::sign::Signature
-   **/
-  SchnorrkelSignSignature: {
-    r: 'Curve25519DalekRistrettoCompressedRistretto',
-    s: 'Curve25519DalekScalar',
+  ConfidentialIdentityV2ClaimProofsScopeClaimProof: {
+    proofScopeIdWellformed: 'ConfidentialIdentityV2SignSignature',
+    proofScopeIdCddIdMatch: 'ConfidentialIdentityV2ClaimProofsZkProofData',
+    scopeId: '[u8;32]',
   },
   /**
-   * Lookup361: curve25519_dalek::ristretto::CompressedRistretto
+   * Lookup364: confidential_identity_v2::sign::Signature
    **/
-  Curve25519DalekRistrettoCompressedRistretto: '[u8;32]',
-  /**
-   * Lookup362: curve25519_dalek::scalar::Scalar
-   **/
-  Curve25519DalekScalar: {
-    bytes: '[u8;32]',
+  ConfidentialIdentityV2SignSignature: {
+    r: '[u8;32]',
+    s: '[u8;32]',
   },
   /**
-   * Lookup363: confidential_identity::claim_proofs::ScopeClaimProof
+   * Lookup365: confidential_identity_v2::claim_proofs::ZkProofData
    **/
-  ConfidentialIdentityClaimProofsScopeClaimProof: {
-    proofScopeIdWellformed: 'ConfidentialIdentitySignSignature',
-    proofScopeIdCddIdMatch: 'ConfidentialIdentityClaimProofsZkProofData',
-    scopeId: 'Curve25519DalekRistrettoRistrettoPoint',
+  ConfidentialIdentityV2ClaimProofsZkProofData: {
+    challengeResponses: '[[u8;32];2]',
+    subtractExpressionsRes: '[u8;32]',
+    blindedScopeDidHash: '[u8;32]',
   },
   /**
-   * Lookup364: confidential_identity::sign::Signature
-   **/
-  ConfidentialIdentitySignSignature: {
-    r: 'Curve25519DalekRistrettoCompressedRistretto',
-    s: 'Curve25519DalekScalar',
-  },
-  /**
-   * Lookup365: confidential_identity::claim_proofs::ZkProofData
-   **/
-  ConfidentialIdentityClaimProofsZkProofData: {
-    challengeResponses: '[Lookup362;2]',
-    subtractExpressionsRes: 'Curve25519DalekRistrettoRistrettoPoint',
-    blindedScopeDidHash: 'Curve25519DalekRistrettoRistrettoPoint',
-  },
-  /**
-   * Lookup367: curve25519_dalek::ristretto::RistrettoPoint
-   **/
-  Curve25519DalekRistrettoRistrettoPoint: 'Curve25519DalekEdwardsEdwardsPoint',
-  /**
-   * Lookup368: curve25519_dalek::edwards::EdwardsPoint
-   **/
-  Curve25519DalekEdwardsEdwardsPoint: {
-    x: 'Curve25519DalekBackendSerialU64FieldFieldElement51',
-    y: 'Curve25519DalekBackendSerialU64FieldFieldElement51',
-    z: 'Curve25519DalekBackendSerialU64FieldFieldElement51',
-    t: 'Curve25519DalekBackendSerialU64FieldFieldElement51',
-  },
-  /**
-   * Lookup369: curve25519_dalek::backend::serial::u64::field::FieldElement51
-   **/
-  Curve25519DalekBackendSerialU64FieldFieldElement51: '[u64;5]',
-  /**
-   * Lookup372: polymesh_common_utilities::traits::identity::SecondaryKeyWithAuth<sp_core::crypto::AccountId32>
+   * Lookup368: polymesh_common_utilities::traits::identity::SecondaryKeyWithAuth<sp_core::crypto::AccountId32>
    **/
   PolymeshCommonUtilitiesIdentitySecondaryKeyWithAuth: {
     secondaryKey: 'PolymeshPrimitivesSecondaryKey',
     authSignature: 'H512',
   },
   /**
-   * Lookup373: pallet_identity::Error<T>
+   * Lookup369: pallet_identity::Error<T>
    **/
   PalletIdentityError: {
     _enum: [
@@ -2495,10 +2471,12 @@ export default {
       'ClaimAndProofVersionsDoNotMatch',
       'AccountKeyIsBeingUsed',
       'CustomScopeTooLong',
+      'CustomClaimTypeAlreadyExists',
+      'CustomClaimTypeDoesNotExist',
     ],
   },
   /**
-   * Lookup375: polymesh_common_utilities::traits::group::InactiveMember<Moment>
+   * Lookup371: polymesh_common_utilities::traits::group::InactiveMember<Moment>
    **/
   PolymeshCommonUtilitiesGroupInactiveMember: {
     id: 'PolymeshPrimitivesIdentityId',
@@ -2506,7 +2484,7 @@ export default {
     expiry: 'Option<u64>',
   },
   /**
-   * Lookup376: pallet_group::Call<T, I>
+   * Lookup372: pallet_group::Call<T, I>
    **/
   PalletGroupCall: {
     _enum: {
@@ -2535,7 +2513,7 @@ export default {
     },
   },
   /**
-   * Lookup377: pallet_group::Error<T, I>
+   * Lookup373: pallet_group::Error<T, I>
    **/
   PalletGroupError: {
     _enum: [
@@ -2549,7 +2527,7 @@ export default {
     ],
   },
   /**
-   * Lookup379: pallet_committee::Call<T, I>
+   * Lookup375: pallet_committee::Call<T, I>
    **/
   PalletCommitteeCall: {
     _enum: {
@@ -2575,7 +2553,7 @@ export default {
     },
   },
   /**
-   * Lookup385: pallet_multisig::Call<T>
+   * Lookup381: pallet_multisig::Call<T>
    **/
   PalletMultisigCall: {
     _enum: {
@@ -2662,7 +2640,7 @@ export default {
     },
   },
   /**
-   * Lookup386: pallet_bridge::Call<T>
+   * Lookup382: pallet_bridge::Call<T>
    **/
   PalletBridgeCall: {
     _enum: {
@@ -2717,7 +2695,7 @@ export default {
     },
   },
   /**
-   * Lookup390: pallet_staking::Call<T>
+   * Lookup386: pallet_staking::Call<T>
    **/
   PalletStakingCall: {
     _enum: {
@@ -2839,7 +2817,7 @@ export default {
     },
   },
   /**
-   * Lookup391: pallet_staking::RewardDestination<sp_core::crypto::AccountId32>
+   * Lookup387: pallet_staking::RewardDestination<sp_core::crypto::AccountId32>
    **/
   PalletStakingRewardDestination: {
     _enum: {
@@ -2850,14 +2828,14 @@ export default {
     },
   },
   /**
-   * Lookup392: pallet_staking::ValidatorPrefs
+   * Lookup388: pallet_staking::ValidatorPrefs
    **/
   PalletStakingValidatorPrefs: {
     commission: 'Compact<Perbill>',
     blocked: 'bool',
   },
   /**
-   * Lookup398: pallet_staking::CompactAssignments
+   * Lookup394: pallet_staking::CompactAssignments
    **/
   PalletStakingCompactAssignments: {
     votes1: 'Vec<(Compact<u32>,Compact<u16>)>',
@@ -2878,7 +2856,7 @@ export default {
     votes16: 'Vec<(Compact<u32>,[(Compact<u16>,Compact<PerU16>);15],Compact<u16>)>',
   },
   /**
-   * Lookup449: sp_npos_elections::ElectionScore
+   * Lookup445: sp_npos_elections::ElectionScore
    **/
   SpNposElectionsElectionScore: {
     minimalStake: 'u128',
@@ -2886,14 +2864,14 @@ export default {
     sumStakeSquared: 'u128',
   },
   /**
-   * Lookup450: pallet_staking::ElectionSize
+   * Lookup446: pallet_staking::ElectionSize
    **/
   PalletStakingElectionSize: {
     validators: 'Compact<u16>',
     nominators: 'Compact<u32>',
   },
   /**
-   * Lookup451: pallet_session::pallet::Call<T>
+   * Lookup447: pallet_session::pallet::Call<T>
    **/
   PalletSessionCall: {
     _enum: {
@@ -2908,7 +2886,7 @@ export default {
     },
   },
   /**
-   * Lookup452: polymesh_runtime_develop::runtime::SessionKeys
+   * Lookup448: polymesh_runtime_develop::runtime::SessionKeys
    **/
   PolymeshRuntimeDevelopRuntimeSessionKeys: {
     grandpa: 'SpFinalityGrandpaAppPublic',
@@ -2917,11 +2895,11 @@ export default {
     authorityDiscovery: 'SpAuthorityDiscoveryAppPublic',
   },
   /**
-   * Lookup453: sp_authority_discovery::app::Public
+   * Lookup449: sp_authority_discovery::app::Public
    **/
   SpAuthorityDiscoveryAppPublic: 'SpCoreSr25519Public',
   /**
-   * Lookup454: pallet_grandpa::pallet::Call<T>
+   * Lookup450: pallet_grandpa::pallet::Call<T>
    **/
   PalletGrandpaCall: {
     _enum: {
@@ -2940,14 +2918,14 @@ export default {
     },
   },
   /**
-   * Lookup455: sp_finality_grandpa::EquivocationProof<primitive_types::H256, N>
+   * Lookup451: sp_finality_grandpa::EquivocationProof<primitive_types::H256, N>
    **/
   SpFinalityGrandpaEquivocationProof: {
     setId: 'u64',
     equivocation: 'SpFinalityGrandpaEquivocation',
   },
   /**
-   * Lookup456: sp_finality_grandpa::Equivocation<primitive_types::H256, N>
+   * Lookup452: sp_finality_grandpa::Equivocation<primitive_types::H256, N>
    **/
   SpFinalityGrandpaEquivocation: {
     _enum: {
@@ -2956,7 +2934,7 @@ export default {
     },
   },
   /**
-   * Lookup457: finality_grandpa::Equivocation<sp_finality_grandpa::app::Public, finality_grandpa::Prevote<primitive_types::H256, N>, sp_finality_grandpa::app::Signature>
+   * Lookup453: finality_grandpa::Equivocation<sp_finality_grandpa::app::Public, finality_grandpa::Prevote<primitive_types::H256, N>, sp_finality_grandpa::app::Signature>
    **/
   FinalityGrandpaEquivocationPrevote: {
     roundNumber: 'u64',
@@ -2965,22 +2943,22 @@ export default {
     second: '(FinalityGrandpaPrevote,SpFinalityGrandpaAppSignature)',
   },
   /**
-   * Lookup458: finality_grandpa::Prevote<primitive_types::H256, N>
+   * Lookup454: finality_grandpa::Prevote<primitive_types::H256, N>
    **/
   FinalityGrandpaPrevote: {
     targetHash: 'H256',
     targetNumber: 'u32',
   },
   /**
-   * Lookup459: sp_finality_grandpa::app::Signature
+   * Lookup455: sp_finality_grandpa::app::Signature
    **/
   SpFinalityGrandpaAppSignature: 'SpCoreEd25519Signature',
   /**
-   * Lookup460: sp_core::ed25519::Signature
+   * Lookup456: sp_core::ed25519::Signature
    **/
   SpCoreEd25519Signature: '[u8;64]',
   /**
-   * Lookup462: finality_grandpa::Equivocation<sp_finality_grandpa::app::Public, finality_grandpa::Precommit<primitive_types::H256, N>, sp_finality_grandpa::app::Signature>
+   * Lookup458: finality_grandpa::Equivocation<sp_finality_grandpa::app::Public, finality_grandpa::Precommit<primitive_types::H256, N>, sp_finality_grandpa::app::Signature>
    **/
   FinalityGrandpaEquivocationPrecommit: {
     roundNumber: 'u64',
@@ -2989,14 +2967,14 @@ export default {
     second: '(FinalityGrandpaPrecommit,SpFinalityGrandpaAppSignature)',
   },
   /**
-   * Lookup463: finality_grandpa::Precommit<primitive_types::H256, N>
+   * Lookup459: finality_grandpa::Precommit<primitive_types::H256, N>
    **/
   FinalityGrandpaPrecommit: {
     targetHash: 'H256',
     targetNumber: 'u32',
   },
   /**
-   * Lookup465: pallet_im_online::pallet::Call<T>
+   * Lookup461: pallet_im_online::pallet::Call<T>
    **/
   PalletImOnlineCall: {
     _enum: {
@@ -3007,7 +2985,7 @@ export default {
     },
   },
   /**
-   * Lookup466: pallet_im_online::Heartbeat<BlockNumber>
+   * Lookup462: pallet_im_online::Heartbeat<BlockNumber>
    **/
   PalletImOnlineHeartbeat: {
     blockNumber: 'u32',
@@ -3017,22 +2995,22 @@ export default {
     validatorsLen: 'u32',
   },
   /**
-   * Lookup467: sp_core::offchain::OpaqueNetworkState
+   * Lookup463: sp_core::offchain::OpaqueNetworkState
    **/
   SpCoreOffchainOpaqueNetworkState: {
     peerId: 'Bytes',
     externalAddresses: 'Vec<Bytes>',
   },
   /**
-   * Lookup471: pallet_im_online::sr25519::app_sr25519::Signature
+   * Lookup467: pallet_im_online::sr25519::app_sr25519::Signature
    **/
   PalletImOnlineSr25519AppSr25519Signature: 'SpCoreSr25519Signature',
   /**
-   * Lookup472: sp_core::sr25519::Signature
+   * Lookup468: sp_core::sr25519::Signature
    **/
   SpCoreSr25519Signature: '[u8;64]',
   /**
-   * Lookup473: pallet_sudo::Call<T>
+   * Lookup469: pallet_sudo::Call<T>
    **/
   PalletSudoCall: {
     _enum: {
@@ -3056,7 +3034,7 @@ export default {
     },
   },
   /**
-   * Lookup474: pallet_asset::Call<T>
+   * Lookup470: pallet_asset::Call<T>
    **/
   PalletAssetCall: {
     _enum: {
@@ -3168,14 +3146,19 @@ export default {
         name: 'Bytes',
         spec: 'PolymeshPrimitivesAssetMetadataAssetMetadataSpec',
       },
+      redeem_from_portfolio: {
+        ticker: 'PolymeshPrimitivesTicker',
+        value: 'u128',
+        portfolio: 'PolymeshPrimitivesIdentityIdPortfolioKind',
+      },
     },
   },
   /**
-   * Lookup477: polymesh_primitives::ethereum::EcdsaSignature
+   * Lookup472: polymesh_primitives::ethereum::EcdsaSignature
    **/
   PolymeshPrimitivesEthereumEcdsaSignature: '[u8;65]',
   /**
-   * Lookup479: pallet_asset::ClassicTickerImport
+   * Lookup474: pallet_asset::ClassicTickerImport
    **/
   PalletAssetClassicTickerImport: {
     ethOwner: 'PolymeshPrimitivesEthereumEthereumAddress',
@@ -3184,14 +3167,14 @@ export default {
     isCreated: 'bool',
   },
   /**
-   * Lookup480: pallet_asset::TickerRegistrationConfig<U>
+   * Lookup475: pallet_asset::TickerRegistrationConfig<U>
    **/
   PalletAssetTickerRegistrationConfig: {
     maxTickerLength: 'u8',
     registrationLength: 'Option<u64>',
   },
   /**
-   * Lookup481: polymesh_primitives::asset_metadata::AssetMetadataKey
+   * Lookup476: polymesh_primitives::asset_metadata::AssetMetadataKey
    **/
   PolymeshPrimitivesAssetMetadataAssetMetadataKey: {
     _enum: {
@@ -3200,7 +3183,7 @@ export default {
     },
   },
   /**
-   * Lookup482: pallet_corporate_actions::distribution::Call<T>
+   * Lookup477: pallet_corporate_actions::distribution::Call<T>
    **/
   PalletCorporateActionsDistributionCall: {
     _enum: {
@@ -3229,7 +3212,7 @@ export default {
     },
   },
   /**
-   * Lookup484: pallet_asset::checkpoint::Call<T>
+   * Lookup479: pallet_asset::checkpoint::Call<T>
    **/
   PalletAssetCheckpointCall: {
     _enum: {
@@ -3250,7 +3233,7 @@ export default {
     },
   },
   /**
-   * Lookup485: pallet_asset::checkpoint::ScheduleSpec
+   * Lookup480: pallet_asset::checkpoint::ScheduleSpec
    **/
   PalletAssetCheckpointScheduleSpec: {
     start: 'Option<u64>',
@@ -3258,7 +3241,7 @@ export default {
     remaining: 'u32',
   },
   /**
-   * Lookup486: pallet_compliance_manager::Call<T>
+   * Lookup481: pallet_compliance_manager::Call<T>
    **/
   PalletComplianceManagerCall: {
     _enum: {
@@ -3299,7 +3282,7 @@ export default {
     },
   },
   /**
-   * Lookup487: pallet_corporate_actions::Call<T>
+   * Lookup482: pallet_corporate_actions::Call<T>
    **/
   PalletCorporateActionsCall: {
     _enum: {
@@ -3352,7 +3335,7 @@ export default {
     },
   },
   /**
-   * Lookup489: pallet_corporate_actions::RecordDateSpec
+   * Lookup484: pallet_corporate_actions::RecordDateSpec
    **/
   PalletCorporateActionsRecordDateSpec: {
     _enum: {
@@ -3362,7 +3345,7 @@ export default {
     },
   },
   /**
-   * Lookup492: pallet_corporate_actions::InitiateCorporateActionArgs
+   * Lookup487: pallet_corporate_actions::InitiateCorporateActionArgs
    **/
   PalletCorporateActionsInitiateCorporateActionArgs: {
     ticker: 'PolymeshPrimitivesTicker',
@@ -3375,7 +3358,7 @@ export default {
     withholdingTax: 'Option<Vec<(PolymeshPrimitivesIdentityId,Permill)>>',
   },
   /**
-   * Lookup493: pallet_corporate_actions::ballot::Call<T>
+   * Lookup488: pallet_corporate_actions::ballot::Call<T>
    **/
   PalletCorporateActionsBallotCall: {
     _enum: {
@@ -3407,7 +3390,7 @@ export default {
     },
   },
   /**
-   * Lookup494: pallet_pips::Call<T>
+   * Lookup489: pallet_pips::Call<T>
    **/
   PalletPipsCall: {
     _enum: {
@@ -3468,13 +3451,13 @@ export default {
     },
   },
   /**
-   * Lookup497: pallet_pips::SnapshotResult
+   * Lookup492: pallet_pips::SnapshotResult
    **/
   PalletPipsSnapshotResult: {
     _enum: ['Approve', 'Reject', 'Skip'],
   },
   /**
-   * Lookup498: pallet_portfolio::Call<T>
+   * Lookup493: pallet_portfolio::Call<T>
    **/
   PalletPortfolioCall: {
     _enum: {
@@ -3502,7 +3485,7 @@ export default {
     },
   },
   /**
-   * Lookup500: pallet_portfolio::MovePortfolioItem
+   * Lookup495: pallet_portfolio::MovePortfolioItem
    **/
   PalletPortfolioMovePortfolioItem: {
     ticker: 'PolymeshPrimitivesTicker',
@@ -3510,7 +3493,7 @@ export default {
     memo: 'Option<PolymeshCommonUtilitiesBalancesMemo>',
   },
   /**
-   * Lookup501: pallet_protocol_fee::Call<T>
+   * Lookup496: pallet_protocol_fee::Call<T>
    **/
   PalletProtocolFeeCall: {
     _enum: {
@@ -3524,7 +3507,7 @@ export default {
     },
   },
   /**
-   * Lookup502: polymesh_common_utilities::protocol_fee::ProtocolOp
+   * Lookup497: polymesh_common_utilities::protocol_fee::ProtocolOp
    **/
   PolymeshCommonUtilitiesProtocolFeeProtocolOp: {
     _enum: [
@@ -3544,7 +3527,7 @@ export default {
     ],
   },
   /**
-   * Lookup503: pallet_scheduler::pallet::Call<T>
+   * Lookup498: pallet_scheduler::pallet::Call<T>
    **/
   PalletSchedulerCall: {
     _enum: {
@@ -3584,7 +3567,7 @@ export default {
     },
   },
   /**
-   * Lookup505: frame_support::traits::schedule::MaybeHashed<polymesh_runtime_develop::runtime::Call, primitive_types::H256>
+   * Lookup500: frame_support::traits::schedule::MaybeHashed<polymesh_runtime_develop::runtime::Call, primitive_types::H256>
    **/
   FrameSupportScheduleMaybeHashed: {
     _enum: {
@@ -3593,7 +3576,7 @@ export default {
     },
   },
   /**
-   * Lookup506: pallet_settlement::Call<T>
+   * Lookup501: pallet_settlement::Call<T>
    **/
   PalletSettlementCall: {
     _enum: {
@@ -3677,10 +3660,32 @@ export default {
       reschedule_instruction: {
         id: 'u64',
       },
+      update_venue_signers: {
+        id: 'u64',
+        signers: 'Vec<AccountId32>',
+        addSigners: 'bool',
+      },
+      add_instruction_with_memo: {
+        venueId: 'u64',
+        settlementType: 'PalletSettlementSettlementType',
+        tradeDate: 'Option<u64>',
+        valueDate: 'Option<u64>',
+        legs: 'Vec<PalletSettlementLeg>',
+        instructionMemo: 'Option<PalletSettlementInstructionMemo>',
+      },
+      add_and_affirm_instruction_with_memo: {
+        venueId: 'u64',
+        settlementType: 'PalletSettlementSettlementType',
+        tradeDate: 'Option<u64>',
+        valueDate: 'Option<u64>',
+        legs: 'Vec<PalletSettlementLeg>',
+        portfolios: 'Vec<PolymeshPrimitivesIdentityIdPortfolioId>',
+        instructionMemo: 'Option<PalletSettlementInstructionMemo>',
+      },
     },
   },
   /**
-   * Lookup508: pallet_settlement::ReceiptDetails<sp_core::crypto::AccountId32, sp_runtime::MultiSignature>
+   * Lookup503: pallet_settlement::ReceiptDetails<sp_core::crypto::AccountId32, sp_runtime::MultiSignature>
    **/
   PalletSettlementReceiptDetails: {
     receiptUid: 'u64',
@@ -3690,7 +3695,7 @@ export default {
     metadata: 'Bytes',
   },
   /**
-   * Lookup509: sp_runtime::MultiSignature
+   * Lookup504: sp_runtime::MultiSignature
    **/
   SpRuntimeMultiSignature: {
     _enum: {
@@ -3700,11 +3705,11 @@ export default {
     },
   },
   /**
-   * Lookup510: sp_core::ecdsa::Signature
+   * Lookup505: sp_core::ecdsa::Signature
    **/
   SpCoreEcdsaSignature: '[u8;65]',
   /**
-   * Lookup511: pallet_statistics::Call<T>
+   * Lookup506: pallet_statistics::Call<T>
    **/
   PalletStatisticsCall: {
     _enum: {
@@ -3729,7 +3734,7 @@ export default {
     },
   },
   /**
-   * Lookup516: pallet_sto::Call<T>
+   * Lookup511: pallet_sto::Call<T>
    **/
   PalletStoCall: {
     _enum: {
@@ -3775,14 +3780,14 @@ export default {
     },
   },
   /**
-   * Lookup518: pallet_sto::PriceTier
+   * Lookup513: pallet_sto::PriceTier
    **/
   PalletStoPriceTier: {
     total: 'u128',
     price: 'u128',
   },
   /**
-   * Lookup520: pallet_treasury::Call<T>
+   * Lookup515: pallet_treasury::Call<T>
    **/
   PalletTreasuryCall: {
     _enum: {
@@ -3795,14 +3800,14 @@ export default {
     },
   },
   /**
-   * Lookup522: polymesh_primitives::Beneficiary<Balance>
+   * Lookup517: polymesh_primitives::Beneficiary<Balance>
    **/
   PolymeshPrimitivesBeneficiary: {
     id: 'PolymeshPrimitivesIdentityId',
     amount: 'u128',
   },
   /**
-   * Lookup523: pallet_utility::Call<T>
+   * Lookup518: pallet_utility::Call<T>
    **/
   PalletUtilityCall: {
     _enum: {
@@ -3823,18 +3828,18 @@ export default {
     },
   },
   /**
-   * Lookup525: pallet_utility::UniqueCall<polymesh_runtime_develop::runtime::Call>
+   * Lookup520: pallet_utility::UniqueCall<polymesh_runtime_develop::runtime::Call>
    **/
   PalletUtilityUniqueCall: {
     nonce: 'u64',
     call: 'Call',
   },
   /**
-   * Lookup526: pallet_base::Call<T>
+   * Lookup521: pallet_base::Call<T>
    **/
   PalletBaseCall: 'Null',
   /**
-   * Lookup527: pallet_external_agents::Call<T>
+   * Lookup522: pallet_external_agents::Call<T>
    **/
   PalletExternalAgentsCall: {
     _enum: {
@@ -3865,7 +3870,8 @@ export default {
       create_group_and_add_auth: {
         ticker: 'PolymeshPrimitivesTicker',
         perms: 'PolymeshPrimitivesSubsetSubsetRestrictionPalletPermissions',
-        target: 'PolymeshPrimitivesSecondaryKeySignatory',
+        target: 'PolymeshPrimitivesIdentityId',
+        expiry: 'Option<u64>',
       },
       create_and_change_custom_group: {
         ticker: 'PolymeshPrimitivesTicker',
@@ -3875,7 +3881,7 @@ export default {
     },
   },
   /**
-   * Lookup528: pallet_relayer::Call<T>
+   * Lookup523: pallet_relayer::Call<T>
    **/
   PalletRelayerCall: {
     _enum: {
@@ -3905,7 +3911,7 @@ export default {
     },
   },
   /**
-   * Lookup529: pallet_rewards::Call<T>
+   * Lookup524: pallet_rewards::Call<T>
    **/
   PalletRewardsCall: {
     _enum: {
@@ -3921,7 +3927,7 @@ export default {
     },
   },
   /**
-   * Lookup530: pallet_rewards::ItnRewardStatus
+   * Lookup525: pallet_rewards::ItnRewardStatus
    **/
   PalletRewardsItnRewardStatus: {
     _enum: {
@@ -3930,40 +3936,47 @@ export default {
     },
   },
   /**
-   * Lookup531: polymesh_contracts::Call<T>
+   * Lookup526: pallet_contracts::pallet::Call<T>
    **/
-  PolymeshContractsCall: {
+  PalletContractsCall: {
     _enum: {
       call: {
-        contract: 'AccountId32',
-        value: 'u128',
-        gasLimit: 'u64',
-        storageDepositLimit: 'Option<u128>',
+        dest: 'MultiAddress',
+        value: 'Compact<u128>',
+        gasLimit: 'Compact<u64>',
+        storageDepositLimit: 'Option<Compact<u128>>',
         data: 'Bytes',
       },
       instantiate_with_code: {
-        endowment: 'u128',
-        gasLimit: 'u64',
-        storageDepositLimit: 'Option<u128>',
+        value: 'Compact<u128>',
+        gasLimit: 'Compact<u64>',
+        storageDepositLimit: 'Option<Compact<u128>>',
         code: 'Bytes',
         data: 'Bytes',
         salt: 'Bytes',
       },
       instantiate: {
-        endowment: 'u128',
-        gasLimit: 'u64',
-        storageDepositLimit: 'Option<u128>',
+        value: 'Compact<u128>',
+        gasLimit: 'Compact<u64>',
+        storageDepositLimit: 'Option<Compact<u128>>',
         codeHash: 'H256',
         data: 'Bytes',
         salt: 'Bytes',
       },
       upload_code: {
         code: 'Bytes',
-        storageDepositLimit: 'Option<u128>',
+        storageDepositLimit: 'Option<Compact<u128>>',
       },
       remove_code: {
         codeHash: 'H256',
       },
+    },
+  },
+  /**
+   * Lookup528: polymesh_contracts::Call<T>
+   **/
+  PolymeshContractsCall: {
+    _enum: {
       instantiate_with_code_perms: {
         endowment: 'u128',
         gasLimit: 'u64',
@@ -3985,7 +3998,7 @@ export default {
     },
   },
   /**
-   * Lookup532: pallet_preimage::pallet::Call<T>
+   * Lookup529: pallet_preimage::pallet::Call<T>
    **/
   PalletPreimageCall: {
     _enum: {
@@ -4013,7 +4026,7 @@ export default {
     },
   },
   /**
-   * Lookup533: pallet_test_utils::Call<T>
+   * Lookup530: pallet_test_utils::Call<T>
    **/
   PalletTestUtilsCall: {
     _enum: {
@@ -4031,7 +4044,7 @@ export default {
     },
   },
   /**
-   * Lookup534: pallet_committee::PolymeshVotes<BlockNumber>
+   * Lookup531: pallet_committee::PolymeshVotes<BlockNumber>
    **/
   PalletCommitteePolymeshVotes: {
     index: 'u32',
@@ -4040,7 +4053,7 @@ export default {
     expiry: 'PolymeshCommonUtilitiesMaybeBlock',
   },
   /**
-   * Lookup536: pallet_committee::Error<T, I>
+   * Lookup533: pallet_committee::Error<T, I>
    **/
   PalletCommitteeError: {
     _enum: [
@@ -4056,7 +4069,7 @@ export default {
     ],
   },
   /**
-   * Lookup546: pallet_multisig::ProposalDetails<T>
+   * Lookup543: pallet_multisig::ProposalDetails<T>
    **/
   PalletMultisigProposalDetails: {
     approvals: 'u64',
@@ -4066,13 +4079,13 @@ export default {
     autoClose: 'bool',
   },
   /**
-   * Lookup547: pallet_multisig::ProposalStatus
+   * Lookup544: pallet_multisig::ProposalStatus
    **/
   PalletMultisigProposalStatus: {
     _enum: ['Invalid', 'ActiveOrExpired', 'ExecutionSuccessful', 'ExecutionFailed', 'Rejected'],
   },
   /**
-   * Lookup549: pallet_multisig::Error<T>
+   * Lookup546: pallet_multisig::Error<T>
    **/
   PalletMultisigError: {
     _enum: [
@@ -4104,7 +4117,7 @@ export default {
     ],
   },
   /**
-   * Lookup551: pallet_bridge::BridgeTxDetail<BlockNumber>
+   * Lookup548: pallet_bridge::BridgeTxDetail<BlockNumber>
    **/
   PalletBridgeBridgeTxDetail: {
     amount: 'u128',
@@ -4113,7 +4126,7 @@ export default {
     txHash: 'H256',
   },
   /**
-   * Lookup552: pallet_bridge::BridgeTxStatus
+   * Lookup549: pallet_bridge::BridgeTxStatus
    **/
   PalletBridgeBridgeTxStatus: {
     _enum: {
@@ -4125,7 +4138,7 @@ export default {
     },
   },
   /**
-   * Lookup555: pallet_bridge::Error<T>
+   * Lookup552: pallet_bridge::Error<T>
    **/
   PalletBridgeError: {
     _enum: [
@@ -4145,7 +4158,7 @@ export default {
     ],
   },
   /**
-   * Lookup556: pallet_staking::StakingLedger<sp_core::crypto::AccountId32, Balance>
+   * Lookup553: pallet_staking::StakingLedger<sp_core::crypto::AccountId32, Balance>
    **/
   PalletStakingStakingLedger: {
     stash: 'AccountId32',
@@ -4155,14 +4168,14 @@ export default {
     claimedRewards: 'Vec<u32>',
   },
   /**
-   * Lookup558: pallet_staking::UnlockChunk<Balance>
+   * Lookup555: pallet_staking::UnlockChunk<Balance>
    **/
   PalletStakingUnlockChunk: {
     value: 'Compact<u128>',
     era: 'Compact<u32>',
   },
   /**
-   * Lookup559: pallet_staking::Nominations<sp_core::crypto::AccountId32>
+   * Lookup556: pallet_staking::Nominations<sp_core::crypto::AccountId32>
    **/
   PalletStakingNominations: {
     targets: 'Vec<AccountId32>',
@@ -4170,27 +4183,27 @@ export default {
     suppressed: 'bool',
   },
   /**
-   * Lookup560: pallet_staking::ActiveEraInfo
+   * Lookup557: pallet_staking::ActiveEraInfo
    **/
   PalletStakingActiveEraInfo: {
     index: 'u32',
     start: 'Option<u64>',
   },
   /**
-   * Lookup562: pallet_staking::EraRewardPoints<sp_core::crypto::AccountId32>
+   * Lookup559: pallet_staking::EraRewardPoints<sp_core::crypto::AccountId32>
    **/
   PalletStakingEraRewardPoints: {
     total: 'u32',
     individual: 'BTreeMap<AccountId32, u32>',
   },
   /**
-   * Lookup565: pallet_staking::Forcing
+   * Lookup562: pallet_staking::Forcing
    **/
   PalletStakingForcing: {
     _enum: ['NotForcing', 'ForceNew', 'ForceNone', 'ForceAlways'],
   },
   /**
-   * Lookup567: pallet_staking::UnappliedSlash<sp_core::crypto::AccountId32, Balance>
+   * Lookup564: pallet_staking::UnappliedSlash<sp_core::crypto::AccountId32, Balance>
    **/
   PalletStakingUnappliedSlash: {
     validator: 'AccountId32',
@@ -4200,7 +4213,7 @@ export default {
     payout: 'u128',
   },
   /**
-   * Lookup571: pallet_staking::slashing::SlashingSpans
+   * Lookup568: pallet_staking::slashing::SlashingSpans
    **/
   PalletStakingSlashingSlashingSpans: {
     spanIndex: 'u32',
@@ -4209,14 +4222,14 @@ export default {
     prior: 'Vec<u32>',
   },
   /**
-   * Lookup572: pallet_staking::slashing::SpanRecord<Balance>
+   * Lookup569: pallet_staking::slashing::SpanRecord<Balance>
    **/
   PalletStakingSlashingSpanRecord: {
     slashed: 'u128',
     paidOut: 'u128',
   },
   /**
-   * Lookup573: pallet_staking::ElectionResult<sp_core::crypto::AccountId32, Balance>
+   * Lookup572: pallet_staking::ElectionResult<sp_core::crypto::AccountId32, Balance>
    **/
   PalletStakingElectionResult: {
     electedStashes: 'Vec<AccountId32>',
@@ -4224,7 +4237,7 @@ export default {
     compute: 'PalletStakingElectionCompute',
   },
   /**
-   * Lookup574: pallet_staking::ElectionStatus<BlockNumber>
+   * Lookup573: pallet_staking::ElectionStatus<BlockNumber>
    **/
   PalletStakingElectionStatus: {
     _enum: {
@@ -4233,20 +4246,20 @@ export default {
     },
   },
   /**
-   * Lookup575: pallet_staking::PermissionedIdentityPrefs
+   * Lookup574: pallet_staking::PermissionedIdentityPrefs
    **/
   PalletStakingPermissionedIdentityPrefs: {
     intendedCount: 'u32',
     runningCount: 'u32',
   },
   /**
-   * Lookup576: pallet_staking::Releases
+   * Lookup575: pallet_staking::Releases
    **/
   PalletStakingReleases: {
     _enum: ['V1_0_0Ancient', 'V2_0_0', 'V3_0_0', 'V4_0_0', 'V5_0_0', 'V6_0_0', 'V6_0_1', 'V7_0_0'],
   },
   /**
-   * Lookup577: pallet_staking::Error<T>
+   * Lookup576: pallet_staking::Error<T>
    **/
   PalletStakingError: {
     _enum: [
@@ -4295,24 +4308,24 @@ export default {
     ],
   },
   /**
-   * Lookup578: sp_staking::offence::OffenceDetails<sp_core::crypto::AccountId32, Offender>
+   * Lookup577: sp_staking::offence::OffenceDetails<sp_core::crypto::AccountId32, Offender>
    **/
   SpStakingOffenceOffenceDetails: {
     offender: '(AccountId32,PalletStakingExposure)',
     reporters: 'Vec<AccountId32>',
   },
   /**
-   * Lookup583: sp_core::crypto::KeyTypeId
+   * Lookup582: sp_core::crypto::KeyTypeId
    **/
   SpCoreCryptoKeyTypeId: '[u8;4]',
   /**
-   * Lookup584: pallet_session::pallet::Error<T>
+   * Lookup583: pallet_session::pallet::Error<T>
    **/
   PalletSessionError: {
     _enum: ['InvalidProof', 'NoAssociatedValidatorId', 'DuplicatedKey', 'NoKeys', 'NoAccount'],
   },
   /**
-   * Lookup585: pallet_grandpa::StoredState<N>
+   * Lookup584: pallet_grandpa::StoredState<N>
    **/
   PalletGrandpaStoredState: {
     _enum: {
@@ -4329,7 +4342,7 @@ export default {
     },
   },
   /**
-   * Lookup586: pallet_grandpa::StoredPendingChange<N, Limit>
+   * Lookup585: pallet_grandpa::StoredPendingChange<N, Limit>
    **/
   PalletGrandpaStoredPendingChange: {
     scheduledAt: 'u32',
@@ -4338,7 +4351,7 @@ export default {
     forced: 'Option<u32>',
   },
   /**
-   * Lookup588: pallet_grandpa::pallet::Error<T>
+   * Lookup587: pallet_grandpa::pallet::Error<T>
    **/
   PalletGrandpaError: {
     _enum: [
@@ -4352,33 +4365,33 @@ export default {
     ],
   },
   /**
-   * Lookup592: pallet_im_online::BoundedOpaqueNetworkState<PeerIdEncodingLimit, MultiAddrEncodingLimit, AddressesLimit>
+   * Lookup591: pallet_im_online::BoundedOpaqueNetworkState<PeerIdEncodingLimit, MultiAddrEncodingLimit, AddressesLimit>
    **/
   PalletImOnlineBoundedOpaqueNetworkState: {
     peerId: 'Bytes',
     externalAddresses: 'Vec<Bytes>',
   },
   /**
-   * Lookup596: pallet_im_online::pallet::Error<T>
+   * Lookup595: pallet_im_online::pallet::Error<T>
    **/
   PalletImOnlineError: {
     _enum: ['InvalidKey', 'DuplicatedHeartbeat'],
   },
   /**
-   * Lookup598: pallet_sudo::Error<T>
+   * Lookup597: pallet_sudo::Error<T>
    **/
   PalletSudoError: {
     _enum: ['RequireSudo'],
   },
   /**
-   * Lookup599: pallet_asset::TickerRegistration<U>
+   * Lookup598: pallet_asset::TickerRegistration<U>
    **/
   PalletAssetTickerRegistration: {
     owner: 'PolymeshPrimitivesIdentityId',
     expiry: 'Option<u64>',
   },
   /**
-   * Lookup600: pallet_asset::SecurityToken
+   * Lookup599: pallet_asset::SecurityToken
    **/
   PalletAssetSecurityToken: {
     totalSupply: 'u128',
@@ -4387,27 +4400,24 @@ export default {
     assetType: 'PolymeshPrimitivesAssetAssetType',
   },
   /**
-   * Lookup604: pallet_asset::AssetOwnershipRelation
+   * Lookup603: pallet_asset::AssetOwnershipRelation
    **/
   PalletAssetAssetOwnershipRelation: {
     _enum: ['NotOwned', 'TickerOwned', 'AssetOwned'],
   },
   /**
-   * Lookup606: pallet_asset::ClassicTickerRegistration
+   * Lookup605: pallet_asset::ClassicTickerRegistration
    **/
   PalletAssetClassicTickerRegistration: {
     ethOwner: 'PolymeshPrimitivesEthereumEthereumAddress',
     isCreated: 'bool',
   },
   /**
-   * Lookup612: pallet_asset::Error<T>
+   * Lookup611: pallet_asset::Error<T>
    **/
   PalletAssetError: {
     _enum: [
       'Unauthorized',
-      'AlreadyArchived',
-      'AlreadyUnArchived',
-      'ExtensionAlreadyPresent',
       'AssetAlreadyCreated',
       'TickerTooLong',
       'TickerNotAscii',
@@ -4423,8 +4433,6 @@ export default {
       'InvalidTransfer',
       'InsufficientBalance',
       'AssetAlreadyDivisible',
-      'MaximumTMExtensionLimitReached',
-      'IncompatibleExtensionVersion',
       'InvalidEthereumSignature',
       'NoSuchClassicTicker',
       'TickerRegistrationExpired',
@@ -4445,7 +4453,7 @@ export default {
     ],
   },
   /**
-   * Lookup615: pallet_corporate_actions::distribution::Error<T>
+   * Lookup614: pallet_corporate_actions::distribution::Error<T>
    **/
   PalletCorporateActionsDistributionError: {
     _enum: [
@@ -4467,7 +4475,7 @@ export default {
     ],
   },
   /**
-   * Lookup622: pallet_asset::checkpoint::Error<T>
+   * Lookup621: pallet_asset::checkpoint::Error<T>
    **/
   PalletAssetCheckpointError: {
     _enum: [
@@ -4479,14 +4487,14 @@ export default {
     ],
   },
   /**
-   * Lookup623: polymesh_primitives::compliance_manager::AssetCompliance
+   * Lookup622: polymesh_primitives::compliance_manager::AssetCompliance
    **/
   PolymeshPrimitivesComplianceManagerAssetCompliance: {
     paused: 'bool',
     requirements: 'Vec<PolymeshPrimitivesComplianceManagerComplianceRequirement>',
   },
   /**
-   * Lookup625: pallet_compliance_manager::Error<T>
+   * Lookup624: pallet_compliance_manager::Error<T>
    **/
   PalletComplianceManagerError: {
     _enum: [
@@ -4499,7 +4507,7 @@ export default {
     ],
   },
   /**
-   * Lookup628: pallet_corporate_actions::Error<T>
+   * Lookup627: pallet_corporate_actions::Error<T>
    **/
   PalletCorporateActionsError: {
     _enum: [
@@ -4518,7 +4526,7 @@ export default {
     ],
   },
   /**
-   * Lookup630: pallet_corporate_actions::ballot::Error<T>
+   * Lookup629: pallet_corporate_actions::ballot::Error<T>
    **/
   PalletCorporateActionsBallotError: {
     _enum: [
@@ -4539,13 +4547,13 @@ export default {
     ],
   },
   /**
-   * Lookup631: pallet_permissions::Error<T>
+   * Lookup630: pallet_permissions::Error<T>
    **/
   PalletPermissionsError: {
     _enum: ['UnauthorizedCaller'],
   },
   /**
-   * Lookup632: pallet_pips::PipsMetadata<BlockNumber>
+   * Lookup631: pallet_pips::PipsMetadata<BlockNumber>
    **/
   PalletPipsPipsMetadata: {
     id: 'u32',
@@ -4556,23 +4564,22 @@ export default {
     expiry: 'PolymeshCommonUtilitiesMaybeBlock',
   },
   /**
-   * Lookup634: pallet_pips::DepositInfo<sp_core::crypto::AccountId32>
+   * Lookup633: pallet_pips::DepositInfo<sp_core::crypto::AccountId32>
    **/
   PalletPipsDepositInfo: {
     owner: 'AccountId32',
     amount: 'u128',
   },
   /**
-   * Lookup635: pallet_pips::Pip<polymesh_runtime_develop::runtime::Call, sp_core::crypto::AccountId32>
+   * Lookup634: pallet_pips::Pip<polymesh_runtime_develop::runtime::Call, sp_core::crypto::AccountId32>
    **/
   PalletPipsPip: {
     id: 'u32',
     proposal: 'Call',
-    state: 'PalletPipsProposalState',
     proposer: 'PalletPipsProposer',
   },
   /**
-   * Lookup636: pallet_pips::VotingResult
+   * Lookup635: pallet_pips::VotingResult
    **/
   PalletPipsVotingResult: {
     ayesCount: 'u32',
@@ -4581,11 +4588,11 @@ export default {
     naysStake: 'u128',
   },
   /**
-   * Lookup637: pallet_pips::Vote
+   * Lookup636: pallet_pips::Vote
    **/
   PalletPipsVote: '(bool,u128)',
   /**
-   * Lookup638: pallet_pips::SnapshotMetadata<BlockNumber, sp_core::crypto::AccountId32>
+   * Lookup637: pallet_pips::SnapshotMetadata<BlockNumber, sp_core::crypto::AccountId32>
    **/
   PalletPipsSnapshotMetadata: {
     createdAt: 'u32',
@@ -4593,7 +4600,7 @@ export default {
     id: 'u32',
   },
   /**
-   * Lookup640: pallet_pips::Error<T>
+   * Lookup639: pallet_pips::Error<T>
    **/
   PalletPipsError: {
     _enum: [
@@ -4618,7 +4625,7 @@ export default {
     ],
   },
   /**
-   * Lookup646: pallet_portfolio::Error<T>
+   * Lookup645: pallet_portfolio::Error<T>
    **/
   PalletPortfolioError: {
     _enum: [
@@ -4634,13 +4641,13 @@ export default {
     ],
   },
   /**
-   * Lookup647: pallet_protocol_fee::Error<T>
+   * Lookup646: pallet_protocol_fee::Error<T>
    **/
   PalletProtocolFeeError: {
     _enum: ['InsufficientAccountBalance', 'UnHandledImbalances', 'InsufficientSubsidyBalance'],
   },
   /**
-   * Lookup650: pallet_scheduler::ScheduledV3<frame_support::traits::schedule::MaybeHashed<polymesh_runtime_develop::runtime::Call, primitive_types::H256>, BlockNumber, polymesh_runtime_develop::runtime::OriginCaller, sp_core::crypto::AccountId32>
+   * Lookup649: pallet_scheduler::ScheduledV3<frame_support::traits::schedule::MaybeHashed<polymesh_runtime_develop::runtime::Call, primitive_types::H256>, BlockNumber, polymesh_runtime_develop::runtime::OriginCaller, sp_core::crypto::AccountId32>
    **/
   PalletSchedulerScheduledV3: {
     maybeId: 'Option<Bytes>',
@@ -4650,7 +4657,7 @@ export default {
     origin: 'PolymeshRuntimeDevelopRuntimeOriginCaller',
   },
   /**
-   * Lookup651: polymesh_runtime_develop::runtime::OriginCaller
+   * Lookup650: polymesh_runtime_develop::runtime::OriginCaller
    **/
   PolymeshRuntimeDevelopRuntimeOriginCaller: {
     _enum: {
@@ -4671,7 +4678,7 @@ export default {
     },
   },
   /**
-   * Lookup652: frame_support::dispatch::RawOrigin<sp_core::crypto::AccountId32>
+   * Lookup651: frame_support::dispatch::RawOrigin<sp_core::crypto::AccountId32>
    **/
   FrameSupportDispatchRawOrigin: {
     _enum: {
@@ -4681,42 +4688,42 @@ export default {
     },
   },
   /**
-   * Lookup653: pallet_committee::RawOrigin<sp_core::crypto::AccountId32, pallet_committee::Instance1>
+   * Lookup652: pallet_committee::RawOrigin<sp_core::crypto::AccountId32, pallet_committee::Instance1>
    **/
   PalletCommitteeRawOriginInstance1: {
     _enum: ['Endorsed'],
   },
   /**
-   * Lookup654: pallet_committee::RawOrigin<sp_core::crypto::AccountId32, pallet_committee::Instance3>
+   * Lookup653: pallet_committee::RawOrigin<sp_core::crypto::AccountId32, pallet_committee::Instance3>
    **/
   PalletCommitteeRawOriginInstance3: {
     _enum: ['Endorsed'],
   },
   /**
-   * Lookup655: pallet_committee::RawOrigin<sp_core::crypto::AccountId32, pallet_committee::Instance4>
+   * Lookup654: pallet_committee::RawOrigin<sp_core::crypto::AccountId32, pallet_committee::Instance4>
    **/
   PalletCommitteeRawOriginInstance4: {
     _enum: ['Endorsed'],
   },
   /**
-   * Lookup656: sp_core::Void
+   * Lookup655: sp_core::Void
    **/
   SpCoreVoid: 'Null',
   /**
-   * Lookup657: pallet_scheduler::pallet::Error<T>
+   * Lookup656: pallet_scheduler::pallet::Error<T>
    **/
   PalletSchedulerError: {
     _enum: ['FailedToSchedule', 'NotFound', 'TargetBlockNumberInPast', 'RescheduleNoChange'],
   },
   /**
-   * Lookup658: pallet_settlement::Venue
+   * Lookup657: pallet_settlement::Venue
    **/
   PalletSettlementVenue: {
     creator: 'PolymeshPrimitivesIdentityId',
     venueType: 'PalletSettlementVenueType',
   },
   /**
-   * Lookup661: pallet_settlement::Instruction<Moment, BlockNumber>
+   * Lookup660: pallet_settlement::Instruction<Moment, BlockNumber>
    **/
   PalletSettlementInstruction: {
     instructionId: 'u64',
@@ -4728,13 +4735,13 @@ export default {
     valueDate: 'Option<u64>',
   },
   /**
-   * Lookup662: pallet_settlement::InstructionStatus
+   * Lookup661: pallet_settlement::InstructionStatus
    **/
   PalletSettlementInstructionStatus: {
     _enum: ['Unknown', 'Pending', 'Failed'],
   },
   /**
-   * Lookup664: pallet_settlement::LegStatus<sp_core::crypto::AccountId32>
+   * Lookup663: pallet_settlement::LegStatus<sp_core::crypto::AccountId32>
    **/
   PalletSettlementLegStatus: {
     _enum: {
@@ -4744,13 +4751,13 @@ export default {
     },
   },
   /**
-   * Lookup666: pallet_settlement::AffirmationStatus
+   * Lookup665: pallet_settlement::AffirmationStatus
    **/
   PalletSettlementAffirmationStatus: {
     _enum: ['Unknown', 'Pending', 'Affirmed'],
   },
   /**
-   * Lookup670: pallet_settlement::Error<T>
+   * Lookup669: pallet_settlement::Error<T>
    **/
   PalletSettlementError: {
     _enum: [
@@ -4779,24 +4786,27 @@ export default {
       'LegCountTooSmall',
       'UnknownInstruction',
       'InstructionHasTooManyLegs',
+      'SignerAlreadyExists',
+      'SignerDoesNotExist',
+      'ZeroAmount',
     ],
   },
   /**
-   * Lookup672: polymesh_primitives::statistics::Stat1stKey
+   * Lookup671: polymesh_primitives::statistics::Stat1stKey
    **/
   PolymeshPrimitivesStatisticsStat1stKey: {
     asset: 'PolymeshPrimitivesStatisticsAssetScope',
     statType: 'PolymeshPrimitivesStatisticsStatType',
   },
   /**
-   * Lookup673: polymesh_primitives::transfer_compliance::AssetTransferCompliance
+   * Lookup672: polymesh_primitives::transfer_compliance::AssetTransferCompliance
    **/
   PolymeshPrimitivesTransferComplianceAssetTransferCompliance: {
     paused: 'bool',
     requirements: 'BTreeSet<PolymeshPrimitivesTransferComplianceTransferCondition>',
   },
   /**
-   * Lookup676: pallet_statistics::Error<T>
+   * Lookup675: pallet_statistics::Error<T>
    **/
   PalletStatisticsError: {
     _enum: [
@@ -4809,7 +4819,7 @@ export default {
     ],
   },
   /**
-   * Lookup678: pallet_sto::Error<T>
+   * Lookup677: pallet_sto::Error<T>
    **/
   PalletStoError: {
     _enum: [
@@ -4828,25 +4838,25 @@ export default {
     ],
   },
   /**
-   * Lookup679: pallet_treasury::Error<T>
+   * Lookup678: pallet_treasury::Error<T>
    **/
   PalletTreasuryError: {
     _enum: ['InsufficientBalance', 'InvalidIdentity'],
   },
   /**
-   * Lookup680: pallet_utility::Error<T>
+   * Lookup679: pallet_utility::Error<T>
    **/
   PalletUtilityError: {
     _enum: ['InvalidSignature', 'TargetCddMissing', 'InvalidNonce'],
   },
   /**
-   * Lookup681: pallet_base::Error<T>
+   * Lookup680: pallet_base::Error<T>
    **/
   PalletBaseError: {
     _enum: ['TooLong', 'CounterOverflow'],
   },
   /**
-   * Lookup683: pallet_external_agents::Error<T>
+   * Lookup682: pallet_external_agents::Error<T>
    **/
   PalletExternalAgentsError: {
     _enum: [
@@ -4859,14 +4869,14 @@ export default {
     ],
   },
   /**
-   * Lookup684: pallet_relayer::Subsidy<sp_core::crypto::AccountId32>
+   * Lookup683: pallet_relayer::Subsidy<sp_core::crypto::AccountId32>
    **/
   PalletRelayerSubsidy: {
     payingKey: 'AccountId32',
     remaining: 'u128',
   },
   /**
-   * Lookup685: pallet_relayer::Error<T>
+   * Lookup684: pallet_relayer::Error<T>
    **/
   PalletRelayerError: {
     _enum: [
@@ -4880,7 +4890,7 @@ export default {
     ],
   },
   /**
-   * Lookup686: pallet_rewards::Error<T>
+   * Lookup685: pallet_rewards::Error<T>
    **/
   PalletRewardsError: {
     _enum: [
@@ -4891,7 +4901,7 @@ export default {
     ],
   },
   /**
-   * Lookup687: pallet_contracts::wasm::PrefabWasmModule<T>
+   * Lookup686: pallet_contracts::wasm::PrefabWasmModule<T>
    **/
   PalletContractsWasmPrefabWasmModule: {
     instructionWeightsVersion: 'Compact<u32>',
@@ -4900,7 +4910,7 @@ export default {
     code: 'Bytes',
   },
   /**
-   * Lookup688: pallet_contracts::wasm::OwnerInfo<T>
+   * Lookup687: pallet_contracts::wasm::OwnerInfo<T>
    **/
   PalletContractsWasmOwnerInfo: {
     owner: 'AccountId32',
@@ -4908,7 +4918,7 @@ export default {
     refcount: 'Compact<u64>',
   },
   /**
-   * Lookup689: pallet_contracts::storage::RawContractInfo<primitive_types::H256, Balance>
+   * Lookup688: pallet_contracts::storage::RawContractInfo<primitive_types::H256, Balance>
    **/
   PalletContractsStorageRawContractInfo: {
     trieId: 'Bytes',
@@ -4916,13 +4926,13 @@ export default {
     storageDeposit: 'u128',
   },
   /**
-   * Lookup691: pallet_contracts::storage::DeletedContract
+   * Lookup690: pallet_contracts::storage::DeletedContract
    **/
   PalletContractsStorageDeletedContract: {
     trieId: 'Bytes',
   },
   /**
-   * Lookup692: pallet_contracts::schedule::Schedule<T>
+   * Lookup691: pallet_contracts::schedule::Schedule<T>
    **/
   PalletContractsSchedule: {
     limits: 'PalletContractsScheduleLimits',
@@ -4930,7 +4940,7 @@ export default {
     hostFnWeights: 'PalletContractsScheduleHostFnWeights',
   },
   /**
-   * Lookup693: pallet_contracts::schedule::Limits
+   * Lookup692: pallet_contracts::schedule::Limits
    **/
   PalletContractsScheduleLimits: {
     eventTopics: 'u32',
@@ -4946,7 +4956,7 @@ export default {
     codeLen: 'u32',
   },
   /**
-   * Lookup694: pallet_contracts::schedule::InstructionWeights<T>
+   * Lookup693: pallet_contracts::schedule::InstructionWeights<T>
    **/
   PalletContractsScheduleInstructionWeights: {
     _alias: {
@@ -5006,7 +5016,7 @@ export default {
     i64rotr: 'u32',
   },
   /**
-   * Lookup695: pallet_contracts::schedule::HostFnWeights<T>
+   * Lookup694: pallet_contracts::schedule::HostFnWeights<T>
    **/
   PalletContractsScheduleHostFnWeights: {
     _alias: {
@@ -5068,7 +5078,7 @@ export default {
     ecdsaToEthAddress: 'u64',
   },
   /**
-   * Lookup696: pallet_contracts::pallet::Error<T>
+   * Lookup695: pallet_contracts::pallet::Error<T>
    **/
   PalletContractsError: {
     _enum: [
@@ -5104,7 +5114,7 @@ export default {
     ],
   },
   /**
-   * Lookup697: polymesh_contracts::Error<T>
+   * Lookup696: polymesh_contracts::Error<T>
    **/
   PolymeshContractsError: {
     _enum: [
@@ -5115,7 +5125,7 @@ export default {
     ],
   },
   /**
-   * Lookup698: pallet_preimage::RequestStatus<sp_core::crypto::AccountId32, Balance>
+   * Lookup697: pallet_preimage::RequestStatus<sp_core::crypto::AccountId32, Balance>
    **/
   PalletPreimageRequestStatus: {
     _enum: {
@@ -5124,49 +5134,49 @@ export default {
     },
   },
   /**
-   * Lookup701: pallet_preimage::pallet::Error<T>
+   * Lookup700: pallet_preimage::pallet::Error<T>
    **/
   PalletPreimageError: {
     _enum: ['TooLarge', 'AlreadyNoted', 'NotAuthorized', 'NotNoted', 'Requested', 'NotRequested'],
   },
   /**
-   * Lookup702: pallet_test_utils::Error<T>
+   * Lookup701: pallet_test_utils::Error<T>
    **/
   PalletTestUtilsError: 'Null',
   /**
-   * Lookup705: frame_system::extensions::check_spec_version::CheckSpecVersion<T>
+   * Lookup704: frame_system::extensions::check_spec_version::CheckSpecVersion<T>
    **/
   FrameSystemExtensionsCheckSpecVersion: 'Null',
   /**
-   * Lookup706: frame_system::extensions::check_tx_version::CheckTxVersion<T>
+   * Lookup705: frame_system::extensions::check_tx_version::CheckTxVersion<T>
    **/
   FrameSystemExtensionsCheckTxVersion: 'Null',
   /**
-   * Lookup707: frame_system::extensions::check_genesis::CheckGenesis<T>
+   * Lookup706: frame_system::extensions::check_genesis::CheckGenesis<T>
    **/
   FrameSystemExtensionsCheckGenesis: 'Null',
   /**
-   * Lookup710: frame_system::extensions::check_nonce::CheckNonce<T>
+   * Lookup709: frame_system::extensions::check_nonce::CheckNonce<T>
    **/
   FrameSystemExtensionsCheckNonce: 'Compact<u32>',
   /**
-   * Lookup711: polymesh_extensions::check_weight::CheckWeight<T>
+   * Lookup710: polymesh_extensions::check_weight::CheckWeight<T>
    **/
   PolymeshExtensionsCheckWeight: 'FrameSystemExtensionsCheckWeight',
   /**
-   * Lookup712: frame_system::extensions::check_weight::CheckWeight<T>
+   * Lookup711: frame_system::extensions::check_weight::CheckWeight<T>
    **/
   FrameSystemExtensionsCheckWeight: 'Null',
   /**
-   * Lookup713: pallet_transaction_payment::ChargeTransactionPayment<T>
+   * Lookup712: pallet_transaction_payment::ChargeTransactionPayment<T>
    **/
   PalletTransactionPaymentChargeTransactionPayment: 'Compact<u128>',
   /**
-   * Lookup714: pallet_permissions::StoreCallMetadata<T>
+   * Lookup713: pallet_permissions::StoreCallMetadata<T>
    **/
   PalletPermissionsStoreCallMetadata: 'Null',
   /**
-   * Lookup715: polymesh_runtime_develop::runtime::Runtime
+   * Lookup714: polymesh_runtime_develop::runtime::Runtime
    **/
   PolymeshRuntimeDevelopRuntime: 'Null',
 };

--- a/src/polkadot/polymesh/definitions.ts
+++ b/src/polkadot/polymesh/definitions.ts
@@ -61,6 +61,7 @@ export default {
         CINS: '[u8; 9]',
         ISIN: '[u8; 12]',
         LEI: '[u8; 20]',
+        FIGI: '[u8; 12]',
       },
     },
     AssetOwnershipRelation: {
@@ -456,11 +457,7 @@ export default {
         Custom: 'Vec<u8>',
       },
     },
-    InvestorZKProofData: {
-      r: 'CompressedRistretto',
-      s: 'Scalar',
-    },
-    CompressedRistretto: '[u8; 32]',
+    InvestorZKProofData: '[u8; 64]',
     Scalar: '[u8; 32]',
     RistrettoPoint: '[u8; 32]',
     ZkProofData: {
@@ -487,6 +484,7 @@ export default {
         InvestorUniqueness: '(Scope, ScopeId, CddId)',
         NoData: '',
         InvestorUniquenessV2: '(CddId)',
+        Custom: '(u32, Option<Scope>)',
       },
     },
     ClaimType: {
@@ -503,6 +501,7 @@ export default {
         InvestorUniqueness: '',
         NoData: '',
         InvestorUniquenessV2: '',
+        Custom: '',
       },
     },
     IdentityClaim: {
@@ -692,37 +691,6 @@ export default {
         AddRelayerPayingKey: '(AccountId, AccountId, Balance)',
         RotatePrimaryKeyToSecondary: 'Permissions',
       },
-    },
-    SmartExtensionType: {
-      _enum: {
-        TransferManager: '',
-        Offerings: '',
-        SmartWallet: '',
-        Custom: 'Vec<u8>',
-      },
-    },
-    SmartExtensionName: 'Text',
-    SmartExtension: {
-      extension_type: 'SmartExtensionType',
-      extension_name: 'SmartExtensionName',
-      extension_id: 'AccountId',
-      is_archive: 'bool',
-    },
-    MetaUrl: 'Text',
-    MetaDescription: 'Text',
-    MetaVersion: 'u32',
-    ExtVersion: 'u32',
-    TemplateMetadata: {
-      url: 'Option<MetaUrl>',
-      se_type: 'SmartExtensionType',
-      usage_fee: 'Balance',
-      description: 'MetaDescription',
-      version: 'MetaVersion',
-    },
-    TemplateDetails: {
-      instantiation_fee: 'Balance',
-      owner: 'IdentityId',
-      frozen: 'bool',
     },
     AuthorizationNonce: 'u64',
     Percentage: 'Permill',
@@ -1087,10 +1055,6 @@ export default {
     VenueType: {
       _enum: ['Other', 'Distribution', 'Sto', 'Exchange'],
     },
-    ExtensionAttributes: {
-      usage_fee: 'Balance',
-      version: 'MetaVersion',
-    },
     Tax: 'Permill',
     TargetIdentities: {
       identities: 'Vec<IdentityId>',
@@ -1133,6 +1097,16 @@ export default {
       targets: 'TargetIdentities',
       default_withholding_tax: 'Tax',
       withholding_tax: 'Vec<(IdentityId, Tax)>',
+    },
+    InitiateCorporateActionArgs: {
+      ticker: 'Ticker',
+      kind: 'CAKind',
+      decl_date: 'Moment',
+      record_date: 'Option<RecordDateSpec>',
+      details: 'CADetails',
+      targets: 'Option<TargetIdentities>',
+      default_withholding_tax: 'Option<Tax>',
+      withholding_tax: 'Option<Vec<(IdentityId, Tax)>>',
     },
     LocalCAId: 'u32',
     CAId: {

--- a/src/polkadot/polymesh/types.ts
+++ b/src/polkadot/polymesh/types.ts
@@ -94,7 +94,9 @@ export interface AssetIdentifier extends Enum {
   readonly asIsin: U8aFixed;
   readonly isLei: boolean;
   readonly asLei: U8aFixed;
-  readonly type: 'Cusip' | 'Cins' | 'Isin' | 'Lei';
+  readonly isFigi: boolean;
+  readonly asFigi: U8aFixed;
+  readonly type: 'Cusip' | 'Cins' | 'Isin' | 'Lei' | 'Figi';
 }
 
 /** @name AssetMetadataDescription */
@@ -441,6 +443,8 @@ export interface Claim extends Enum {
   readonly isNoData: boolean;
   readonly isInvestorUniquenessV2: boolean;
   readonly asInvestorUniquenessV2: CddId;
+  readonly isCustom: boolean;
+  readonly asCustom: ITuple<[u32, Option<Scope>]>;
   readonly type:
     | 'Accredited'
     | 'Affiliate'
@@ -453,7 +457,8 @@ export interface Claim extends Enum {
     | 'Blocked'
     | 'InvestorUniqueness'
     | 'NoData'
-    | 'InvestorUniquenessV2';
+    | 'InvestorUniquenessV2'
+    | 'Custom';
 }
 
 /** @name Claim1stKey */
@@ -482,6 +487,7 @@ export interface ClaimType extends Enum {
   readonly isInvestorUniqueness: boolean;
   readonly isNoData: boolean;
   readonly isInvestorUniquenessV2: boolean;
+  readonly isCustom: boolean;
   readonly type:
     | 'Accredited'
     | 'Affiliate'
@@ -494,7 +500,8 @@ export interface ClaimType extends Enum {
     | 'Blocked'
     | 'InvestorUniqueness'
     | 'NoData'
-    | 'InvestorUniquenessV2';
+    | 'InvestorUniquenessV2'
+    | 'Custom';
 }
 
 /** @name ClassicTickerImport */
@@ -532,9 +539,6 @@ export interface ComplianceRequirementResult extends Struct {
   readonly id: u32;
   readonly result: bool;
 }
-
-/** @name CompressedRistretto */
-export interface CompressedRistretto extends U8aFixed {}
 
 /** @name Condition */
 export interface Condition extends Struct {
@@ -1183,12 +1187,6 @@ export interface EventCounts extends Vec<u32> {}
 /** @name EventDid */
 export interface EventDid extends IdentityId {}
 
-/** @name ExtensionAttributes */
-export interface ExtensionAttributes extends Struct {
-  readonly usage_fee: Balance;
-  readonly version: MetaVersion;
-}
-
 /** @name ExtrinsicPermissions */
 export interface ExtrinsicPermissions extends Enum {
   readonly isWhole: boolean;
@@ -1198,9 +1196,6 @@ export interface ExtrinsicPermissions extends Enum {
   readonly asExcept: Vec<PalletPermissions>;
   readonly type: 'Whole' | 'These' | 'Except';
 }
-
-/** @name ExtVersion */
-export interface ExtVersion extends u32 {}
 
 /** @name FundingRoundName */
 export interface FundingRoundName extends Text {}
@@ -1311,6 +1306,18 @@ export interface InactiveMember extends Struct {
   readonly expiry: Option<Moment>;
 }
 
+/** @name InitiateCorporateActionArgs */
+export interface InitiateCorporateActionArgs extends Struct {
+  readonly ticker: Ticker;
+  readonly kind: CAKind;
+  readonly decl_date: Moment;
+  readonly record_date: Option<RecordDateSpec>;
+  readonly details: CADetails;
+  readonly targets: Option<TargetIdentities>;
+  readonly default_withholding_tax: Option<Tax>;
+  readonly withholding_tax: Option<Vec<ITuple<[IdentityId, Tax]>>>;
+}
+
 /** @name Instruction */
 export interface Instruction extends Struct {
   readonly instruction_id: InstructionId;
@@ -1337,10 +1344,7 @@ export interface InstructionStatus extends Enum {
 export interface InvestorUid extends U8aFixed {}
 
 /** @name InvestorZKProofData */
-export interface InvestorZKProofData extends Struct {
-  readonly r: CompressedRistretto;
-  readonly s: Scalar;
-}
+export interface InvestorZKProofData extends U8aFixed {}
 
 /** @name ItnRewardStatus */
 export interface ItnRewardStatus extends Enum {
@@ -1403,15 +1407,6 @@ export interface MaybeBlock extends Enum {
 
 /** @name Memo */
 export interface Memo extends U8aFixed {}
-
-/** @name MetaDescription */
-export interface MetaDescription extends Text {}
-
-/** @name MetaUrl */
-export interface MetaUrl extends Text {}
-
-/** @name MetaVersion */
-export interface MetaVersion extends u32 {}
 
 /** @name Moment */
 export interface Moment extends u64 {}
@@ -1780,27 +1775,6 @@ export interface SlashingSwitch extends Enum {
   readonly type: 'Validator' | 'ValidatorAndNominator' | 'None';
 }
 
-/** @name SmartExtension */
-export interface SmartExtension extends Struct {
-  readonly extension_type: SmartExtensionType;
-  readonly extension_name: SmartExtensionName;
-  readonly extension_id: AccountId;
-  readonly is_archive: bool;
-}
-
-/** @name SmartExtensionName */
-export interface SmartExtensionName extends Text {}
-
-/** @name SmartExtensionType */
-export interface SmartExtensionType extends Enum {
-  readonly isTransferManager: boolean;
-  readonly isOfferings: boolean;
-  readonly isSmartWallet: boolean;
-  readonly isCustom: boolean;
-  readonly asCustom: Bytes;
-  readonly type: 'TransferManager' | 'Offerings' | 'SmartWallet' | 'Custom';
-}
-
 /** @name SnapshotId */
 export interface SnapshotId extends u32 {}
 
@@ -1913,22 +1887,6 @@ export interface TargetTreatment extends Enum {
 
 /** @name Tax */
 export interface Tax extends Permill {}
-
-/** @name TemplateDetails */
-export interface TemplateDetails extends Struct {
-  readonly instantiation_fee: Balance;
-  readonly owner: IdentityId;
-  readonly frozen: bool;
-}
-
-/** @name TemplateMetadata */
-export interface TemplateMetadata extends Struct {
-  readonly url: Option<MetaUrl>;
-  readonly se_type: SmartExtensionType;
-  readonly usage_fee: Balance;
-  readonly description: MetaDescription;
-  readonly version: MetaVersion;
-}
 
 /** @name Ticker */
 export interface Ticker extends U8aFixed {}

--- a/src/polkadot/registry.ts
+++ b/src/polkadot/registry.ts
@@ -2,14 +2,9 @@
 /* eslint-disable */
 
 import type {
-  ConfidentialIdentityClaimProofsScopeClaimProof,
-  ConfidentialIdentityClaimProofsZkProofData,
-  ConfidentialIdentitySignSignature,
-  Curve25519DalekBackendSerialU64FieldFieldElement51,
-  Curve25519DalekEdwardsEdwardsPoint,
-  Curve25519DalekRistrettoCompressedRistretto,
-  Curve25519DalekRistrettoRistrettoPoint,
-  Curve25519DalekScalar,
+  ConfidentialIdentityV2ClaimProofsScopeClaimProof,
+  ConfidentialIdentityV2ClaimProofsZkProofData,
+  ConfidentialIdentityV2SignSignature,
   FinalityGrandpaEquivocationPrecommit,
   FinalityGrandpaEquivocationPrevote,
   FinalityGrandpaPrecommit,
@@ -84,6 +79,7 @@ import type {
   PalletComplianceManagerCall,
   PalletComplianceManagerError,
   PalletComplianceManagerEvent,
+  PalletContractsCall,
   PalletContractsError,
   PalletContractsEvent,
   PalletContractsSchedule,
@@ -195,6 +191,7 @@ import type {
   PalletSettlementCall,
   PalletSettlementError,
   PalletSettlementInstruction,
+  PalletSettlementInstructionMemo,
   PalletSettlementInstructionStatus,
   PalletSettlementLeg,
   PalletSettlementLegStatus,
@@ -313,7 +310,6 @@ import type {
   PolymeshPrimitivesIdentityId,
   PolymeshPrimitivesIdentityIdPortfolioId,
   PolymeshPrimitivesIdentityIdPortfolioKind,
-  PolymeshPrimitivesInvestorZkproofDataV1InvestorZKProofData,
   PolymeshPrimitivesJurisdictionCountryCode,
   PolymeshPrimitivesPosRatio,
   PolymeshPrimitivesSecondaryKey,
@@ -340,7 +336,6 @@ import type {
   PolymeshRuntimeDevelopRuntime,
   PolymeshRuntimeDevelopRuntimeOriginCaller,
   PolymeshRuntimeDevelopRuntimeSessionKeys,
-  SchnorrkelSignSignature,
   SpAuthorityDiscoveryAppPublic,
   SpConsensusBabeAllowedSlots,
   SpConsensusBabeAppPublic,
@@ -377,14 +372,9 @@ import type {
 
 declare module '@polkadot/types/types/registry' {
   export interface InterfaceTypes {
-    ConfidentialIdentityClaimProofsScopeClaimProof: ConfidentialIdentityClaimProofsScopeClaimProof;
-    ConfidentialIdentityClaimProofsZkProofData: ConfidentialIdentityClaimProofsZkProofData;
-    ConfidentialIdentitySignSignature: ConfidentialIdentitySignSignature;
-    Curve25519DalekBackendSerialU64FieldFieldElement51: Curve25519DalekBackendSerialU64FieldFieldElement51;
-    Curve25519DalekEdwardsEdwardsPoint: Curve25519DalekEdwardsEdwardsPoint;
-    Curve25519DalekRistrettoCompressedRistretto: Curve25519DalekRistrettoCompressedRistretto;
-    Curve25519DalekRistrettoRistrettoPoint: Curve25519DalekRistrettoRistrettoPoint;
-    Curve25519DalekScalar: Curve25519DalekScalar;
+    ConfidentialIdentityV2ClaimProofsScopeClaimProof: ConfidentialIdentityV2ClaimProofsScopeClaimProof;
+    ConfidentialIdentityV2ClaimProofsZkProofData: ConfidentialIdentityV2ClaimProofsZkProofData;
+    ConfidentialIdentityV2SignSignature: ConfidentialIdentityV2SignSignature;
     FinalityGrandpaEquivocationPrecommit: FinalityGrandpaEquivocationPrecommit;
     FinalityGrandpaEquivocationPrevote: FinalityGrandpaEquivocationPrevote;
     FinalityGrandpaPrecommit: FinalityGrandpaPrecommit;
@@ -459,6 +449,7 @@ declare module '@polkadot/types/types/registry' {
     PalletComplianceManagerCall: PalletComplianceManagerCall;
     PalletComplianceManagerError: PalletComplianceManagerError;
     PalletComplianceManagerEvent: PalletComplianceManagerEvent;
+    PalletContractsCall: PalletContractsCall;
     PalletContractsError: PalletContractsError;
     PalletContractsEvent: PalletContractsEvent;
     PalletContractsSchedule: PalletContractsSchedule;
@@ -570,6 +561,7 @@ declare module '@polkadot/types/types/registry' {
     PalletSettlementCall: PalletSettlementCall;
     PalletSettlementError: PalletSettlementError;
     PalletSettlementInstruction: PalletSettlementInstruction;
+    PalletSettlementInstructionMemo: PalletSettlementInstructionMemo;
     PalletSettlementInstructionStatus: PalletSettlementInstructionStatus;
     PalletSettlementLeg: PalletSettlementLeg;
     PalletSettlementLegStatus: PalletSettlementLegStatus;
@@ -688,7 +680,6 @@ declare module '@polkadot/types/types/registry' {
     PolymeshPrimitivesIdentityId: PolymeshPrimitivesIdentityId;
     PolymeshPrimitivesIdentityIdPortfolioId: PolymeshPrimitivesIdentityIdPortfolioId;
     PolymeshPrimitivesIdentityIdPortfolioKind: PolymeshPrimitivesIdentityIdPortfolioKind;
-    PolymeshPrimitivesInvestorZkproofDataV1InvestorZKProofData: PolymeshPrimitivesInvestorZkproofDataV1InvestorZKProofData;
     PolymeshPrimitivesJurisdictionCountryCode: PolymeshPrimitivesJurisdictionCountryCode;
     PolymeshPrimitivesPosRatio: PolymeshPrimitivesPosRatio;
     PolymeshPrimitivesSecondaryKey: PolymeshPrimitivesSecondaryKey;
@@ -715,7 +706,6 @@ declare module '@polkadot/types/types/registry' {
     PolymeshRuntimeDevelopRuntime: PolymeshRuntimeDevelopRuntime;
     PolymeshRuntimeDevelopRuntimeOriginCaller: PolymeshRuntimeDevelopRuntimeOriginCaller;
     PolymeshRuntimeDevelopRuntimeSessionKeys: PolymeshRuntimeDevelopRuntimeSessionKeys;
-    SchnorrkelSignSignature: SchnorrkelSignSignature;
     SpAuthorityDiscoveryAppPublic: SpAuthorityDiscoveryAppPublic;
     SpConsensusBabeAllowedSlots: SpConsensusBabeAllowedSlots;
     SpConsensusBabeAppPublic: SpConsensusBabeAppPublic;

--- a/src/polkadot/schema.ts
+++ b/src/polkadot/schema.ts
@@ -60,6 +60,7 @@ export default {
         CINS: '[u8; 9]',
         ISIN: '[u8; 12]',
         LEI: '[u8; 20]',
+        FIGI: '[u8; 12]',
       },
     },
     AssetOwnershipRelation: {
@@ -455,11 +456,7 @@ export default {
         Custom: 'Vec<u8>',
       },
     },
-    InvestorZKProofData: {
-      r: 'CompressedRistretto',
-      s: 'Scalar',
-    },
-    CompressedRistretto: '[u8; 32]',
+    InvestorZKProofData: '[u8; 64]',
     Scalar: '[u8; 32]',
     RistrettoPoint: '[u8; 32]',
     ZkProofData: {
@@ -486,6 +483,7 @@ export default {
         InvestorUniqueness: '(Scope, ScopeId, CddId)',
         NoData: '',
         InvestorUniquenessV2: '(CddId)',
+        Custom: '(u32, Option<Scope>)',
       },
     },
     ClaimType: {
@@ -502,6 +500,7 @@ export default {
         InvestorUniqueness: '',
         NoData: '',
         InvestorUniquenessV2: '',
+        Custom: '',
       },
     },
     IdentityClaim: {
@@ -691,37 +690,6 @@ export default {
         AddRelayerPayingKey: '(AccountId, AccountId, Balance)',
         RotatePrimaryKeyToSecondary: 'Permissions',
       },
-    },
-    SmartExtensionType: {
-      _enum: {
-        TransferManager: '',
-        Offerings: '',
-        SmartWallet: '',
-        Custom: 'Vec<u8>',
-      },
-    },
-    SmartExtensionName: 'Text',
-    SmartExtension: {
-      extension_type: 'SmartExtensionType',
-      extension_name: 'SmartExtensionName',
-      extension_id: 'AccountId',
-      is_archive: 'bool',
-    },
-    MetaUrl: 'Text',
-    MetaDescription: 'Text',
-    MetaVersion: 'u32',
-    ExtVersion: 'u32',
-    TemplateMetadata: {
-      url: 'Option<MetaUrl>',
-      se_type: 'SmartExtensionType',
-      usage_fee: 'Balance',
-      description: 'MetaDescription',
-      version: 'MetaVersion',
-    },
-    TemplateDetails: {
-      instantiation_fee: 'Balance',
-      owner: 'IdentityId',
-      frozen: 'bool',
     },
     AuthorizationNonce: 'u64',
     Percentage: 'Permill',
@@ -1086,10 +1054,6 @@ export default {
     VenueType: {
       _enum: ['Other', 'Distribution', 'Sto', 'Exchange'],
     },
-    ExtensionAttributes: {
-      usage_fee: 'Balance',
-      version: 'MetaVersion',
-    },
     Tax: 'Permill',
     TargetIdentities: {
       identities: 'Vec<IdentityId>',
@@ -1132,6 +1096,16 @@ export default {
       targets: 'TargetIdentities',
       default_withholding_tax: 'Tax',
       withholding_tax: 'Vec<(IdentityId, Tax)>',
+    },
+    InitiateCorporateActionArgs: {
+      ticker: 'Ticker',
+      kind: 'CAKind',
+      decl_date: 'Moment',
+      record_date: 'Option<RecordDateSpec>',
+      details: 'CADetails',
+      targets: 'Option<TargetIdentities>',
+      default_withholding_tax: 'Option<Tax>',
+      withholding_tax: 'Option<Vec<(IdentityId, Tax)>>',
     },
     LocalCAId: 'u32',
     CAId: {

--- a/src/polkadot/types-lookup.ts
+++ b/src/polkadot/types-lookup.ts
@@ -336,6 +336,10 @@ declare module '@polkadot/types/lookup' {
     readonly asAuthorizationConsumed: ITuple<
       [Option<PolymeshPrimitivesIdentityId>, Option<AccountId32>, u64]
     >;
+    readonly isAuthorizationRetryLimitReached: boolean;
+    readonly asAuthorizationRetryLimitReached: ITuple<
+      [Option<PolymeshPrimitivesIdentityId>, Option<AccountId32>, u64]
+    >;
     readonly isCddRequirementForPrimaryKeyUpdated: boolean;
     readonly asCddRequirementForPrimaryKeyUpdated: bool;
     readonly isCddClaimsInvalidated: boolean;
@@ -344,6 +348,8 @@ declare module '@polkadot/types/lookup' {
     readonly asSecondaryKeysFrozen: PolymeshPrimitivesIdentityId;
     readonly isSecondaryKeysUnfrozen: boolean;
     readonly asSecondaryKeysUnfrozen: PolymeshPrimitivesIdentityId;
+    readonly isCustomClaimTypeAdded: boolean;
+    readonly asCustomClaimTypeAdded: ITuple<[PolymeshPrimitivesIdentityId, u32, Bytes]>;
     readonly type:
       | 'DidCreated'
       | 'SecondaryKeysAdded'
@@ -358,10 +364,12 @@ declare module '@polkadot/types/lookup' {
       | 'AuthorizationRevoked'
       | 'AuthorizationRejected'
       | 'AuthorizationConsumed'
+      | 'AuthorizationRetryLimitReached'
       | 'CddRequirementForPrimaryKeyUpdated'
       | 'CddClaimsInvalidated'
       | 'SecondaryKeysFrozen'
-      | 'SecondaryKeysUnfrozen';
+      | 'SecondaryKeysUnfrozen'
+      | 'CustomClaimTypeAdded';
   }
 
   /** @name PolymeshPrimitivesSecondaryKey (36) */
@@ -478,6 +486,8 @@ declare module '@polkadot/types/lookup' {
     readonly isNoData: boolean;
     readonly isInvestorUniquenessV2: boolean;
     readonly asInvestorUniquenessV2: PolymeshPrimitivesCddId;
+    readonly isCustom: boolean;
+    readonly asCustom: ITuple<[u32, Option<PolymeshPrimitivesIdentityClaimScope>]>;
     readonly type:
       | 'Accredited'
       | 'Affiliate'
@@ -490,7 +500,8 @@ declare module '@polkadot/types/lookup' {
       | 'Blocked'
       | 'InvestorUniqueness'
       | 'NoData'
-      | 'InvestorUniquenessV2';
+      | 'InvestorUniquenessV2'
+      | 'Custom';
   }
 
   /** @name PolymeshPrimitivesIdentityClaimScope (62) */
@@ -1012,7 +1023,7 @@ declare module '@polkadot/types/lookup' {
       | 'Sx';
   }
 
-  /** @name PolymeshPrimitivesAuthorizationAuthorizationData (66) */
+  /** @name PolymeshPrimitivesAuthorizationAuthorizationData (68) */
   export interface PolymeshPrimitivesAuthorizationAuthorizationData extends Enum {
     readonly isAttestPrimaryKeyRotation: boolean;
     readonly asAttestPrimaryKeyRotation: PolymeshPrimitivesIdentityId;
@@ -1046,7 +1057,7 @@ declare module '@polkadot/types/lookup' {
       | 'RotatePrimaryKeyToSecondary';
   }
 
-  /** @name PolymeshPrimitivesAgentAgentGroup (67) */
+  /** @name PolymeshPrimitivesAgentAgentGroup (69) */
   export interface PolymeshPrimitivesAgentAgentGroup extends Enum {
     readonly isFull: boolean;
     readonly isCustom: boolean;
@@ -1057,7 +1068,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Full' | 'Custom' | 'ExceptMeta' | 'PolymeshV1CAA' | 'PolymeshV1PIA';
   }
 
-  /** @name PolymeshCommonUtilitiesGroupRawEventInstance2 (70) */
+  /** @name PolymeshCommonUtilitiesGroupRawEventInstance2 (72) */
   export interface PolymeshCommonUtilitiesGroupRawEventInstance2 extends Enum {
     readonly isMemberAdded: boolean;
     readonly asMemberAdded: ITuple<[PolymeshPrimitivesIdentityId, PolymeshPrimitivesIdentityId]>;
@@ -1086,10 +1097,10 @@ declare module '@polkadot/types/lookup' {
       | 'Dummy';
   }
 
-  /** @name PalletGroupInstance2 (71) */
+  /** @name PalletGroupInstance2 (73) */
   export type PalletGroupInstance2 = Null;
 
-  /** @name PalletCommitteeRawEventInstance1 (73) */
+  /** @name PalletCommitteeRawEventInstance1 (75) */
   export interface PalletCommitteeRawEventInstance1 extends Enum {
     readonly isProposed: boolean;
     readonly asProposed: ITuple<[PolymeshPrimitivesIdentityId, u32, H256]>;
@@ -1138,10 +1149,10 @@ declare module '@polkadot/types/lookup' {
       | 'VoteThresholdUpdated';
   }
 
-  /** @name PalletCommitteeInstance1 (74) */
+  /** @name PalletCommitteeInstance1 (76) */
   export type PalletCommitteeInstance1 = Null;
 
-  /** @name PolymeshCommonUtilitiesMaybeBlock (77) */
+  /** @name PolymeshCommonUtilitiesMaybeBlock (79) */
   export interface PolymeshCommonUtilitiesMaybeBlock extends Enum {
     readonly isSome: boolean;
     readonly asSome: u32;
@@ -1149,7 +1160,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Some' | 'None';
   }
 
-  /** @name PolymeshCommonUtilitiesGroupRawEventInstance1 (78) */
+  /** @name PolymeshCommonUtilitiesGroupRawEventInstance1 (80) */
   export interface PolymeshCommonUtilitiesGroupRawEventInstance1 extends Enum {
     readonly isMemberAdded: boolean;
     readonly asMemberAdded: ITuple<[PolymeshPrimitivesIdentityId, PolymeshPrimitivesIdentityId]>;
@@ -1178,10 +1189,10 @@ declare module '@polkadot/types/lookup' {
       | 'Dummy';
   }
 
-  /** @name PalletGroupInstance1 (79) */
+  /** @name PalletGroupInstance1 (81) */
   export type PalletGroupInstance1 = Null;
 
-  /** @name PalletCommitteeRawEventInstance3 (80) */
+  /** @name PalletCommitteeRawEventInstance3 (82) */
   export interface PalletCommitteeRawEventInstance3 extends Enum {
     readonly isProposed: boolean;
     readonly asProposed: ITuple<[PolymeshPrimitivesIdentityId, u32, H256]>;
@@ -1230,10 +1241,10 @@ declare module '@polkadot/types/lookup' {
       | 'VoteThresholdUpdated';
   }
 
-  /** @name PalletCommitteeInstance3 (81) */
+  /** @name PalletCommitteeInstance3 (83) */
   export type PalletCommitteeInstance3 = Null;
 
-  /** @name PolymeshCommonUtilitiesGroupRawEventInstance3 (82) */
+  /** @name PolymeshCommonUtilitiesGroupRawEventInstance3 (84) */
   export interface PolymeshCommonUtilitiesGroupRawEventInstance3 extends Enum {
     readonly isMemberAdded: boolean;
     readonly asMemberAdded: ITuple<[PolymeshPrimitivesIdentityId, PolymeshPrimitivesIdentityId]>;
@@ -1262,10 +1273,10 @@ declare module '@polkadot/types/lookup' {
       | 'Dummy';
   }
 
-  /** @name PalletGroupInstance3 (83) */
+  /** @name PalletGroupInstance3 (85) */
   export type PalletGroupInstance3 = Null;
 
-  /** @name PalletCommitteeRawEventInstance4 (84) */
+  /** @name PalletCommitteeRawEventInstance4 (86) */
   export interface PalletCommitteeRawEventInstance4 extends Enum {
     readonly isProposed: boolean;
     readonly asProposed: ITuple<[PolymeshPrimitivesIdentityId, u32, H256]>;
@@ -1314,10 +1325,10 @@ declare module '@polkadot/types/lookup' {
       | 'VoteThresholdUpdated';
   }
 
-  /** @name PalletCommitteeInstance4 (85) */
+  /** @name PalletCommitteeInstance4 (87) */
   export type PalletCommitteeInstance4 = Null;
 
-  /** @name PolymeshCommonUtilitiesGroupRawEventInstance4 (86) */
+  /** @name PolymeshCommonUtilitiesGroupRawEventInstance4 (88) */
   export interface PolymeshCommonUtilitiesGroupRawEventInstance4 extends Enum {
     readonly isMemberAdded: boolean;
     readonly asMemberAdded: ITuple<[PolymeshPrimitivesIdentityId, PolymeshPrimitivesIdentityId]>;
@@ -1346,10 +1357,10 @@ declare module '@polkadot/types/lookup' {
       | 'Dummy';
   }
 
-  /** @name PalletGroupInstance4 (87) */
+  /** @name PalletGroupInstance4 (89) */
   export type PalletGroupInstance4 = Null;
 
-  /** @name PalletMultisigRawEvent (88) */
+  /** @name PalletMultisigRawEvent (90) */
   export interface PalletMultisigRawEvent extends Enum {
     readonly isMultiSigCreated: boolean;
     readonly asMultiSigCreated: ITuple<
@@ -1410,7 +1421,7 @@ declare module '@polkadot/types/lookup' {
       | 'SchedulingFailed';
   }
 
-  /** @name PolymeshPrimitivesSecondaryKeySignatory (90) */
+  /** @name PolymeshPrimitivesSecondaryKeySignatory (92) */
   export interface PolymeshPrimitivesSecondaryKeySignatory extends Enum {
     readonly isIdentity: boolean;
     readonly asIdentity: PolymeshPrimitivesIdentityId;
@@ -1419,7 +1430,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Identity' | 'Account';
   }
 
-  /** @name PalletBridgeRawEvent (91) */
+  /** @name PalletBridgeRawEvent (93) */
   export interface PalletBridgeRawEvent extends Enum {
     readonly isControllerChanged: boolean;
     readonly asControllerChanged: ITuple<[PolymeshPrimitivesIdentityId, AccountId32]>;
@@ -1476,7 +1487,7 @@ declare module '@polkadot/types/lookup' {
       | 'TxRemoved';
   }
 
-  /** @name PalletBridgeBridgeTx (92) */
+  /** @name PalletBridgeBridgeTx (94) */
   export interface PalletBridgeBridgeTx extends Struct {
     readonly nonce: u32;
     readonly recipient: AccountId32;
@@ -1484,7 +1495,7 @@ declare module '@polkadot/types/lookup' {
     readonly txHash: H256;
   }
 
-  /** @name PalletBridgeHandledTxStatus (95) */
+  /** @name PalletBridgeHandledTxStatus (97) */
   export interface PalletBridgeHandledTxStatus extends Enum {
     readonly isSuccess: boolean;
     readonly isError: boolean;
@@ -1492,7 +1503,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Success' | 'Error';
   }
 
-  /** @name PalletStakingRawEvent (96) */
+  /** @name PalletStakingRawEvent (98) */
   export interface PalletStakingRawEvent extends Enum {
     readonly isEraPayout: boolean;
     readonly asEraPayout: ITuple<[u32, u128, u128]>;
@@ -1556,7 +1567,7 @@ declare module '@polkadot/types/lookup' {
       | 'SlashingAllowedForChanged';
   }
 
-  /** @name PalletStakingElectionCompute (97) */
+  /** @name PalletStakingElectionCompute (99) */
   export interface PalletStakingElectionCompute extends Enum {
     readonly isOnChain: boolean;
     readonly isSigned: boolean;
@@ -1564,7 +1575,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'OnChain' | 'Signed' | 'Unsigned';
   }
 
-  /** @name PalletStakingSlashingSwitch (99) */
+  /** @name PalletStakingSlashingSwitch (101) */
   export interface PalletStakingSlashingSwitch extends Enum {
     readonly isValidator: boolean;
     readonly isValidatorAndNominator: boolean;
@@ -1572,7 +1583,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Validator' | 'ValidatorAndNominator' | 'None';
   }
 
-  /** @name PalletOffencesEvent (100) */
+  /** @name PalletOffencesEvent (102) */
   export interface PalletOffencesEvent extends Enum {
     readonly isOffence: boolean;
     readonly asOffence: {
@@ -1582,7 +1593,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Offence';
   }
 
-  /** @name PalletSessionEvent (102) */
+  /** @name PalletSessionEvent (104) */
   export interface PalletSessionEvent extends Enum {
     readonly isNewSession: boolean;
     readonly asNewSession: {
@@ -1591,7 +1602,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'NewSession';
   }
 
-  /** @name PalletGrandpaEvent (103) */
+  /** @name PalletGrandpaEvent (105) */
   export interface PalletGrandpaEvent extends Enum {
     readonly isNewAuthorities: boolean;
     readonly asNewAuthorities: {
@@ -1602,13 +1613,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'NewAuthorities' | 'Paused' | 'Resumed';
   }
 
-  /** @name SpFinalityGrandpaAppPublic (106) */
+  /** @name SpFinalityGrandpaAppPublic (108) */
   export interface SpFinalityGrandpaAppPublic extends SpCoreEd25519Public {}
 
-  /** @name SpCoreEd25519Public (107) */
+  /** @name SpCoreEd25519Public (109) */
   export interface SpCoreEd25519Public extends U8aFixed {}
 
-  /** @name PalletImOnlineEvent (108) */
+  /** @name PalletImOnlineEvent (110) */
   export interface PalletImOnlineEvent extends Enum {
     readonly isHeartbeatReceived: boolean;
     readonly asHeartbeatReceived: {
@@ -1622,26 +1633,26 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'HeartbeatReceived' | 'AllGood' | 'SomeOffline';
   }
 
-  /** @name PalletImOnlineSr25519AppSr25519Public (109) */
+  /** @name PalletImOnlineSr25519AppSr25519Public (111) */
   export interface PalletImOnlineSr25519AppSr25519Public extends SpCoreSr25519Public {}
 
-  /** @name SpCoreSr25519Public (110) */
+  /** @name SpCoreSr25519Public (112) */
   export interface SpCoreSr25519Public extends U8aFixed {}
 
-  /** @name PalletStakingExposure (113) */
+  /** @name PalletStakingExposure (115) */
   export interface PalletStakingExposure extends Struct {
     readonly total: Compact<u128>;
     readonly own: Compact<u128>;
     readonly others: Vec<PalletStakingIndividualExposure>;
   }
 
-  /** @name PalletStakingIndividualExposure (116) */
+  /** @name PalletStakingIndividualExposure (118) */
   export interface PalletStakingIndividualExposure extends Struct {
     readonly who: AccountId32;
     readonly value: Compact<u128>;
   }
 
-  /** @name PalletSudoRawEvent (117) */
+  /** @name PalletSudoRawEvent (119) */
   export interface PalletSudoRawEvent extends Enum {
     readonly isSudid: boolean;
     readonly asSudid: Result<Null, SpRuntimeDispatchError>;
@@ -1652,7 +1663,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Sudid' | 'KeyChanged' | 'SudoAsDone';
   }
 
-  /** @name PolymeshCommonUtilitiesAssetRawEvent (118) */
+  /** @name PolymeshCommonUtilitiesAssetRawEvent (120) */
   export interface PolymeshCommonUtilitiesAssetRawEvent extends Enum {
     readonly isTransfer: boolean;
     readonly asTransfer: ITuple<
@@ -1687,7 +1698,10 @@ declare module '@polkadot/types/lookup' {
         bool,
         PolymeshPrimitivesAssetAssetType,
         PolymeshPrimitivesIdentityId,
-        bool
+        bool,
+        Bytes,
+        Vec<PolymeshPrimitivesAssetIdentifier>,
+        Option<Bytes>
       ]
     >;
     readonly isIdentifiersUpdated: boolean;
@@ -1832,7 +1846,7 @@ declare module '@polkadot/types/lookup' {
       | 'RegisterAssetMetadataGlobalType';
   }
 
-  /** @name PolymeshPrimitivesAssetAssetType (120) */
+  /** @name PolymeshPrimitivesAssetAssetType (122) */
   export interface PolymeshPrimitivesAssetAssetType extends Enum {
     readonly isEquityCommon: boolean;
     readonly isEquityPreferred: boolean;
@@ -1860,7 +1874,7 @@ declare module '@polkadot/types/lookup' {
       | 'StableCoin';
   }
 
-  /** @name PolymeshPrimitivesAssetIdentifier (123) */
+  /** @name PolymeshPrimitivesAssetIdentifier (126) */
   export interface PolymeshPrimitivesAssetIdentifier extends Enum {
     readonly isCusip: boolean;
     readonly asCusip: U8aFixed;
@@ -1875,7 +1889,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Cusip' | 'Cins' | 'Isin' | 'Lei' | 'Figi';
   }
 
-  /** @name PolymeshPrimitivesDocument (128) */
+  /** @name PolymeshPrimitivesDocument (131) */
   export interface PolymeshPrimitivesDocument extends Struct {
     readonly uri: Bytes;
     readonly contentHash: PolymeshPrimitivesDocumentHash;
@@ -1884,7 +1898,7 @@ declare module '@polkadot/types/lookup' {
     readonly filingDate: Option<u64>;
   }
 
-  /** @name PolymeshPrimitivesDocumentHash (130) */
+  /** @name PolymeshPrimitivesDocumentHash (133) */
   export interface PolymeshPrimitivesDocumentHash extends Enum {
     readonly isNone: boolean;
     readonly isH512: boolean;
@@ -1906,16 +1920,16 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'None' | 'H512' | 'H384' | 'H320' | 'H256' | 'H224' | 'H192' | 'H160' | 'H128';
   }
 
-  /** @name PolymeshPrimitivesEthereumEthereumAddress (139) */
+  /** @name PolymeshPrimitivesEthereumEthereumAddress (142) */
   export interface PolymeshPrimitivesEthereumEthereumAddress extends U8aFixed {}
 
-  /** @name PolymeshPrimitivesAssetMetadataAssetMetadataValueDetail (142) */
+  /** @name PolymeshPrimitivesAssetMetadataAssetMetadataValueDetail (145) */
   export interface PolymeshPrimitivesAssetMetadataAssetMetadataValueDetail extends Struct {
     readonly expire: Option<u64>;
     readonly lockStatus: PolymeshPrimitivesAssetMetadataAssetMetadataLockStatus;
   }
 
-  /** @name PolymeshPrimitivesAssetMetadataAssetMetadataLockStatus (143) */
+  /** @name PolymeshPrimitivesAssetMetadataAssetMetadataLockStatus (146) */
   export interface PolymeshPrimitivesAssetMetadataAssetMetadataLockStatus extends Enum {
     readonly isUnlocked: boolean;
     readonly isLocked: boolean;
@@ -1924,14 +1938,14 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Unlocked' | 'Locked' | 'LockedUntil';
   }
 
-  /** @name PolymeshPrimitivesAssetMetadataAssetMetadataSpec (146) */
+  /** @name PolymeshPrimitivesAssetMetadataAssetMetadataSpec (149) */
   export interface PolymeshPrimitivesAssetMetadataAssetMetadataSpec extends Struct {
     readonly url: Option<Bytes>;
     readonly description: Option<Bytes>;
     readonly typeDef: Option<Bytes>;
   }
 
-  /** @name PalletCorporateActionsDistributionEvent (153) */
+  /** @name PalletCorporateActionsDistributionEvent (156) */
   export interface PalletCorporateActionsDistributionEvent extends Enum {
     readonly isCreated: boolean;
     readonly asCreated: ITuple<
@@ -1955,16 +1969,16 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Created' | 'BenefitClaimed' | 'Reclaimed' | 'Removed';
   }
 
-  /** @name PolymeshPrimitivesEventOnly (154) */
+  /** @name PolymeshPrimitivesEventOnly (157) */
   export interface PolymeshPrimitivesEventOnly extends PolymeshPrimitivesIdentityId {}
 
-  /** @name PalletCorporateActionsCaId (155) */
+  /** @name PalletCorporateActionsCaId (158) */
   export interface PalletCorporateActionsCaId extends Struct {
     readonly ticker: PolymeshPrimitivesTicker;
     readonly localId: u32;
   }
 
-  /** @name PalletCorporateActionsDistribution (157) */
+  /** @name PalletCorporateActionsDistribution (160) */
   export interface PalletCorporateActionsDistribution extends Struct {
     readonly from: PolymeshPrimitivesIdentityIdPortfolioId;
     readonly currency: PolymeshPrimitivesTicker;
@@ -1976,7 +1990,7 @@ declare module '@polkadot/types/lookup' {
     readonly expiresAt: Option<u64>;
   }
 
-  /** @name PolymeshCommonUtilitiesCheckpointEvent (159) */
+  /** @name PolymeshCommonUtilitiesCheckpointEvent (162) */
   export interface PolymeshCommonUtilitiesCheckpointEvent extends Enum {
     readonly isCheckpointCreated: boolean;
     readonly asCheckpointCreated: ITuple<
@@ -2007,7 +2021,7 @@ declare module '@polkadot/types/lookup' {
       | 'ScheduleRemoved';
   }
 
-  /** @name PolymeshCommonUtilitiesCheckpointStoredSchedule (162) */
+  /** @name PolymeshCommonUtilitiesCheckpointStoredSchedule (165) */
   export interface PolymeshCommonUtilitiesCheckpointStoredSchedule extends Struct {
     readonly schedule: PolymeshPrimitivesCalendarCheckpointSchedule;
     readonly id: u64;
@@ -2015,19 +2029,19 @@ declare module '@polkadot/types/lookup' {
     readonly remaining: u32;
   }
 
-  /** @name PolymeshPrimitivesCalendarCheckpointSchedule (163) */
+  /** @name PolymeshPrimitivesCalendarCheckpointSchedule (166) */
   export interface PolymeshPrimitivesCalendarCheckpointSchedule extends Struct {
     readonly start: u64;
     readonly period: PolymeshPrimitivesCalendarCalendarPeriod;
   }
 
-  /** @name PolymeshPrimitivesCalendarCalendarPeriod (164) */
+  /** @name PolymeshPrimitivesCalendarCalendarPeriod (167) */
   export interface PolymeshPrimitivesCalendarCalendarPeriod extends Struct {
     readonly unit: PolymeshPrimitivesCalendarCalendarUnit;
     readonly amount: u64;
   }
 
-  /** @name PolymeshPrimitivesCalendarCalendarUnit (165) */
+  /** @name PolymeshPrimitivesCalendarCalendarUnit (168) */
   export interface PolymeshPrimitivesCalendarCalendarUnit extends Enum {
     readonly isSecond: boolean;
     readonly isMinute: boolean;
@@ -2039,7 +2053,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Second' | 'Minute' | 'Hour' | 'Day' | 'Week' | 'Month' | 'Year';
   }
 
-  /** @name PalletComplianceManagerEvent (167) */
+  /** @name PalletComplianceManagerEvent (170) */
   export interface PalletComplianceManagerEvent extends Enum {
     readonly isComplianceRequirementCreated: boolean;
     readonly asComplianceRequirementCreated: ITuple<
@@ -2105,20 +2119,20 @@ declare module '@polkadot/types/lookup' {
       | 'TrustedDefaultClaimIssuerRemoved';
   }
 
-  /** @name PolymeshPrimitivesComplianceManagerComplianceRequirement (168) */
+  /** @name PolymeshPrimitivesComplianceManagerComplianceRequirement (171) */
   export interface PolymeshPrimitivesComplianceManagerComplianceRequirement extends Struct {
     readonly senderConditions: Vec<PolymeshPrimitivesCondition>;
     readonly receiverConditions: Vec<PolymeshPrimitivesCondition>;
     readonly id: u32;
   }
 
-  /** @name PolymeshPrimitivesCondition (170) */
+  /** @name PolymeshPrimitivesCondition (173) */
   export interface PolymeshPrimitivesCondition extends Struct {
     readonly conditionType: PolymeshPrimitivesConditionConditionType;
     readonly issuers: Vec<PolymeshPrimitivesConditionTrustedIssuer>;
   }
 
-  /** @name PolymeshPrimitivesConditionConditionType (171) */
+  /** @name PolymeshPrimitivesConditionConditionType (174) */
   export interface PolymeshPrimitivesConditionConditionType extends Enum {
     readonly isIsPresent: boolean;
     readonly asIsPresent: PolymeshPrimitivesIdentityClaimClaim;
@@ -2133,7 +2147,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'IsPresent' | 'IsAbsent' | 'IsAnyOf' | 'IsNoneOf' | 'IsIdentity';
   }
 
-  /** @name PolymeshPrimitivesConditionTargetIdentity (173) */
+  /** @name PolymeshPrimitivesConditionTargetIdentity (176) */
   export interface PolymeshPrimitivesConditionTargetIdentity extends Enum {
     readonly isExternalAgent: boolean;
     readonly isSpecific: boolean;
@@ -2141,13 +2155,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'ExternalAgent' | 'Specific';
   }
 
-  /** @name PolymeshPrimitivesConditionTrustedIssuer (175) */
+  /** @name PolymeshPrimitivesConditionTrustedIssuer (178) */
   export interface PolymeshPrimitivesConditionTrustedIssuer extends Struct {
     readonly issuer: PolymeshPrimitivesIdentityId;
     readonly trustedFor: PolymeshPrimitivesConditionTrustedFor;
   }
 
-  /** @name PolymeshPrimitivesConditionTrustedFor (176) */
+  /** @name PolymeshPrimitivesConditionTrustedFor (179) */
   export interface PolymeshPrimitivesConditionTrustedFor extends Enum {
     readonly isAny: boolean;
     readonly isSpecific: boolean;
@@ -2155,7 +2169,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Any' | 'Specific';
   }
 
-  /** @name PolymeshPrimitivesIdentityClaimClaimType (178) */
+  /** @name PolymeshPrimitivesIdentityClaimClaimType (181) */
   export interface PolymeshPrimitivesIdentityClaimClaimType extends Enum {
     readonly isAccredited: boolean;
     readonly isAffiliate: boolean;
@@ -2169,6 +2183,8 @@ declare module '@polkadot/types/lookup' {
     readonly isInvestorUniqueness: boolean;
     readonly isNoType: boolean;
     readonly isInvestorUniquenessV2: boolean;
+    readonly isCustom: boolean;
+    readonly asCustom: u32;
     readonly type:
       | 'Accredited'
       | 'Affiliate'
@@ -2181,10 +2197,11 @@ declare module '@polkadot/types/lookup' {
       | 'Blocked'
       | 'InvestorUniqueness'
       | 'NoType'
-      | 'InvestorUniquenessV2';
+      | 'InvestorUniquenessV2'
+      | 'Custom';
   }
 
-  /** @name PalletCorporateActionsEvent (180) */
+  /** @name PalletCorporateActionsEvent (183) */
   export interface PalletCorporateActionsEvent extends Enum {
     readonly isMaxDetailsLengthChanged: boolean;
     readonly asMaxDetailsLengthChanged: ITuple<[PolymeshPrimitivesIdentityId, u32]>;
@@ -2248,20 +2265,20 @@ declare module '@polkadot/types/lookup' {
       | 'RecordDateChanged';
   }
 
-  /** @name PalletCorporateActionsTargetIdentities (181) */
+  /** @name PalletCorporateActionsTargetIdentities (184) */
   export interface PalletCorporateActionsTargetIdentities extends Struct {
     readonly identities: Vec<PolymeshPrimitivesIdentityId>;
     readonly treatment: PalletCorporateActionsTargetTreatment;
   }
 
-  /** @name PalletCorporateActionsTargetTreatment (182) */
+  /** @name PalletCorporateActionsTargetTreatment (185) */
   export interface PalletCorporateActionsTargetTreatment extends Enum {
     readonly isInclude: boolean;
     readonly isExclude: boolean;
     readonly type: 'Include' | 'Exclude';
   }
 
-  /** @name PalletCorporateActionsCorporateAction (184) */
+  /** @name PalletCorporateActionsCorporateAction (187) */
   export interface PalletCorporateActionsCorporateAction extends Struct {
     readonly kind: PalletCorporateActionsCaKind;
     readonly declDate: u64;
@@ -2271,7 +2288,7 @@ declare module '@polkadot/types/lookup' {
     readonly withholdingTax: Vec<ITuple<[PolymeshPrimitivesIdentityId, Permill]>>;
   }
 
-  /** @name PalletCorporateActionsCaKind (185) */
+  /** @name PalletCorporateActionsCaKind (188) */
   export interface PalletCorporateActionsCaKind extends Enum {
     readonly isPredictableBenefit: boolean;
     readonly isUnpredictableBenefit: boolean;
@@ -2286,13 +2303,13 @@ declare module '@polkadot/types/lookup' {
       | 'Other';
   }
 
-  /** @name PalletCorporateActionsRecordDate (187) */
+  /** @name PalletCorporateActionsRecordDate (190) */
   export interface PalletCorporateActionsRecordDate extends Struct {
     readonly date: u64;
     readonly checkpoint: PalletCorporateActionsCaCheckpoint;
   }
 
-  /** @name PalletCorporateActionsCaCheckpoint (188) */
+  /** @name PalletCorporateActionsCaCheckpoint (191) */
   export interface PalletCorporateActionsCaCheckpoint extends Enum {
     readonly isScheduled: boolean;
     readonly asScheduled: ITuple<[u64, u64]>;
@@ -2301,7 +2318,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Scheduled' | 'Existing';
   }
 
-  /** @name PalletCorporateActionsBallotEvent (193) */
+  /** @name PalletCorporateActionsBallotEvent (196) */
   export interface PalletCorporateActionsBallotEvent extends Enum {
     readonly isCreated: boolean;
     readonly asCreated: ITuple<
@@ -2350,32 +2367,32 @@ declare module '@polkadot/types/lookup' {
       | 'Removed';
   }
 
-  /** @name PalletCorporateActionsBallotBallotTimeRange (194) */
+  /** @name PalletCorporateActionsBallotBallotTimeRange (197) */
   export interface PalletCorporateActionsBallotBallotTimeRange extends Struct {
     readonly start: u64;
     readonly end: u64;
   }
 
-  /** @name PalletCorporateActionsBallotBallotMeta (195) */
+  /** @name PalletCorporateActionsBallotBallotMeta (198) */
   export interface PalletCorporateActionsBallotBallotMeta extends Struct {
     readonly title: Bytes;
     readonly motions: Vec<PalletCorporateActionsBallotMotion>;
   }
 
-  /** @name PalletCorporateActionsBallotMotion (198) */
+  /** @name PalletCorporateActionsBallotMotion (201) */
   export interface PalletCorporateActionsBallotMotion extends Struct {
     readonly title: Bytes;
     readonly infoLink: Bytes;
     readonly choices: Vec<Bytes>;
   }
 
-  /** @name PalletCorporateActionsBallotBallotVote (204) */
+  /** @name PalletCorporateActionsBallotBallotVote (207) */
   export interface PalletCorporateActionsBallotBallotVote extends Struct {
     readonly power: u128;
     readonly fallback: Option<u16>;
   }
 
-  /** @name PalletPipsRawEvent (207) */
+  /** @name PalletPipsRawEvent (210) */
   export interface PalletPipsRawEvent extends Enum {
     readonly isHistoricalPipsPruned: boolean;
     readonly asHistoricalPipsPruned: ITuple<[PolymeshPrimitivesIdentityId, bool, bool]>;
@@ -2463,7 +2480,7 @@ declare module '@polkadot/types/lookup' {
       | 'ExecutionCancellingFailed';
   }
 
-  /** @name PalletPipsProposer (208) */
+  /** @name PalletPipsProposer (211) */
   export interface PalletPipsProposer extends Enum {
     readonly isCommunity: boolean;
     readonly asCommunity: AccountId32;
@@ -2472,14 +2489,14 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Community' | 'Committee';
   }
 
-  /** @name PalletPipsCommittee (209) */
+  /** @name PalletPipsCommittee (212) */
   export interface PalletPipsCommittee extends Enum {
     readonly isTechnical: boolean;
     readonly isUpgrade: boolean;
     readonly type: 'Technical' | 'Upgrade';
   }
 
-  /** @name PalletPipsProposalData (213) */
+  /** @name PalletPipsProposalData (216) */
   export interface PalletPipsProposalData extends Enum {
     readonly isHash: boolean;
     readonly asHash: H256;
@@ -2488,7 +2505,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Hash' | 'Proposal';
   }
 
-  /** @name PalletPipsProposalState (214) */
+  /** @name PalletPipsProposalState (217) */
   export interface PalletPipsProposalState extends Enum {
     readonly isPending: boolean;
     readonly isRejected: boolean;
@@ -2499,13 +2516,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Pending' | 'Rejected' | 'Scheduled' | 'Failed' | 'Executed' | 'Expired';
   }
 
-  /** @name PalletPipsSnapshottedPip (217) */
+  /** @name PalletPipsSnapshottedPip (220) */
   export interface PalletPipsSnapshottedPip extends Struct {
     readonly id: u32;
     readonly weight: ITuple<[bool, u128]>;
   }
 
-  /** @name PolymeshCommonUtilitiesPortfolioEvent (223) */
+  /** @name PolymeshCommonUtilitiesPortfolioEvent (226) */
   export interface PolymeshCommonUtilitiesPortfolioEvent extends Enum {
     readonly isPortfolioCreated: boolean;
     readonly asPortfolioCreated: ITuple<[PolymeshPrimitivesIdentityId, u64, Bytes]>;
@@ -2543,7 +2560,7 @@ declare module '@polkadot/types/lookup' {
       | 'PortfolioCustodianChanged';
   }
 
-  /** @name PalletProtocolFeeRawEvent (227) */
+  /** @name PalletProtocolFeeRawEvent (230) */
   export interface PalletProtocolFeeRawEvent extends Enum {
     readonly isFeeSet: boolean;
     readonly asFeeSet: ITuple<[PolymeshPrimitivesIdentityId, u128]>;
@@ -2554,10 +2571,10 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'FeeSet' | 'CoefficientSet' | 'FeeCharged';
   }
 
-  /** @name PolymeshPrimitivesPosRatio (228) */
+  /** @name PolymeshPrimitivesPosRatio (231) */
   export interface PolymeshPrimitivesPosRatio extends ITuple<[u32, u32]> {}
 
-  /** @name PalletSchedulerEvent (229) */
+  /** @name PalletSchedulerEvent (232) */
   export interface PalletSchedulerEvent extends Enum {
     readonly isScheduled: boolean;
     readonly asScheduled: {
@@ -2584,14 +2601,14 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Scheduled' | 'Canceled' | 'Dispatched' | 'CallLookupFailed';
   }
 
-  /** @name FrameSupportScheduleLookupError (231) */
+  /** @name FrameSupportScheduleLookupError (234) */
   export interface FrameSupportScheduleLookupError extends Enum {
     readonly isUnknown: boolean;
     readonly isBadFormat: boolean;
     readonly type: 'Unknown' | 'BadFormat';
   }
 
-  /** @name PalletSettlementRawEvent (232) */
+  /** @name PalletSettlementRawEvent (235) */
   export interface PalletSettlementRawEvent extends Enum {
     readonly isVenueCreated: boolean;
     readonly asVenueCreated: ITuple<
@@ -2612,7 +2629,8 @@ declare module '@polkadot/types/lookup' {
         PalletSettlementSettlementType,
         Option<u64>,
         Option<u64>,
-        Vec<PalletSettlementLeg>
+        Vec<PalletSettlementLeg>,
+        Option<PalletSettlementInstructionMemo>
       ]
     >;
     readonly isInstructionAffirmed: boolean;
@@ -2661,6 +2679,10 @@ declare module '@polkadot/types/lookup' {
     readonly asSchedulingFailed: SpRuntimeDispatchError;
     readonly isInstructionRescheduled: boolean;
     readonly asInstructionRescheduled: ITuple<[PolymeshPrimitivesIdentityId, u64]>;
+    readonly isVenueSignersUpdated: boolean;
+    readonly asVenueSignersUpdated: ITuple<
+      [PolymeshPrimitivesIdentityId, u64, Vec<AccountId32>, bool]
+    >;
     readonly type:
       | 'VenueCreated'
       | 'VenueDetailsUpdated'
@@ -2680,10 +2702,11 @@ declare module '@polkadot/types/lookup' {
       | 'InstructionExecuted'
       | 'VenueUnauthorized'
       | 'SchedulingFailed'
-      | 'InstructionRescheduled';
+      | 'InstructionRescheduled'
+      | 'VenueSignersUpdated';
   }
 
-  /** @name PalletSettlementVenueType (235) */
+  /** @name PalletSettlementVenueType (238) */
   export interface PalletSettlementVenueType extends Enum {
     readonly isOther: boolean;
     readonly isDistribution: boolean;
@@ -2692,7 +2715,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Other' | 'Distribution' | 'Sto' | 'Exchange';
   }
 
-  /** @name PalletSettlementSettlementType (237) */
+  /** @name PalletSettlementSettlementType (240) */
   export interface PalletSettlementSettlementType extends Enum {
     readonly isSettleOnAffirmation: boolean;
     readonly isSettleOnBlock: boolean;
@@ -2700,7 +2723,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'SettleOnAffirmation' | 'SettleOnBlock';
   }
 
-  /** @name PalletSettlementLeg (239) */
+  /** @name PalletSettlementLeg (242) */
   export interface PalletSettlementLeg extends Struct {
     readonly from: PolymeshPrimitivesIdentityIdPortfolioId;
     readonly to: PolymeshPrimitivesIdentityIdPortfolioId;
@@ -2708,7 +2731,10 @@ declare module '@polkadot/types/lookup' {
     readonly amount: u128;
   }
 
-  /** @name PolymeshCommonUtilitiesStatisticsEvent (243) */
+  /** @name PalletSettlementInstructionMemo (244) */
+  export interface PalletSettlementInstructionMemo extends U8aFixed {}
+
+  /** @name PolymeshCommonUtilitiesStatisticsEvent (248) */
   export interface PolymeshCommonUtilitiesStatisticsEvent extends Enum {
     readonly isStatTypesAdded: boolean;
     readonly asStatTypesAdded: ITuple<
@@ -2768,14 +2794,14 @@ declare module '@polkadot/types/lookup' {
       | 'TransferConditionExemptionsRemoved';
   }
 
-  /** @name PolymeshPrimitivesStatisticsAssetScope (244) */
+  /** @name PolymeshPrimitivesStatisticsAssetScope (249) */
   export interface PolymeshPrimitivesStatisticsAssetScope extends Enum {
     readonly isTicker: boolean;
     readonly asTicker: PolymeshPrimitivesTicker;
     readonly type: 'Ticker';
   }
 
-  /** @name PolymeshPrimitivesStatisticsStatType (246) */
+  /** @name PolymeshPrimitivesStatisticsStatType (251) */
   export interface PolymeshPrimitivesStatisticsStatType extends Struct {
     readonly op: PolymeshPrimitivesStatisticsStatOpType;
     readonly claimIssuer: Option<
@@ -2783,20 +2809,20 @@ declare module '@polkadot/types/lookup' {
     >;
   }
 
-  /** @name PolymeshPrimitivesStatisticsStatOpType (247) */
+  /** @name PolymeshPrimitivesStatisticsStatOpType (252) */
   export interface PolymeshPrimitivesStatisticsStatOpType extends Enum {
     readonly isCount: boolean;
     readonly isBalance: boolean;
     readonly type: 'Count' | 'Balance';
   }
 
-  /** @name PolymeshPrimitivesStatisticsStatUpdate (251) */
+  /** @name PolymeshPrimitivesStatisticsStatUpdate (256) */
   export interface PolymeshPrimitivesStatisticsStatUpdate extends Struct {
     readonly key2: PolymeshPrimitivesStatisticsStat2ndKey;
     readonly value: Option<u128>;
   }
 
-  /** @name PolymeshPrimitivesStatisticsStat2ndKey (252) */
+  /** @name PolymeshPrimitivesStatisticsStat2ndKey (257) */
   export interface PolymeshPrimitivesStatisticsStat2ndKey extends Enum {
     readonly isNoClaimStat: boolean;
     readonly isClaim: boolean;
@@ -2804,7 +2830,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'NoClaimStat' | 'Claim';
   }
 
-  /** @name PolymeshPrimitivesStatisticsStatClaim (253) */
+  /** @name PolymeshPrimitivesStatisticsStatClaim (258) */
   export interface PolymeshPrimitivesStatisticsStatClaim extends Enum {
     readonly isAccredited: boolean;
     readonly asAccredited: bool;
@@ -2815,7 +2841,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Accredited' | 'Affiliate' | 'Jurisdiction';
   }
 
-  /** @name PolymeshPrimitivesTransferComplianceTransferCondition (257) */
+  /** @name PolymeshPrimitivesTransferComplianceTransferCondition (262) */
   export interface PolymeshPrimitivesTransferComplianceTransferCondition extends Enum {
     readonly isMaxInvestorCount: boolean;
     readonly asMaxInvestorCount: u64;
@@ -2832,14 +2858,14 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'MaxInvestorCount' | 'MaxInvestorOwnership' | 'ClaimCount' | 'ClaimOwnership';
   }
 
-  /** @name PolymeshPrimitivesTransferComplianceTransferConditionExemptKey (259) */
+  /** @name PolymeshPrimitivesTransferComplianceTransferConditionExemptKey (263) */
   export interface PolymeshPrimitivesTransferComplianceTransferConditionExemptKey extends Struct {
     readonly asset: PolymeshPrimitivesStatisticsAssetScope;
     readonly op: PolymeshPrimitivesStatisticsStatOpType;
     readonly claimType: Option<PolymeshPrimitivesIdentityClaimClaimType>;
   }
 
-  /** @name PalletStoRawEvent (261) */
+  /** @name PalletStoRawEvent (265) */
   export interface PalletStoRawEvent extends Enum {
     readonly isFundraiserCreated: boolean;
     readonly asFundraiserCreated: ITuple<
@@ -2875,7 +2901,7 @@ declare module '@polkadot/types/lookup' {
       | 'FundraiserClosed';
   }
 
-  /** @name PalletStoFundraiser (264) */
+  /** @name PalletStoFundraiser (268) */
   export interface PalletStoFundraiser extends Struct {
     readonly creator: PolymeshPrimitivesIdentityId;
     readonly offeringPortfolio: PolymeshPrimitivesIdentityIdPortfolioId;
@@ -2890,14 +2916,14 @@ declare module '@polkadot/types/lookup' {
     readonly minimumInvestment: u128;
   }
 
-  /** @name PalletStoFundraiserTier (266) */
+  /** @name PalletStoFundraiserTier (270) */
   export interface PalletStoFundraiserTier extends Struct {
     readonly total: u128;
     readonly price: u128;
     readonly remaining: u128;
   }
 
-  /** @name PalletStoFundraiserStatus (267) */
+  /** @name PalletStoFundraiserStatus (271) */
   export interface PalletStoFundraiserStatus extends Enum {
     readonly isLive: boolean;
     readonly isFrozen: boolean;
@@ -2906,7 +2932,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Live' | 'Frozen' | 'Closed' | 'ClosedEarly';
   }
 
-  /** @name PalletTreasuryRawEvent (268) */
+  /** @name PalletTreasuryRawEvent (272) */
   export interface PalletTreasuryRawEvent extends Enum {
     readonly isTreasuryDisbursement: boolean;
     readonly asTreasuryDisbursement: ITuple<
@@ -2921,7 +2947,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'TreasuryDisbursement' | 'TreasuryDisbursementFailed' | 'TreasuryReimbursement';
   }
 
-  /** @name PalletUtilityEvent (269) */
+  /** @name PalletUtilityEvent (273) */
   export interface PalletUtilityEvent extends Enum {
     readonly isBatchInterrupted: boolean;
     readonly asBatchInterrupted: ITuple<[Vec<u32>, ITuple<[u32, SpRuntimeDispatchError]>]>;
@@ -2934,14 +2960,14 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'BatchInterrupted' | 'BatchOptimisticFailed' | 'BatchCompleted';
   }
 
-  /** @name PolymeshCommonUtilitiesBaseEvent (273) */
+  /** @name PolymeshCommonUtilitiesBaseEvent (277) */
   export interface PolymeshCommonUtilitiesBaseEvent extends Enum {
     readonly isUnexpectedError: boolean;
     readonly asUnexpectedError: Option<SpRuntimeDispatchError>;
     readonly type: 'UnexpectedError';
   }
 
-  /** @name PolymeshCommonUtilitiesExternalAgentsEvent (275) */
+  /** @name PolymeshCommonUtilitiesExternalAgentsEvent (279) */
   export interface PolymeshCommonUtilitiesExternalAgentsEvent extends Enum {
     readonly isGroupCreated: boolean;
     readonly asGroupCreated: ITuple<
@@ -2986,7 +3012,7 @@ declare module '@polkadot/types/lookup' {
       | 'GroupChanged';
   }
 
-  /** @name PolymeshCommonUtilitiesRelayerRawEvent (276) */
+  /** @name PolymeshCommonUtilitiesRelayerRawEvent (280) */
   export interface PolymeshCommonUtilitiesRelayerRawEvent extends Enum {
     readonly isAuthorizedPayingKey: boolean;
     readonly asAuthorizedPayingKey: ITuple<
@@ -3007,14 +3033,14 @@ declare module '@polkadot/types/lookup' {
       | 'UpdatedPolyxLimit';
   }
 
-  /** @name PalletRewardsRawEvent (277) */
+  /** @name PalletRewardsRawEvent (281) */
   export interface PalletRewardsRawEvent extends Enum {
     readonly isItnRewardClaimed: boolean;
     readonly asItnRewardClaimed: ITuple<[AccountId32, u128]>;
     readonly type: 'ItnRewardClaimed';
   }
 
-  /** @name PalletContractsEvent (278) */
+  /** @name PalletContractsEvent (282) */
   export interface PalletContractsEvent extends Enum {
     readonly isInstantiated: boolean;
     readonly asInstantiated: {
@@ -3054,10 +3080,10 @@ declare module '@polkadot/types/lookup' {
       | 'ContractCodeUpdated';
   }
 
-  /** @name PolymeshContractsEvent (279) */
+  /** @name PolymeshContractsEvent (283) */
   export type PolymeshContractsEvent = Null;
 
-  /** @name PalletPreimageEvent (280) */
+  /** @name PalletPreimageEvent (284) */
   export interface PalletPreimageEvent extends Enum {
     readonly isNoted: boolean;
     readonly asNoted: {
@@ -3074,7 +3100,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Noted' | 'Requested' | 'Cleared';
   }
 
-  /** @name PalletTestUtilsRawEvent (281) */
+  /** @name PalletTestUtilsRawEvent (285) */
   export interface PalletTestUtilsRawEvent extends Enum {
     readonly isMockInvestorUIDCreated: boolean;
     readonly asMockInvestorUIDCreated: ITuple<
@@ -3087,10 +3113,10 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'MockInvestorUIDCreated' | 'DidStatus' | 'CddStatus';
   }
 
-  /** @name PolymeshPrimitivesCddIdInvestorUid (282) */
+  /** @name PolymeshPrimitivesCddIdInvestorUid (286) */
   export interface PolymeshPrimitivesCddIdInvestorUid extends U8aFixed {}
 
-  /** @name FrameSystemPhase (283) */
+  /** @name FrameSystemPhase (287) */
   export interface FrameSystemPhase extends Enum {
     readonly isApplyExtrinsic: boolean;
     readonly asApplyExtrinsic: u32;
@@ -3099,13 +3125,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'ApplyExtrinsic' | 'Finalization' | 'Initialization';
   }
 
-  /** @name FrameSystemLastRuntimeUpgradeInfo (286) */
+  /** @name FrameSystemLastRuntimeUpgradeInfo (290) */
   export interface FrameSystemLastRuntimeUpgradeInfo extends Struct {
     readonly specVersion: Compact<u32>;
     readonly specName: Text;
   }
 
-  /** @name FrameSystemCall (289) */
+  /** @name FrameSystemCall (293) */
   export interface FrameSystemCall extends Enum {
     readonly isFillBlock: boolean;
     readonly asFillBlock: {
@@ -3156,21 +3182,21 @@ declare module '@polkadot/types/lookup' {
       | 'RemarkWithEvent';
   }
 
-  /** @name FrameSystemLimitsBlockWeights (293) */
+  /** @name FrameSystemLimitsBlockWeights (297) */
   export interface FrameSystemLimitsBlockWeights extends Struct {
     readonly baseBlock: u64;
     readonly maxBlock: u64;
     readonly perClass: FrameSupportWeightsPerDispatchClassWeightsPerClass;
   }
 
-  /** @name FrameSupportWeightsPerDispatchClassWeightsPerClass (294) */
+  /** @name FrameSupportWeightsPerDispatchClassWeightsPerClass (298) */
   export interface FrameSupportWeightsPerDispatchClassWeightsPerClass extends Struct {
     readonly normal: FrameSystemLimitsWeightsPerClass;
     readonly operational: FrameSystemLimitsWeightsPerClass;
     readonly mandatory: FrameSystemLimitsWeightsPerClass;
   }
 
-  /** @name FrameSystemLimitsWeightsPerClass (295) */
+  /** @name FrameSystemLimitsWeightsPerClass (299) */
   export interface FrameSystemLimitsWeightsPerClass extends Struct {
     readonly baseExtrinsic: u64;
     readonly maxExtrinsic: Option<u64>;
@@ -3178,25 +3204,25 @@ declare module '@polkadot/types/lookup' {
     readonly reserved: Option<u64>;
   }
 
-  /** @name FrameSystemLimitsBlockLength (296) */
+  /** @name FrameSystemLimitsBlockLength (300) */
   export interface FrameSystemLimitsBlockLength extends Struct {
     readonly max: FrameSupportWeightsPerDispatchClassU32;
   }
 
-  /** @name FrameSupportWeightsPerDispatchClassU32 (297) */
+  /** @name FrameSupportWeightsPerDispatchClassU32 (301) */
   export interface FrameSupportWeightsPerDispatchClassU32 extends Struct {
     readonly normal: u32;
     readonly operational: u32;
     readonly mandatory: u32;
   }
 
-  /** @name FrameSupportWeightsRuntimeDbWeight (298) */
+  /** @name FrameSupportWeightsRuntimeDbWeight (302) */
   export interface FrameSupportWeightsRuntimeDbWeight extends Struct {
     readonly read: u64;
     readonly write: u64;
   }
 
-  /** @name SpVersionRuntimeVersion (299) */
+  /** @name SpVersionRuntimeVersion (303) */
   export interface SpVersionRuntimeVersion extends Struct {
     readonly specName: Text;
     readonly implName: Text;
@@ -3208,7 +3234,7 @@ declare module '@polkadot/types/lookup' {
     readonly stateVersion: u8;
   }
 
-  /** @name FrameSystemError (304) */
+  /** @name FrameSystemError (308) */
   export interface FrameSystemError extends Enum {
     readonly isInvalidSpecName: boolean;
     readonly isSpecVersionNeedsToIncrease: boolean;
@@ -3225,10 +3251,10 @@ declare module '@polkadot/types/lookup' {
       | 'CallFiltered';
   }
 
-  /** @name SpConsensusBabeAppPublic (307) */
+  /** @name SpConsensusBabeAppPublic (311) */
   export interface SpConsensusBabeAppPublic extends SpCoreSr25519Public {}
 
-  /** @name SpConsensusBabeDigestsNextConfigDescriptor (310) */
+  /** @name SpConsensusBabeDigestsNextConfigDescriptor (314) */
   export interface SpConsensusBabeDigestsNextConfigDescriptor extends Enum {
     readonly isV1: boolean;
     readonly asV1: {
@@ -3238,7 +3264,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'V1';
   }
 
-  /** @name SpConsensusBabeAllowedSlots (312) */
+  /** @name SpConsensusBabeAllowedSlots (316) */
   export interface SpConsensusBabeAllowedSlots extends Enum {
     readonly isPrimarySlots: boolean;
     readonly isPrimaryAndSecondaryPlainSlots: boolean;
@@ -3246,13 +3272,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'PrimarySlots' | 'PrimaryAndSecondaryPlainSlots' | 'PrimaryAndSecondaryVRFSlots';
   }
 
-  /** @name SpConsensusBabeBabeEpochConfiguration (316) */
+  /** @name SpConsensusBabeBabeEpochConfiguration (320) */
   export interface SpConsensusBabeBabeEpochConfiguration extends Struct {
     readonly c: ITuple<[u64, u64]>;
     readonly allowedSlots: SpConsensusBabeAllowedSlots;
   }
 
-  /** @name PalletBabeCall (317) */
+  /** @name PalletBabeCall (321) */
   export interface PalletBabeCall extends Enum {
     readonly isReportEquivocation: boolean;
     readonly asReportEquivocation: {
@@ -3271,7 +3297,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'ReportEquivocation' | 'ReportEquivocationUnsigned' | 'PlanConfigChange';
   }
 
-  /** @name SpConsensusSlotsEquivocationProof (318) */
+  /** @name SpConsensusSlotsEquivocationProof (322) */
   export interface SpConsensusSlotsEquivocationProof extends Struct {
     readonly offender: SpConsensusBabeAppPublic;
     readonly slot: u64;
@@ -3279,7 +3305,7 @@ declare module '@polkadot/types/lookup' {
     readonly secondHeader: SpRuntimeHeader;
   }
 
-  /** @name SpRuntimeHeader (319) */
+  /** @name SpRuntimeHeader (323) */
   export interface SpRuntimeHeader extends Struct {
     readonly parentHash: H256;
     readonly number: Compact<u32>;
@@ -3288,17 +3314,17 @@ declare module '@polkadot/types/lookup' {
     readonly digest: SpRuntimeDigest;
   }
 
-  /** @name SpRuntimeBlakeTwo256 (320) */
+  /** @name SpRuntimeBlakeTwo256 (324) */
   export type SpRuntimeBlakeTwo256 = Null;
 
-  /** @name SpSessionMembershipProof (321) */
+  /** @name SpSessionMembershipProof (325) */
   export interface SpSessionMembershipProof extends Struct {
     readonly session: u32;
     readonly trieNodes: Vec<Bytes>;
     readonly validatorCount: u32;
   }
 
-  /** @name PalletBabeError (322) */
+  /** @name PalletBabeError (326) */
   export interface PalletBabeError extends Enum {
     readonly isInvalidEquivocationProof: boolean;
     readonly isInvalidKeyOwnershipProof: boolean;
@@ -3309,7 +3335,7 @@ declare module '@polkadot/types/lookup' {
       | 'DuplicateOffenceReport';
   }
 
-  /** @name PalletTimestampCall (323) */
+  /** @name PalletTimestampCall (327) */
   export interface PalletTimestampCall extends Enum {
     readonly isSet: boolean;
     readonly asSet: {
@@ -3318,7 +3344,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Set';
   }
 
-  /** @name PalletIndicesCall (326) */
+  /** @name PalletIndicesCall (330) */
   export interface PalletIndicesCall extends Enum {
     readonly isClaim: boolean;
     readonly asClaim: {
@@ -3346,7 +3372,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Claim' | 'Transfer' | 'Free' | 'ForceTransfer' | 'Freeze';
   }
 
-  /** @name PalletIndicesError (327) */
+  /** @name PalletIndicesError (331) */
   export interface PalletIndicesError extends Enum {
     readonly isNotAssigned: boolean;
     readonly isNotOwner: boolean;
@@ -3356,7 +3382,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'NotAssigned' | 'NotOwner' | 'InUse' | 'NotTransfer' | 'Permanent';
   }
 
-  /** @name PalletAuthorshipUncleEntryItem (329) */
+  /** @name PalletAuthorshipUncleEntryItem (333) */
   export interface PalletAuthorshipUncleEntryItem extends Enum {
     readonly isInclusionHeight: boolean;
     readonly asInclusionHeight: u32;
@@ -3365,7 +3391,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'InclusionHeight' | 'Uncle';
   }
 
-  /** @name PalletAuthorshipCall (330) */
+  /** @name PalletAuthorshipCall (334) */
   export interface PalletAuthorshipCall extends Enum {
     readonly isSetUncles: boolean;
     readonly asSetUncles: {
@@ -3374,7 +3400,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'SetUncles';
   }
 
-  /** @name PalletAuthorshipError (332) */
+  /** @name PalletAuthorshipError (336) */
   export interface PalletAuthorshipError extends Enum {
     readonly isInvalidUncleParent: boolean;
     readonly isUnclesAlreadySet: boolean;
@@ -3393,14 +3419,14 @@ declare module '@polkadot/types/lookup' {
       | 'OldUncle';
   }
 
-  /** @name PalletBalancesBalanceLock (334) */
+  /** @name PalletBalancesBalanceLock (338) */
   export interface PalletBalancesBalanceLock extends Struct {
     readonly id: U8aFixed;
     readonly amount: u128;
     readonly reasons: PolymeshCommonUtilitiesBalancesReasons;
   }
 
-  /** @name PolymeshCommonUtilitiesBalancesReasons (335) */
+  /** @name PolymeshCommonUtilitiesBalancesReasons (339) */
   export interface PolymeshCommonUtilitiesBalancesReasons extends Enum {
     readonly isFee: boolean;
     readonly isMisc: boolean;
@@ -3408,7 +3434,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Fee' | 'Misc' | 'All';
   }
 
-  /** @name PalletBalancesCall (336) */
+  /** @name PalletBalancesCall (340) */
   export interface PalletBalancesCall extends Enum {
     readonly isTransfer: boolean;
     readonly asTransfer: {
@@ -3450,7 +3476,7 @@ declare module '@polkadot/types/lookup' {
       | 'BurnAccountBalance';
   }
 
-  /** @name PalletBalancesError (338) */
+  /** @name PalletBalancesError (342) */
   export interface PalletBalancesError extends Enum {
     readonly isLiquidityRestrictions: boolean;
     readonly isOverflow: boolean;
@@ -3465,14 +3491,14 @@ declare module '@polkadot/types/lookup' {
       | 'ReceiverCddMissing';
   }
 
-  /** @name PalletTransactionPaymentReleases (340) */
+  /** @name PalletTransactionPaymentReleases (344) */
   export interface PalletTransactionPaymentReleases extends Enum {
     readonly isV1Ancient: boolean;
     readonly isV2: boolean;
     readonly type: 'V1Ancient' | 'V2';
   }
 
-  /** @name FrameSupportWeightsWeightToFeeCoefficient (342) */
+  /** @name FrameSupportWeightsWeightToFeeCoefficient (346) */
   export interface FrameSupportWeightsWeightToFeeCoefficient extends Struct {
     readonly coeffInteger: u128;
     readonly coeffFrac: Perbill;
@@ -3480,24 +3506,24 @@ declare module '@polkadot/types/lookup' {
     readonly degree: u8;
   }
 
-  /** @name PolymeshPrimitivesIdentityDidRecord (343) */
+  /** @name PolymeshPrimitivesIdentityDidRecord (347) */
   export interface PolymeshPrimitivesIdentityDidRecord extends Struct {
     readonly primaryKey: Option<AccountId32>;
   }
 
-  /** @name PalletIdentityClaim1stKey (345) */
+  /** @name PalletIdentityClaim1stKey (349) */
   export interface PalletIdentityClaim1stKey extends Struct {
     readonly target: PolymeshPrimitivesIdentityId;
     readonly claimType: PolymeshPrimitivesIdentityClaimClaimType;
   }
 
-  /** @name PalletIdentityClaim2ndKey (346) */
+  /** @name PalletIdentityClaim2ndKey (350) */
   export interface PalletIdentityClaim2ndKey extends Struct {
     readonly issuer: PolymeshPrimitivesIdentityId;
     readonly scope: Option<PolymeshPrimitivesIdentityClaimScope>;
   }
 
-  /** @name PolymeshPrimitivesSecondaryKeyKeyRecord (348) */
+  /** @name PolymeshPrimitivesSecondaryKeyKeyRecord (351) */
   export interface PolymeshPrimitivesSecondaryKeyKeyRecord extends Enum {
     readonly isPrimaryKey: boolean;
     readonly asPrimaryKey: PolymeshPrimitivesIdentityId;
@@ -3510,15 +3536,16 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'PrimaryKey' | 'SecondaryKey' | 'MultiSigSignerKey';
   }
 
-  /** @name PolymeshPrimitivesAuthorization (351) */
+  /** @name PolymeshPrimitivesAuthorization (354) */
   export interface PolymeshPrimitivesAuthorization extends Struct {
     readonly authorizationData: PolymeshPrimitivesAuthorizationAuthorizationData;
     readonly authorizedBy: PolymeshPrimitivesIdentityId;
     readonly expiry: Option<u64>;
     readonly authId: u64;
+    readonly count: u32;
   }
 
-  /** @name PalletIdentityCall (354) */
+  /** @name PalletIdentityCall (357) */
   export interface PalletIdentityCall extends Enum {
     readonly isCddRegisterDid: boolean;
     readonly asCddRegisterDid: {
@@ -3589,7 +3616,7 @@ declare module '@polkadot/types/lookup' {
     readonly asAddInvestorUniquenessClaim: {
       readonly target: PolymeshPrimitivesIdentityId;
       readonly claim: PolymeshPrimitivesIdentityClaimClaim;
-      readonly proof: PolymeshPrimitivesInvestorZkproofDataV1InvestorZKProofData;
+      readonly proof: U8aFixed;
       readonly expiry: Option<u64>;
     } & Struct;
     readonly isGcAddCddClaim: boolean;
@@ -3605,7 +3632,7 @@ declare module '@polkadot/types/lookup' {
       readonly target: PolymeshPrimitivesIdentityId;
       readonly scope: PolymeshPrimitivesIdentityClaimScope;
       readonly claim: PolymeshPrimitivesIdentityClaimClaim;
-      readonly proof: ConfidentialIdentityClaimProofsScopeClaimProof;
+      readonly proof: ConfidentialIdentityV2ClaimProofsScopeClaimProof;
       readonly expiry: Option<u64>;
     } & Struct;
     readonly isRevokeClaimByIndex: boolean;
@@ -3633,6 +3660,10 @@ declare module '@polkadot/types/lookup' {
     readonly asRemoveSecondaryKeys: {
       readonly keysToRemove: Vec<AccountId32>;
     } & Struct;
+    readonly isRegisterCustomClaimType: boolean;
+    readonly asRegisterCustomClaimType: {
+      readonly ty: Bytes;
+    } & Struct;
     readonly type:
       | 'CddRegisterDid'
       | 'InvalidateCddClaims'
@@ -3658,81 +3689,49 @@ declare module '@polkadot/types/lookup' {
       | 'RotatePrimaryKeyToSecondary'
       | 'AddSecondaryKeysWithAuthorization'
       | 'SetSecondaryKeyPermissions'
-      | 'RemoveSecondaryKeys';
+      | 'RemoveSecondaryKeys'
+      | 'RegisterCustomClaimType';
   }
 
-  /** @name PolymeshCommonUtilitiesIdentitySecondaryKeyWithAuthV1 (356) */
+  /** @name PolymeshCommonUtilitiesIdentitySecondaryKeyWithAuthV1 (359) */
   export interface PolymeshCommonUtilitiesIdentitySecondaryKeyWithAuthV1 extends Struct {
     readonly secondaryKey: PolymeshPrimitivesSecondaryKeyV1SecondaryKey;
     readonly authSignature: H512;
   }
 
-  /** @name PolymeshPrimitivesSecondaryKeyV1SecondaryKey (357) */
+  /** @name PolymeshPrimitivesSecondaryKeyV1SecondaryKey (360) */
   export interface PolymeshPrimitivesSecondaryKeyV1SecondaryKey extends Struct {
     readonly signer: PolymeshPrimitivesSecondaryKeySignatory;
     readonly permissions: PolymeshPrimitivesSecondaryKeyPermissions;
   }
 
-  /** @name PolymeshPrimitivesInvestorZkproofDataV1InvestorZKProofData (359) */
-  export interface PolymeshPrimitivesInvestorZkproofDataV1InvestorZKProofData
-    extends SchnorrkelSignSignature {}
-
-  /** @name SchnorrkelSignSignature (360) */
-  export interface SchnorrkelSignSignature extends Struct {
-    readonly r: Curve25519DalekRistrettoCompressedRistretto;
-    readonly s: Curve25519DalekScalar;
+  /** @name ConfidentialIdentityV2ClaimProofsScopeClaimProof (363) */
+  export interface ConfidentialIdentityV2ClaimProofsScopeClaimProof extends Struct {
+    readonly proofScopeIdWellformed: ConfidentialIdentityV2SignSignature;
+    readonly proofScopeIdCddIdMatch: ConfidentialIdentityV2ClaimProofsZkProofData;
+    readonly scopeId: U8aFixed;
   }
 
-  /** @name Curve25519DalekRistrettoCompressedRistretto (361) */
-  export interface Curve25519DalekRistrettoCompressedRistretto extends U8aFixed {}
-
-  /** @name Curve25519DalekScalar (362) */
-  export interface Curve25519DalekScalar extends Struct {
-    readonly bytes: U8aFixed;
+  /** @name ConfidentialIdentityV2SignSignature (364) */
+  export interface ConfidentialIdentityV2SignSignature extends Struct {
+    readonly r: U8aFixed;
+    readonly s: U8aFixed;
   }
 
-  /** @name ConfidentialIdentityClaimProofsScopeClaimProof (363) */
-  export interface ConfidentialIdentityClaimProofsScopeClaimProof extends Struct {
-    readonly proofScopeIdWellformed: ConfidentialIdentitySignSignature;
-    readonly proofScopeIdCddIdMatch: ConfidentialIdentityClaimProofsZkProofData;
-    readonly scopeId: Curve25519DalekRistrettoRistrettoPoint;
+  /** @name ConfidentialIdentityV2ClaimProofsZkProofData (365) */
+  export interface ConfidentialIdentityV2ClaimProofsZkProofData extends Struct {
+    readonly challengeResponses: Vec<U8aFixed>;
+    readonly subtractExpressionsRes: U8aFixed;
+    readonly blindedScopeDidHash: U8aFixed;
   }
 
-  /** @name ConfidentialIdentitySignSignature (364) */
-  export interface ConfidentialIdentitySignSignature extends Struct {
-    readonly r: Curve25519DalekRistrettoCompressedRistretto;
-    readonly s: Curve25519DalekScalar;
-  }
-
-  /** @name ConfidentialIdentityClaimProofsZkProofData (365) */
-  export interface ConfidentialIdentityClaimProofsZkProofData extends Struct {
-    readonly challengeResponses: Vec<Curve25519DalekScalar>;
-    readonly subtractExpressionsRes: Curve25519DalekRistrettoRistrettoPoint;
-    readonly blindedScopeDidHash: Curve25519DalekRistrettoRistrettoPoint;
-  }
-
-  /** @name Curve25519DalekRistrettoRistrettoPoint (367) */
-  export interface Curve25519DalekRistrettoRistrettoPoint
-    extends Curve25519DalekEdwardsEdwardsPoint {}
-
-  /** @name Curve25519DalekEdwardsEdwardsPoint (368) */
-  export interface Curve25519DalekEdwardsEdwardsPoint extends Struct {
-    readonly x: Curve25519DalekBackendSerialU64FieldFieldElement51;
-    readonly y: Curve25519DalekBackendSerialU64FieldFieldElement51;
-    readonly z: Curve25519DalekBackendSerialU64FieldFieldElement51;
-    readonly t: Curve25519DalekBackendSerialU64FieldFieldElement51;
-  }
-
-  /** @name Curve25519DalekBackendSerialU64FieldFieldElement51 (369) */
-  export interface Curve25519DalekBackendSerialU64FieldFieldElement51 extends Vec<u64> {}
-
-  /** @name PolymeshCommonUtilitiesIdentitySecondaryKeyWithAuth (372) */
+  /** @name PolymeshCommonUtilitiesIdentitySecondaryKeyWithAuth (368) */
   export interface PolymeshCommonUtilitiesIdentitySecondaryKeyWithAuth extends Struct {
     readonly secondaryKey: PolymeshPrimitivesSecondaryKey;
     readonly authSignature: H512;
   }
 
-  /** @name PalletIdentityError (373) */
+  /** @name PalletIdentityError (369) */
   export interface PalletIdentityError extends Enum {
     readonly isAlreadyLinked: boolean;
     readonly isMissingCurrentIdentity: boolean;
@@ -3767,6 +3766,8 @@ declare module '@polkadot/types/lookup' {
     readonly isClaimAndProofVersionsDoNotMatch: boolean;
     readonly isAccountKeyIsBeingUsed: boolean;
     readonly isCustomScopeTooLong: boolean;
+    readonly isCustomClaimTypeAlreadyExists: boolean;
+    readonly isCustomClaimTypeDoesNotExist: boolean;
     readonly type:
       | 'AlreadyLinked'
       | 'MissingCurrentIdentity'
@@ -3800,17 +3801,19 @@ declare module '@polkadot/types/lookup' {
       | 'InvalidCDDId'
       | 'ClaimAndProofVersionsDoNotMatch'
       | 'AccountKeyIsBeingUsed'
-      | 'CustomScopeTooLong';
+      | 'CustomScopeTooLong'
+      | 'CustomClaimTypeAlreadyExists'
+      | 'CustomClaimTypeDoesNotExist';
   }
 
-  /** @name PolymeshCommonUtilitiesGroupInactiveMember (375) */
+  /** @name PolymeshCommonUtilitiesGroupInactiveMember (371) */
   export interface PolymeshCommonUtilitiesGroupInactiveMember extends Struct {
     readonly id: PolymeshPrimitivesIdentityId;
     readonly deactivatedAt: u64;
     readonly expiry: Option<u64>;
   }
 
-  /** @name PalletGroupCall (376) */
+  /** @name PalletGroupCall (372) */
   export interface PalletGroupCall extends Enum {
     readonly isSetActiveMembersLimit: boolean;
     readonly asSetActiveMembersLimit: {
@@ -3850,7 +3853,7 @@ declare module '@polkadot/types/lookup' {
       | 'AbdicateMembership';
   }
 
-  /** @name PalletGroupError (377) */
+  /** @name PalletGroupError (373) */
   export interface PalletGroupError extends Enum {
     readonly isOnlyPrimaryKeyAllowed: boolean;
     readonly isDuplicateMember: boolean;
@@ -3869,7 +3872,7 @@ declare module '@polkadot/types/lookup' {
       | 'ActiveMembersLimitOverflow';
   }
 
-  /** @name PalletCommitteeCall (379) */
+  /** @name PalletCommitteeCall (375) */
   export interface PalletCommitteeCall extends Enum {
     readonly isSetVoteThreshold: boolean;
     readonly asSetVoteThreshold: {
@@ -3903,7 +3906,7 @@ declare module '@polkadot/types/lookup' {
       | 'Vote';
   }
 
-  /** @name PalletMultisigCall (385) */
+  /** @name PalletMultisigCall (381) */
   export interface PalletMultisigCall extends Enum {
     readonly isCreateMultisig: boolean;
     readonly asCreateMultisig: {
@@ -4026,7 +4029,7 @@ declare module '@polkadot/types/lookup' {
       | 'ExecuteScheduledProposal';
   }
 
-  /** @name PalletBridgeCall (386) */
+  /** @name PalletBridgeCall (382) */
   export interface PalletBridgeCall extends Enum {
     readonly isChangeController: boolean;
     readonly asChangeController: {
@@ -4111,7 +4114,7 @@ declare module '@polkadot/types/lookup' {
       | 'RemoveTxs';
   }
 
-  /** @name PalletStakingCall (390) */
+  /** @name PalletStakingCall (386) */
   export interface PalletStakingCall extends Enum {
     readonly isBond: boolean;
     readonly asBond: {
@@ -4282,7 +4285,7 @@ declare module '@polkadot/types/lookup' {
       | 'UpdatePermissionedValidatorIntendedCount';
   }
 
-  /** @name PalletStakingRewardDestination (391) */
+  /** @name PalletStakingRewardDestination (387) */
   export interface PalletStakingRewardDestination extends Enum {
     readonly isStaked: boolean;
     readonly isStash: boolean;
@@ -4292,13 +4295,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Staked' | 'Stash' | 'Controller' | 'Account';
   }
 
-  /** @name PalletStakingValidatorPrefs (392) */
+  /** @name PalletStakingValidatorPrefs (388) */
   export interface PalletStakingValidatorPrefs extends Struct {
     readonly commission: Compact<Perbill>;
     readonly blocked: bool;
   }
 
-  /** @name PalletStakingCompactAssignments (398) */
+  /** @name PalletStakingCompactAssignments (394) */
   export interface PalletStakingCompactAssignments extends Struct {
     readonly votes1: Vec<ITuple<[Compact<u32>, Compact<u16>]>>;
     readonly votes2: Vec<
@@ -4348,20 +4351,20 @@ declare module '@polkadot/types/lookup' {
     >;
   }
 
-  /** @name SpNposElectionsElectionScore (449) */
+  /** @name SpNposElectionsElectionScore (445) */
   export interface SpNposElectionsElectionScore extends Struct {
     readonly minimalStake: u128;
     readonly sumStake: u128;
     readonly sumStakeSquared: u128;
   }
 
-  /** @name PalletStakingElectionSize (450) */
+  /** @name PalletStakingElectionSize (446) */
   export interface PalletStakingElectionSize extends Struct {
     readonly validators: Compact<u16>;
     readonly nominators: Compact<u32>;
   }
 
-  /** @name PalletSessionCall (451) */
+  /** @name PalletSessionCall (447) */
   export interface PalletSessionCall extends Enum {
     readonly isSetKeys: boolean;
     readonly asSetKeys: {
@@ -4372,7 +4375,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'SetKeys' | 'PurgeKeys';
   }
 
-  /** @name PolymeshRuntimeDevelopRuntimeSessionKeys (452) */
+  /** @name PolymeshRuntimeDevelopRuntimeSessionKeys (448) */
   export interface PolymeshRuntimeDevelopRuntimeSessionKeys extends Struct {
     readonly grandpa: SpFinalityGrandpaAppPublic;
     readonly babe: SpConsensusBabeAppPublic;
@@ -4380,10 +4383,10 @@ declare module '@polkadot/types/lookup' {
     readonly authorityDiscovery: SpAuthorityDiscoveryAppPublic;
   }
 
-  /** @name SpAuthorityDiscoveryAppPublic (453) */
+  /** @name SpAuthorityDiscoveryAppPublic (449) */
   export interface SpAuthorityDiscoveryAppPublic extends SpCoreSr25519Public {}
 
-  /** @name PalletGrandpaCall (454) */
+  /** @name PalletGrandpaCall (450) */
   export interface PalletGrandpaCall extends Enum {
     readonly isReportEquivocation: boolean;
     readonly asReportEquivocation: {
@@ -4403,13 +4406,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'ReportEquivocation' | 'ReportEquivocationUnsigned' | 'NoteStalled';
   }
 
-  /** @name SpFinalityGrandpaEquivocationProof (455) */
+  /** @name SpFinalityGrandpaEquivocationProof (451) */
   export interface SpFinalityGrandpaEquivocationProof extends Struct {
     readonly setId: u64;
     readonly equivocation: SpFinalityGrandpaEquivocation;
   }
 
-  /** @name SpFinalityGrandpaEquivocation (456) */
+  /** @name SpFinalityGrandpaEquivocation (452) */
   export interface SpFinalityGrandpaEquivocation extends Enum {
     readonly isPrevote: boolean;
     readonly asPrevote: FinalityGrandpaEquivocationPrevote;
@@ -4418,7 +4421,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Prevote' | 'Precommit';
   }
 
-  /** @name FinalityGrandpaEquivocationPrevote (457) */
+  /** @name FinalityGrandpaEquivocationPrevote (453) */
   export interface FinalityGrandpaEquivocationPrevote extends Struct {
     readonly roundNumber: u64;
     readonly identity: SpFinalityGrandpaAppPublic;
@@ -4426,19 +4429,19 @@ declare module '@polkadot/types/lookup' {
     readonly second: ITuple<[FinalityGrandpaPrevote, SpFinalityGrandpaAppSignature]>;
   }
 
-  /** @name FinalityGrandpaPrevote (458) */
+  /** @name FinalityGrandpaPrevote (454) */
   export interface FinalityGrandpaPrevote extends Struct {
     readonly targetHash: H256;
     readonly targetNumber: u32;
   }
 
-  /** @name SpFinalityGrandpaAppSignature (459) */
+  /** @name SpFinalityGrandpaAppSignature (455) */
   export interface SpFinalityGrandpaAppSignature extends SpCoreEd25519Signature {}
 
-  /** @name SpCoreEd25519Signature (460) */
+  /** @name SpCoreEd25519Signature (456) */
   export interface SpCoreEd25519Signature extends U8aFixed {}
 
-  /** @name FinalityGrandpaEquivocationPrecommit (462) */
+  /** @name FinalityGrandpaEquivocationPrecommit (458) */
   export interface FinalityGrandpaEquivocationPrecommit extends Struct {
     readonly roundNumber: u64;
     readonly identity: SpFinalityGrandpaAppPublic;
@@ -4446,13 +4449,13 @@ declare module '@polkadot/types/lookup' {
     readonly second: ITuple<[FinalityGrandpaPrecommit, SpFinalityGrandpaAppSignature]>;
   }
 
-  /** @name FinalityGrandpaPrecommit (463) */
+  /** @name FinalityGrandpaPrecommit (459) */
   export interface FinalityGrandpaPrecommit extends Struct {
     readonly targetHash: H256;
     readonly targetNumber: u32;
   }
 
-  /** @name PalletImOnlineCall (465) */
+  /** @name PalletImOnlineCall (461) */
   export interface PalletImOnlineCall extends Enum {
     readonly isHeartbeat: boolean;
     readonly asHeartbeat: {
@@ -4462,7 +4465,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Heartbeat';
   }
 
-  /** @name PalletImOnlineHeartbeat (466) */
+  /** @name PalletImOnlineHeartbeat (462) */
   export interface PalletImOnlineHeartbeat extends Struct {
     readonly blockNumber: u32;
     readonly networkState: SpCoreOffchainOpaqueNetworkState;
@@ -4471,19 +4474,19 @@ declare module '@polkadot/types/lookup' {
     readonly validatorsLen: u32;
   }
 
-  /** @name SpCoreOffchainOpaqueNetworkState (467) */
+  /** @name SpCoreOffchainOpaqueNetworkState (463) */
   export interface SpCoreOffchainOpaqueNetworkState extends Struct {
     readonly peerId: Bytes;
     readonly externalAddresses: Vec<Bytes>;
   }
 
-  /** @name PalletImOnlineSr25519AppSr25519Signature (471) */
+  /** @name PalletImOnlineSr25519AppSr25519Signature (467) */
   export interface PalletImOnlineSr25519AppSr25519Signature extends SpCoreSr25519Signature {}
 
-  /** @name SpCoreSr25519Signature (472) */
+  /** @name SpCoreSr25519Signature (468) */
   export interface SpCoreSr25519Signature extends U8aFixed {}
 
-  /** @name PalletSudoCall (473) */
+  /** @name PalletSudoCall (469) */
   export interface PalletSudoCall extends Enum {
     readonly isSudo: boolean;
     readonly asSudo: {
@@ -4506,7 +4509,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Sudo' | 'SudoUncheckedWeight' | 'SetKey' | 'SudoAs';
   }
 
-  /** @name PalletAssetCall (474) */
+  /** @name PalletAssetCall (470) */
   export interface PalletAssetCall extends Enum {
     readonly isRegisterTicker: boolean;
     readonly asRegisterTicker: {
@@ -4640,6 +4643,12 @@ declare module '@polkadot/types/lookup' {
       readonly name: Bytes;
       readonly spec: PolymeshPrimitivesAssetMetadataAssetMetadataSpec;
     } & Struct;
+    readonly isRedeemFromPortfolio: boolean;
+    readonly asRedeemFromPortfolio: {
+      readonly ticker: PolymeshPrimitivesTicker;
+      readonly value: u128;
+      readonly portfolio: PolymeshPrimitivesIdentityIdPortfolioKind;
+    } & Struct;
     readonly type:
       | 'RegisterTicker'
       | 'AcceptTickerTransfer'
@@ -4664,13 +4673,14 @@ declare module '@polkadot/types/lookup' {
       | 'SetAssetMetadataDetails'
       | 'RegisterAndSetLocalAssetMetadata'
       | 'RegisterAssetMetadataLocalType'
-      | 'RegisterAssetMetadataGlobalType';
+      | 'RegisterAssetMetadataGlobalType'
+      | 'RedeemFromPortfolio';
   }
 
-  /** @name PolymeshPrimitivesEthereumEcdsaSignature (477) */
+  /** @name PolymeshPrimitivesEthereumEcdsaSignature (472) */
   export interface PolymeshPrimitivesEthereumEcdsaSignature extends U8aFixed {}
 
-  /** @name PalletAssetClassicTickerImport (479) */
+  /** @name PalletAssetClassicTickerImport (474) */
   export interface PalletAssetClassicTickerImport extends Struct {
     readonly ethOwner: PolymeshPrimitivesEthereumEthereumAddress;
     readonly ticker: PolymeshPrimitivesTicker;
@@ -4678,13 +4688,13 @@ declare module '@polkadot/types/lookup' {
     readonly isCreated: bool;
   }
 
-  /** @name PalletAssetTickerRegistrationConfig (480) */
+  /** @name PalletAssetTickerRegistrationConfig (475) */
   export interface PalletAssetTickerRegistrationConfig extends Struct {
     readonly maxTickerLength: u8;
     readonly registrationLength: Option<u64>;
   }
 
-  /** @name PolymeshPrimitivesAssetMetadataAssetMetadataKey (481) */
+  /** @name PolymeshPrimitivesAssetMetadataAssetMetadataKey (476) */
   export interface PolymeshPrimitivesAssetMetadataAssetMetadataKey extends Enum {
     readonly isGlobal: boolean;
     readonly asGlobal: u64;
@@ -4693,7 +4703,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Global' | 'Local';
   }
 
-  /** @name PalletCorporateActionsDistributionCall (482) */
+  /** @name PalletCorporateActionsDistributionCall (477) */
   export interface PalletCorporateActionsDistributionCall extends Enum {
     readonly isDistribute: boolean;
     readonly asDistribute: {
@@ -4725,7 +4735,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Distribute' | 'Claim' | 'PushBenefit' | 'Reclaim' | 'RemoveDistribution';
   }
 
-  /** @name PalletAssetCheckpointCall (484) */
+  /** @name PalletAssetCheckpointCall (479) */
   export interface PalletAssetCheckpointCall extends Enum {
     readonly isCreateCheckpoint: boolean;
     readonly asCreateCheckpoint: {
@@ -4752,14 +4762,14 @@ declare module '@polkadot/types/lookup' {
       | 'RemoveSchedule';
   }
 
-  /** @name PalletAssetCheckpointScheduleSpec (485) */
+  /** @name PalletAssetCheckpointScheduleSpec (480) */
   export interface PalletAssetCheckpointScheduleSpec extends Struct {
     readonly start: Option<u64>;
     readonly period: PolymeshPrimitivesCalendarCalendarPeriod;
     readonly remaining: u32;
   }
 
-  /** @name PalletComplianceManagerCall (486) */
+  /** @name PalletComplianceManagerCall (481) */
   export interface PalletComplianceManagerCall extends Enum {
     readonly isAddComplianceRequirement: boolean;
     readonly asAddComplianceRequirement: {
@@ -4816,7 +4826,7 @@ declare module '@polkadot/types/lookup' {
       | 'ChangeComplianceRequirement';
   }
 
-  /** @name PalletCorporateActionsCall (487) */
+  /** @name PalletCorporateActionsCall (482) */
   export interface PalletCorporateActionsCall extends Enum {
     readonly isSetMaxDetailsLength: boolean;
     readonly asSetMaxDetailsLength: {
@@ -4885,7 +4895,7 @@ declare module '@polkadot/types/lookup' {
       | 'InitiateCorporateActionAndDistribute';
   }
 
-  /** @name PalletCorporateActionsRecordDateSpec (489) */
+  /** @name PalletCorporateActionsRecordDateSpec (484) */
   export interface PalletCorporateActionsRecordDateSpec extends Enum {
     readonly isScheduled: boolean;
     readonly asScheduled: u64;
@@ -4896,7 +4906,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Scheduled' | 'ExistingSchedule' | 'Existing';
   }
 
-  /** @name PalletCorporateActionsInitiateCorporateActionArgs (492) */
+  /** @name PalletCorporateActionsInitiateCorporateActionArgs (487) */
   export interface PalletCorporateActionsInitiateCorporateActionArgs extends Struct {
     readonly ticker: PolymeshPrimitivesTicker;
     readonly kind: PalletCorporateActionsCaKind;
@@ -4908,7 +4918,7 @@ declare module '@polkadot/types/lookup' {
     readonly withholdingTax: Option<Vec<ITuple<[PolymeshPrimitivesIdentityId, Permill]>>>;
   }
 
-  /** @name PalletCorporateActionsBallotCall (493) */
+  /** @name PalletCorporateActionsBallotCall (488) */
   export interface PalletCorporateActionsBallotCall extends Enum {
     readonly isAttachBallot: boolean;
     readonly asAttachBallot: {
@@ -4950,7 +4960,7 @@ declare module '@polkadot/types/lookup' {
       | 'RemoveBallot';
   }
 
-  /** @name PalletPipsCall (494) */
+  /** @name PalletPipsCall (489) */
   export interface PalletPipsCall extends Enum {
     readonly isSetPruneHistoricalPips: boolean;
     readonly asSetPruneHistoricalPips: {
@@ -5041,7 +5051,7 @@ declare module '@polkadot/types/lookup' {
       | 'ExpireScheduledPip';
   }
 
-  /** @name PalletPipsSnapshotResult (497) */
+  /** @name PalletPipsSnapshotResult (492) */
   export interface PalletPipsSnapshotResult extends Enum {
     readonly isApprove: boolean;
     readonly isReject: boolean;
@@ -5049,7 +5059,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Approve' | 'Reject' | 'Skip';
   }
 
-  /** @name PalletPortfolioCall (498) */
+  /** @name PalletPortfolioCall (493) */
   export interface PalletPortfolioCall extends Enum {
     readonly isCreatePortfolio: boolean;
     readonly asCreatePortfolio: {
@@ -5087,14 +5097,14 @@ declare module '@polkadot/types/lookup' {
       | 'AcceptPortfolioCustody';
   }
 
-  /** @name PalletPortfolioMovePortfolioItem (500) */
+  /** @name PalletPortfolioMovePortfolioItem (495) */
   export interface PalletPortfolioMovePortfolioItem extends Struct {
     readonly ticker: PolymeshPrimitivesTicker;
     readonly amount: u128;
     readonly memo: Option<PolymeshCommonUtilitiesBalancesMemo>;
   }
 
-  /** @name PalletProtocolFeeCall (501) */
+  /** @name PalletProtocolFeeCall (496) */
   export interface PalletProtocolFeeCall extends Enum {
     readonly isChangeCoefficient: boolean;
     readonly asChangeCoefficient: {
@@ -5108,7 +5118,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'ChangeCoefficient' | 'ChangeBaseFee';
   }
 
-  /** @name PolymeshCommonUtilitiesProtocolFeeProtocolOp (502) */
+  /** @name PolymeshCommonUtilitiesProtocolFeeProtocolOp (497) */
   export interface PolymeshCommonUtilitiesProtocolFeeProtocolOp extends Enum {
     readonly isAssetRegisterTicker: boolean;
     readonly isAssetIssue: boolean;
@@ -5139,7 +5149,7 @@ declare module '@polkadot/types/lookup' {
       | 'CapitalDistributionDistribute';
   }
 
-  /** @name PalletSchedulerCall (503) */
+  /** @name PalletSchedulerCall (498) */
   export interface PalletSchedulerCall extends Enum {
     readonly isSchedule: boolean;
     readonly asSchedule: {
@@ -5189,7 +5199,7 @@ declare module '@polkadot/types/lookup' {
       | 'ScheduleNamedAfter';
   }
 
-  /** @name FrameSupportScheduleMaybeHashed (505) */
+  /** @name FrameSupportScheduleMaybeHashed (500) */
   export interface FrameSupportScheduleMaybeHashed extends Enum {
     readonly isValue: boolean;
     readonly asValue: Call;
@@ -5198,7 +5208,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Value' | 'Hash';
   }
 
-  /** @name PalletSettlementCall (506) */
+  /** @name PalletSettlementCall (501) */
   export interface PalletSettlementCall extends Enum {
     readonly isCreateVenue: boolean;
     readonly asCreateVenue: {
@@ -5297,6 +5307,31 @@ declare module '@polkadot/types/lookup' {
     readonly asRescheduleInstruction: {
       readonly id: u64;
     } & Struct;
+    readonly isUpdateVenueSigners: boolean;
+    readonly asUpdateVenueSigners: {
+      readonly id: u64;
+      readonly signers: Vec<AccountId32>;
+      readonly addSigners: bool;
+    } & Struct;
+    readonly isAddInstructionWithMemo: boolean;
+    readonly asAddInstructionWithMemo: {
+      readonly venueId: u64;
+      readonly settlementType: PalletSettlementSettlementType;
+      readonly tradeDate: Option<u64>;
+      readonly valueDate: Option<u64>;
+      readonly legs: Vec<PalletSettlementLeg>;
+      readonly instructionMemo: Option<PalletSettlementInstructionMemo>;
+    } & Struct;
+    readonly isAddAndAffirmInstructionWithMemo: boolean;
+    readonly asAddAndAffirmInstructionWithMemo: {
+      readonly venueId: u64;
+      readonly settlementType: PalletSettlementSettlementType;
+      readonly tradeDate: Option<u64>;
+      readonly valueDate: Option<u64>;
+      readonly legs: Vec<PalletSettlementLeg>;
+      readonly portfolios: Vec<PolymeshPrimitivesIdentityIdPortfolioId>;
+      readonly instructionMemo: Option<PalletSettlementInstructionMemo>;
+    } & Struct;
     readonly type:
       | 'CreateVenue'
       | 'UpdateVenueDetails'
@@ -5314,10 +5349,13 @@ declare module '@polkadot/types/lookup' {
       | 'DisallowVenues'
       | 'ChangeReceiptValidity'
       | 'ExecuteScheduledInstruction'
-      | 'RescheduleInstruction';
+      | 'RescheduleInstruction'
+      | 'UpdateVenueSigners'
+      | 'AddInstructionWithMemo'
+      | 'AddAndAffirmInstructionWithMemo';
   }
 
-  /** @name PalletSettlementReceiptDetails (508) */
+  /** @name PalletSettlementReceiptDetails (503) */
   export interface PalletSettlementReceiptDetails extends Struct {
     readonly receiptUid: u64;
     readonly legId: u64;
@@ -5326,7 +5364,7 @@ declare module '@polkadot/types/lookup' {
     readonly metadata: Bytes;
   }
 
-  /** @name SpRuntimeMultiSignature (509) */
+  /** @name SpRuntimeMultiSignature (504) */
   export interface SpRuntimeMultiSignature extends Enum {
     readonly isEd25519: boolean;
     readonly asEd25519: SpCoreEd25519Signature;
@@ -5337,10 +5375,10 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Ed25519' | 'Sr25519' | 'Ecdsa';
   }
 
-  /** @name SpCoreEcdsaSignature (510) */
+  /** @name SpCoreEcdsaSignature (505) */
   export interface SpCoreEcdsaSignature extends U8aFixed {}
 
-  /** @name PalletStatisticsCall (511) */
+  /** @name PalletStatisticsCall (506) */
   export interface PalletStatisticsCall extends Enum {
     readonly isSetActiveAssetStats: boolean;
     readonly asSetActiveAssetStats: {
@@ -5371,7 +5409,7 @@ declare module '@polkadot/types/lookup' {
       | 'SetEntitiesExempt';
   }
 
-  /** @name PalletStoCall (516) */
+  /** @name PalletStoCall (511) */
   export interface PalletStoCall extends Enum {
     readonly isCreateFundraiser: boolean;
     readonly asCreateFundraiser: {
@@ -5427,13 +5465,13 @@ declare module '@polkadot/types/lookup' {
       | 'Stop';
   }
 
-  /** @name PalletStoPriceTier (518) */
+  /** @name PalletStoPriceTier (513) */
   export interface PalletStoPriceTier extends Struct {
     readonly total: u128;
     readonly price: u128;
   }
 
-  /** @name PalletTreasuryCall (520) */
+  /** @name PalletTreasuryCall (515) */
   export interface PalletTreasuryCall extends Enum {
     readonly isDisbursement: boolean;
     readonly asDisbursement: {
@@ -5446,13 +5484,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Disbursement' | 'Reimbursement';
   }
 
-  /** @name PolymeshPrimitivesBeneficiary (522) */
+  /** @name PolymeshPrimitivesBeneficiary (517) */
   export interface PolymeshPrimitivesBeneficiary extends Struct {
     readonly id: PolymeshPrimitivesIdentityId;
     readonly amount: u128;
   }
 
-  /** @name PalletUtilityCall (523) */
+  /** @name PalletUtilityCall (518) */
   export interface PalletUtilityCall extends Enum {
     readonly isBatch: boolean;
     readonly asBatch: {
@@ -5475,16 +5513,16 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Batch' | 'BatchAtomic' | 'BatchOptimistic' | 'RelayTx';
   }
 
-  /** @name PalletUtilityUniqueCall (525) */
+  /** @name PalletUtilityUniqueCall (520) */
   export interface PalletUtilityUniqueCall extends Struct {
     readonly nonce: u64;
     readonly call: Call;
   }
 
-  /** @name PalletBaseCall (526) */
+  /** @name PalletBaseCall (521) */
   export type PalletBaseCall = Null;
 
-  /** @name PalletExternalAgentsCall (527) */
+  /** @name PalletExternalAgentsCall (522) */
   export interface PalletExternalAgentsCall extends Enum {
     readonly isCreateGroup: boolean;
     readonly asCreateGroup: {
@@ -5520,7 +5558,8 @@ declare module '@polkadot/types/lookup' {
     readonly asCreateGroupAndAddAuth: {
       readonly ticker: PolymeshPrimitivesTicker;
       readonly perms: PolymeshPrimitivesSubsetSubsetRestrictionPalletPermissions;
-      readonly target: PolymeshPrimitivesSecondaryKeySignatory;
+      readonly target: PolymeshPrimitivesIdentityId;
+      readonly expiry: Option<u64>;
     } & Struct;
     readonly isCreateAndChangeCustomGroup: boolean;
     readonly asCreateAndChangeCustomGroup: {
@@ -5539,7 +5578,7 @@ declare module '@polkadot/types/lookup' {
       | 'CreateAndChangeCustomGroup';
   }
 
-  /** @name PalletRelayerCall (528) */
+  /** @name PalletRelayerCall (523) */
   export interface PalletRelayerCall extends Enum {
     readonly isSetPayingKey: boolean;
     readonly asSetPayingKey: {
@@ -5579,7 +5618,7 @@ declare module '@polkadot/types/lookup' {
       | 'DecreasePolyxLimit';
   }
 
-  /** @name PalletRewardsCall (529) */
+  /** @name PalletRewardsCall (524) */
   export interface PalletRewardsCall extends Enum {
     readonly isClaimItnReward: boolean;
     readonly asClaimItnReward: {
@@ -5595,7 +5634,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'ClaimItnReward' | 'SetItnRewardStatus';
   }
 
-  /** @name PalletRewardsItnRewardStatus (530) */
+  /** @name PalletRewardsItnRewardStatus (525) */
   export interface PalletRewardsItnRewardStatus extends Enum {
     readonly isUnclaimed: boolean;
     readonly asUnclaimed: u128;
@@ -5603,30 +5642,30 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Unclaimed' | 'Claimed';
   }
 
-  /** @name PolymeshContractsCall (531) */
-  export interface PolymeshContractsCall extends Enum {
+  /** @name PalletContractsCall (526) */
+  export interface PalletContractsCall extends Enum {
     readonly isCall: boolean;
     readonly asCall: {
-      readonly contract: AccountId32;
-      readonly value: u128;
-      readonly gasLimit: u64;
-      readonly storageDepositLimit: Option<u128>;
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+      readonly gasLimit: Compact<u64>;
+      readonly storageDepositLimit: Option<Compact<u128>>;
       readonly data: Bytes;
     } & Struct;
     readonly isInstantiateWithCode: boolean;
     readonly asInstantiateWithCode: {
-      readonly endowment: u128;
-      readonly gasLimit: u64;
-      readonly storageDepositLimit: Option<u128>;
+      readonly value: Compact<u128>;
+      readonly gasLimit: Compact<u64>;
+      readonly storageDepositLimit: Option<Compact<u128>>;
       readonly code: Bytes;
       readonly data: Bytes;
       readonly salt: Bytes;
     } & Struct;
     readonly isInstantiate: boolean;
     readonly asInstantiate: {
-      readonly endowment: u128;
-      readonly gasLimit: u64;
-      readonly storageDepositLimit: Option<u128>;
+      readonly value: Compact<u128>;
+      readonly gasLimit: Compact<u64>;
+      readonly storageDepositLimit: Option<Compact<u128>>;
       readonly codeHash: H256;
       readonly data: Bytes;
       readonly salt: Bytes;
@@ -5634,12 +5673,17 @@ declare module '@polkadot/types/lookup' {
     readonly isUploadCode: boolean;
     readonly asUploadCode: {
       readonly code: Bytes;
-      readonly storageDepositLimit: Option<u128>;
+      readonly storageDepositLimit: Option<Compact<u128>>;
     } & Struct;
     readonly isRemoveCode: boolean;
     readonly asRemoveCode: {
       readonly codeHash: H256;
     } & Struct;
+    readonly type: 'Call' | 'InstantiateWithCode' | 'Instantiate' | 'UploadCode' | 'RemoveCode';
+  }
+
+  /** @name PolymeshContractsCall (528) */
+  export interface PolymeshContractsCall extends Enum {
     readonly isInstantiateWithCodePerms: boolean;
     readonly asInstantiateWithCodePerms: {
       readonly endowment: u128;
@@ -5660,17 +5704,10 @@ declare module '@polkadot/types/lookup' {
       readonly salt: Bytes;
       readonly perms: PolymeshPrimitivesSecondaryKeyPermissions;
     } & Struct;
-    readonly type:
-      | 'Call'
-      | 'InstantiateWithCode'
-      | 'Instantiate'
-      | 'UploadCode'
-      | 'RemoveCode'
-      | 'InstantiateWithCodePerms'
-      | 'InstantiateWithHashPerms';
+    readonly type: 'InstantiateWithCodePerms' | 'InstantiateWithHashPerms';
   }
 
-  /** @name PalletPreimageCall (532) */
+  /** @name PalletPreimageCall (529) */
   export interface PalletPreimageCall extends Enum {
     readonly isNotePreimage: boolean;
     readonly asNotePreimage: {
@@ -5691,7 +5728,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'NotePreimage' | 'UnnotePreimage' | 'RequestPreimage' | 'UnrequestPreimage';
   }
 
-  /** @name PalletTestUtilsCall (533) */
+  /** @name PalletTestUtilsCall (530) */
   export interface PalletTestUtilsCall extends Enum {
     readonly isRegisterDid: boolean;
     readonly asRegisterDid: {
@@ -5710,7 +5747,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'RegisterDid' | 'MockCddRegisterDid' | 'GetMyDid' | 'GetCddOf';
   }
 
-  /** @name PalletCommitteePolymeshVotes (534) */
+  /** @name PalletCommitteePolymeshVotes (531) */
   export interface PalletCommitteePolymeshVotes extends Struct {
     readonly index: u32;
     readonly ayes: Vec<PolymeshPrimitivesIdentityId>;
@@ -5718,7 +5755,7 @@ declare module '@polkadot/types/lookup' {
     readonly expiry: PolymeshCommonUtilitiesMaybeBlock;
   }
 
-  /** @name PalletCommitteeError (536) */
+  /** @name PalletCommitteeError (533) */
   export interface PalletCommitteeError extends Enum {
     readonly isDuplicateVote: boolean;
     readonly isNotAMember: boolean;
@@ -5741,7 +5778,7 @@ declare module '@polkadot/types/lookup' {
       | 'ProposalsLimitReached';
   }
 
-  /** @name PalletMultisigProposalDetails (546) */
+  /** @name PalletMultisigProposalDetails (543) */
   export interface PalletMultisigProposalDetails extends Struct {
     readonly approvals: u64;
     readonly rejections: u64;
@@ -5750,7 +5787,7 @@ declare module '@polkadot/types/lookup' {
     readonly autoClose: bool;
   }
 
-  /** @name PalletMultisigProposalStatus (547) */
+  /** @name PalletMultisigProposalStatus (544) */
   export interface PalletMultisigProposalStatus extends Enum {
     readonly isInvalid: boolean;
     readonly isActiveOrExpired: boolean;
@@ -5765,7 +5802,7 @@ declare module '@polkadot/types/lookup' {
       | 'Rejected';
   }
 
-  /** @name PalletMultisigError (549) */
+  /** @name PalletMultisigError (546) */
   export interface PalletMultisigError extends Enum {
     readonly isCddMissing: boolean;
     readonly isProposalMissing: boolean;
@@ -5820,7 +5857,7 @@ declare module '@polkadot/types/lookup' {
       | 'TooManySigners';
   }
 
-  /** @name PalletBridgeBridgeTxDetail (551) */
+  /** @name PalletBridgeBridgeTxDetail (548) */
   export interface PalletBridgeBridgeTxDetail extends Struct {
     readonly amount: u128;
     readonly status: PalletBridgeBridgeTxStatus;
@@ -5828,7 +5865,7 @@ declare module '@polkadot/types/lookup' {
     readonly txHash: H256;
   }
 
-  /** @name PalletBridgeBridgeTxStatus (552) */
+  /** @name PalletBridgeBridgeTxStatus (549) */
   export interface PalletBridgeBridgeTxStatus extends Enum {
     readonly isAbsent: boolean;
     readonly isPending: boolean;
@@ -5839,7 +5876,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Absent' | 'Pending' | 'Frozen' | 'Timelocked' | 'Handled';
   }
 
-  /** @name PalletBridgeError (555) */
+  /** @name PalletBridgeError (552) */
   export interface PalletBridgeError extends Enum {
     readonly isControllerNotSet: boolean;
     readonly isBadCaller: boolean;
@@ -5870,7 +5907,7 @@ declare module '@polkadot/types/lookup' {
       | 'TimelockedTx';
   }
 
-  /** @name PalletStakingStakingLedger (556) */
+  /** @name PalletStakingStakingLedger (553) */
   export interface PalletStakingStakingLedger extends Struct {
     readonly stash: AccountId32;
     readonly total: Compact<u128>;
@@ -5879,32 +5916,32 @@ declare module '@polkadot/types/lookup' {
     readonly claimedRewards: Vec<u32>;
   }
 
-  /** @name PalletStakingUnlockChunk (558) */
+  /** @name PalletStakingUnlockChunk (555) */
   export interface PalletStakingUnlockChunk extends Struct {
     readonly value: Compact<u128>;
     readonly era: Compact<u32>;
   }
 
-  /** @name PalletStakingNominations (559) */
+  /** @name PalletStakingNominations (556) */
   export interface PalletStakingNominations extends Struct {
     readonly targets: Vec<AccountId32>;
     readonly submittedIn: u32;
     readonly suppressed: bool;
   }
 
-  /** @name PalletStakingActiveEraInfo (560) */
+  /** @name PalletStakingActiveEraInfo (557) */
   export interface PalletStakingActiveEraInfo extends Struct {
     readonly index: u32;
     readonly start: Option<u64>;
   }
 
-  /** @name PalletStakingEraRewardPoints (562) */
+  /** @name PalletStakingEraRewardPoints (559) */
   export interface PalletStakingEraRewardPoints extends Struct {
     readonly total: u32;
     readonly individual: BTreeMap<AccountId32, u32>;
   }
 
-  /** @name PalletStakingForcing (565) */
+  /** @name PalletStakingForcing (562) */
   export interface PalletStakingForcing extends Enum {
     readonly isNotForcing: boolean;
     readonly isForceNew: boolean;
@@ -5913,7 +5950,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'NotForcing' | 'ForceNew' | 'ForceNone' | 'ForceAlways';
   }
 
-  /** @name PalletStakingUnappliedSlash (567) */
+  /** @name PalletStakingUnappliedSlash (564) */
   export interface PalletStakingUnappliedSlash extends Struct {
     readonly validator: AccountId32;
     readonly own: u128;
@@ -5922,7 +5959,7 @@ declare module '@polkadot/types/lookup' {
     readonly payout: u128;
   }
 
-  /** @name PalletStakingSlashingSlashingSpans (571) */
+  /** @name PalletStakingSlashingSlashingSpans (568) */
   export interface PalletStakingSlashingSlashingSpans extends Struct {
     readonly spanIndex: u32;
     readonly lastStart: u32;
@@ -5930,20 +5967,20 @@ declare module '@polkadot/types/lookup' {
     readonly prior: Vec<u32>;
   }
 
-  /** @name PalletStakingSlashingSpanRecord (572) */
+  /** @name PalletStakingSlashingSpanRecord (569) */
   export interface PalletStakingSlashingSpanRecord extends Struct {
     readonly slashed: u128;
     readonly paidOut: u128;
   }
 
-  /** @name PalletStakingElectionResult (573) */
+  /** @name PalletStakingElectionResult (572) */
   export interface PalletStakingElectionResult extends Struct {
     readonly electedStashes: Vec<AccountId32>;
     readonly exposures: Vec<ITuple<[AccountId32, PalletStakingExposure]>>;
     readonly compute: PalletStakingElectionCompute;
   }
 
-  /** @name PalletStakingElectionStatus (574) */
+  /** @name PalletStakingElectionStatus (573) */
   export interface PalletStakingElectionStatus extends Enum {
     readonly isClosed: boolean;
     readonly isOpen: boolean;
@@ -5951,13 +5988,13 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Closed' | 'Open';
   }
 
-  /** @name PalletStakingPermissionedIdentityPrefs (575) */
+  /** @name PalletStakingPermissionedIdentityPrefs (574) */
   export interface PalletStakingPermissionedIdentityPrefs extends Struct {
     readonly intendedCount: u32;
     readonly runningCount: u32;
   }
 
-  /** @name PalletStakingReleases (576) */
+  /** @name PalletStakingReleases (575) */
   export interface PalletStakingReleases extends Enum {
     readonly isV100Ancient: boolean;
     readonly isV200: boolean;
@@ -5970,7 +6007,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'V100Ancient' | 'V200' | 'V300' | 'V400' | 'V500' | 'V600' | 'V601' | 'V700';
   }
 
-  /** @name PalletStakingError (577) */
+  /** @name PalletStakingError (576) */
   export interface PalletStakingError extends Enum {
     readonly isNotController: boolean;
     readonly isNotStash: boolean;
@@ -6059,16 +6096,16 @@ declare module '@polkadot/types/lookup' {
       | 'BadTarget';
   }
 
-  /** @name SpStakingOffenceOffenceDetails (578) */
+  /** @name SpStakingOffenceOffenceDetails (577) */
   export interface SpStakingOffenceOffenceDetails extends Struct {
     readonly offender: ITuple<[AccountId32, PalletStakingExposure]>;
     readonly reporters: Vec<AccountId32>;
   }
 
-  /** @name SpCoreCryptoKeyTypeId (583) */
+  /** @name SpCoreCryptoKeyTypeId (582) */
   export interface SpCoreCryptoKeyTypeId extends U8aFixed {}
 
-  /** @name PalletSessionError (584) */
+  /** @name PalletSessionError (583) */
   export interface PalletSessionError extends Enum {
     readonly isInvalidProof: boolean;
     readonly isNoAssociatedValidatorId: boolean;
@@ -6083,7 +6120,7 @@ declare module '@polkadot/types/lookup' {
       | 'NoAccount';
   }
 
-  /** @name PalletGrandpaStoredState (585) */
+  /** @name PalletGrandpaStoredState (584) */
   export interface PalletGrandpaStoredState extends Enum {
     readonly isLive: boolean;
     readonly isPendingPause: boolean;
@@ -6100,7 +6137,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Live' | 'PendingPause' | 'Paused' | 'PendingResume';
   }
 
-  /** @name PalletGrandpaStoredPendingChange (586) */
+  /** @name PalletGrandpaStoredPendingChange (585) */
   export interface PalletGrandpaStoredPendingChange extends Struct {
     readonly scheduledAt: u32;
     readonly delay: u32;
@@ -6108,7 +6145,7 @@ declare module '@polkadot/types/lookup' {
     readonly forced: Option<u32>;
   }
 
-  /** @name PalletGrandpaError (588) */
+  /** @name PalletGrandpaError (587) */
   export interface PalletGrandpaError extends Enum {
     readonly isPauseFailed: boolean;
     readonly isResumeFailed: boolean;
@@ -6127,32 +6164,32 @@ declare module '@polkadot/types/lookup' {
       | 'DuplicateOffenceReport';
   }
 
-  /** @name PalletImOnlineBoundedOpaqueNetworkState (592) */
+  /** @name PalletImOnlineBoundedOpaqueNetworkState (591) */
   export interface PalletImOnlineBoundedOpaqueNetworkState extends Struct {
     readonly peerId: Bytes;
     readonly externalAddresses: Vec<Bytes>;
   }
 
-  /** @name PalletImOnlineError (596) */
+  /** @name PalletImOnlineError (595) */
   export interface PalletImOnlineError extends Enum {
     readonly isInvalidKey: boolean;
     readonly isDuplicatedHeartbeat: boolean;
     readonly type: 'InvalidKey' | 'DuplicatedHeartbeat';
   }
 
-  /** @name PalletSudoError (598) */
+  /** @name PalletSudoError (597) */
   export interface PalletSudoError extends Enum {
     readonly isRequireSudo: boolean;
     readonly type: 'RequireSudo';
   }
 
-  /** @name PalletAssetTickerRegistration (599) */
+  /** @name PalletAssetTickerRegistration (598) */
   export interface PalletAssetTickerRegistration extends Struct {
     readonly owner: PolymeshPrimitivesIdentityId;
     readonly expiry: Option<u64>;
   }
 
-  /** @name PalletAssetSecurityToken (600) */
+  /** @name PalletAssetSecurityToken (599) */
   export interface PalletAssetSecurityToken extends Struct {
     readonly totalSupply: u128;
     readonly ownerDid: PolymeshPrimitivesIdentityId;
@@ -6160,7 +6197,7 @@ declare module '@polkadot/types/lookup' {
     readonly assetType: PolymeshPrimitivesAssetAssetType;
   }
 
-  /** @name PalletAssetAssetOwnershipRelation (604) */
+  /** @name PalletAssetAssetOwnershipRelation (603) */
   export interface PalletAssetAssetOwnershipRelation extends Enum {
     readonly isNotOwned: boolean;
     readonly isTickerOwned: boolean;
@@ -6168,18 +6205,15 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'NotOwned' | 'TickerOwned' | 'AssetOwned';
   }
 
-  /** @name PalletAssetClassicTickerRegistration (606) */
+  /** @name PalletAssetClassicTickerRegistration (605) */
   export interface PalletAssetClassicTickerRegistration extends Struct {
     readonly ethOwner: PolymeshPrimitivesEthereumEthereumAddress;
     readonly isCreated: bool;
   }
 
-  /** @name PalletAssetError (612) */
+  /** @name PalletAssetError (611) */
   export interface PalletAssetError extends Enum {
     readonly isUnauthorized: boolean;
-    readonly isAlreadyArchived: boolean;
-    readonly isAlreadyUnArchived: boolean;
-    readonly isExtensionAlreadyPresent: boolean;
     readonly isAssetAlreadyCreated: boolean;
     readonly isTickerTooLong: boolean;
     readonly isTickerNotAscii: boolean;
@@ -6195,8 +6229,6 @@ declare module '@polkadot/types/lookup' {
     readonly isInvalidTransfer: boolean;
     readonly isInsufficientBalance: boolean;
     readonly isAssetAlreadyDivisible: boolean;
-    readonly isMaximumTMExtensionLimitReached: boolean;
-    readonly isIncompatibleExtensionVersion: boolean;
     readonly isInvalidEthereumSignature: boolean;
     readonly isNoSuchClassicTicker: boolean;
     readonly isTickerRegistrationExpired: boolean;
@@ -6216,9 +6248,6 @@ declare module '@polkadot/types/lookup' {
     readonly isAssetMetadataGlobalKeyAlreadyExists: boolean;
     readonly type:
       | 'Unauthorized'
-      | 'AlreadyArchived'
-      | 'AlreadyUnArchived'
-      | 'ExtensionAlreadyPresent'
       | 'AssetAlreadyCreated'
       | 'TickerTooLong'
       | 'TickerNotAscii'
@@ -6234,8 +6263,6 @@ declare module '@polkadot/types/lookup' {
       | 'InvalidTransfer'
       | 'InsufficientBalance'
       | 'AssetAlreadyDivisible'
-      | 'MaximumTMExtensionLimitReached'
-      | 'IncompatibleExtensionVersion'
       | 'InvalidEthereumSignature'
       | 'NoSuchClassicTicker'
       | 'TickerRegistrationExpired'
@@ -6255,7 +6282,7 @@ declare module '@polkadot/types/lookup' {
       | 'AssetMetadataGlobalKeyAlreadyExists';
   }
 
-  /** @name PalletCorporateActionsDistributionError (615) */
+  /** @name PalletCorporateActionsDistributionError (614) */
   export interface PalletCorporateActionsDistributionError extends Enum {
     readonly isCaNotBenefit: boolean;
     readonly isAlreadyExists: boolean;
@@ -6290,7 +6317,7 @@ declare module '@polkadot/types/lookup' {
       | 'DistributionPerShareIsZero';
   }
 
-  /** @name PalletAssetCheckpointError (622) */
+  /** @name PalletAssetCheckpointError (621) */
   export interface PalletAssetCheckpointError extends Enum {
     readonly isNoSuchSchedule: boolean;
     readonly isScheduleNotRemovable: boolean;
@@ -6305,13 +6332,13 @@ declare module '@polkadot/types/lookup' {
       | 'SchedulesTooComplex';
   }
 
-  /** @name PolymeshPrimitivesComplianceManagerAssetCompliance (623) */
+  /** @name PolymeshPrimitivesComplianceManagerAssetCompliance (622) */
   export interface PolymeshPrimitivesComplianceManagerAssetCompliance extends Struct {
     readonly paused: bool;
     readonly requirements: Vec<PolymeshPrimitivesComplianceManagerComplianceRequirement>;
   }
 
-  /** @name PalletComplianceManagerError (625) */
+  /** @name PalletComplianceManagerError (624) */
   export interface PalletComplianceManagerError extends Enum {
     readonly isUnauthorized: boolean;
     readonly isDidNotExist: boolean;
@@ -6328,7 +6355,7 @@ declare module '@polkadot/types/lookup' {
       | 'ComplianceRequirementTooComplex';
   }
 
-  /** @name PalletCorporateActionsError (628) */
+  /** @name PalletCorporateActionsError (627) */
   export interface PalletCorporateActionsError extends Enum {
     readonly isAuthNotCAATransfer: boolean;
     readonly isDetailsTooLong: boolean;
@@ -6357,7 +6384,7 @@ declare module '@polkadot/types/lookup' {
       | 'NotTargetedByCA';
   }
 
-  /** @name PalletCorporateActionsBallotError (630) */
+  /** @name PalletCorporateActionsBallotError (629) */
   export interface PalletCorporateActionsBallotError extends Enum {
     readonly isCaNotNotice: boolean;
     readonly isAlreadyExists: boolean;
@@ -6390,13 +6417,13 @@ declare module '@polkadot/types/lookup' {
       | 'RcvNotAllowed';
   }
 
-  /** @name PalletPermissionsError (631) */
+  /** @name PalletPermissionsError (630) */
   export interface PalletPermissionsError extends Enum {
     readonly isUnauthorizedCaller: boolean;
     readonly type: 'UnauthorizedCaller';
   }
 
-  /** @name PalletPipsPipsMetadata (632) */
+  /** @name PalletPipsPipsMetadata (631) */
   export interface PalletPipsPipsMetadata extends Struct {
     readonly id: u32;
     readonly url: Option<Bytes>;
@@ -6406,21 +6433,20 @@ declare module '@polkadot/types/lookup' {
     readonly expiry: PolymeshCommonUtilitiesMaybeBlock;
   }
 
-  /** @name PalletPipsDepositInfo (634) */
+  /** @name PalletPipsDepositInfo (633) */
   export interface PalletPipsDepositInfo extends Struct {
     readonly owner: AccountId32;
     readonly amount: u128;
   }
 
-  /** @name PalletPipsPip (635) */
+  /** @name PalletPipsPip (634) */
   export interface PalletPipsPip extends Struct {
     readonly id: u32;
     readonly proposal: Call;
-    readonly state: PalletPipsProposalState;
     readonly proposer: PalletPipsProposer;
   }
 
-  /** @name PalletPipsVotingResult (636) */
+  /** @name PalletPipsVotingResult (635) */
   export interface PalletPipsVotingResult extends Struct {
     readonly ayesCount: u32;
     readonly ayesStake: u128;
@@ -6428,17 +6454,17 @@ declare module '@polkadot/types/lookup' {
     readonly naysStake: u128;
   }
 
-  /** @name PalletPipsVote (637) */
+  /** @name PalletPipsVote (636) */
   export interface PalletPipsVote extends ITuple<[bool, u128]> {}
 
-  /** @name PalletPipsSnapshotMetadata (638) */
+  /** @name PalletPipsSnapshotMetadata (637) */
   export interface PalletPipsSnapshotMetadata extends Struct {
     readonly createdAt: u32;
     readonly madeBy: AccountId32;
     readonly id: u32;
   }
 
-  /** @name PalletPipsError (640) */
+  /** @name PalletPipsError (639) */
   export interface PalletPipsError extends Enum {
     readonly isRescheduleNotByReleaseCoordinator: boolean;
     readonly isNotFromCommunity: boolean;
@@ -6479,7 +6505,7 @@ declare module '@polkadot/types/lookup' {
       | 'ProposalNotInScheduledState';
   }
 
-  /** @name PalletPortfolioError (646) */
+  /** @name PalletPortfolioError (645) */
   export interface PalletPortfolioError extends Enum {
     readonly isPortfolioDoesNotExist: boolean;
     readonly isInsufficientPortfolioBalance: boolean;
@@ -6502,7 +6528,7 @@ declare module '@polkadot/types/lookup' {
       | 'DifferentIdentityPortfolios';
   }
 
-  /** @name PalletProtocolFeeError (647) */
+  /** @name PalletProtocolFeeError (646) */
   export interface PalletProtocolFeeError extends Enum {
     readonly isInsufficientAccountBalance: boolean;
     readonly isUnHandledImbalances: boolean;
@@ -6513,7 +6539,7 @@ declare module '@polkadot/types/lookup' {
       | 'InsufficientSubsidyBalance';
   }
 
-  /** @name PalletSchedulerScheduledV3 (650) */
+  /** @name PalletSchedulerScheduledV3 (649) */
   export interface PalletSchedulerScheduledV3 extends Struct {
     readonly maybeId: Option<Bytes>;
     readonly priority: u8;
@@ -6522,7 +6548,7 @@ declare module '@polkadot/types/lookup' {
     readonly origin: PolymeshRuntimeDevelopRuntimeOriginCaller;
   }
 
-  /** @name PolymeshRuntimeDevelopRuntimeOriginCaller (651) */
+  /** @name PolymeshRuntimeDevelopRuntimeOriginCaller (650) */
   export interface PolymeshRuntimeDevelopRuntimeOriginCaller extends Enum {
     readonly isSystem: boolean;
     readonly asSystem: FrameSupportDispatchRawOrigin;
@@ -6541,7 +6567,7 @@ declare module '@polkadot/types/lookup' {
       | 'UpgradeCommittee';
   }
 
-  /** @name FrameSupportDispatchRawOrigin (652) */
+  /** @name FrameSupportDispatchRawOrigin (651) */
   export interface FrameSupportDispatchRawOrigin extends Enum {
     readonly isRoot: boolean;
     readonly isSigned: boolean;
@@ -6550,28 +6576,28 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Root' | 'Signed' | 'None';
   }
 
-  /** @name PalletCommitteeRawOriginInstance1 (653) */
+  /** @name PalletCommitteeRawOriginInstance1 (652) */
   export interface PalletCommitteeRawOriginInstance1 extends Enum {
     readonly isEndorsed: boolean;
     readonly type: 'Endorsed';
   }
 
-  /** @name PalletCommitteeRawOriginInstance3 (654) */
+  /** @name PalletCommitteeRawOriginInstance3 (653) */
   export interface PalletCommitteeRawOriginInstance3 extends Enum {
     readonly isEndorsed: boolean;
     readonly type: 'Endorsed';
   }
 
-  /** @name PalletCommitteeRawOriginInstance4 (655) */
+  /** @name PalletCommitteeRawOriginInstance4 (654) */
   export interface PalletCommitteeRawOriginInstance4 extends Enum {
     readonly isEndorsed: boolean;
     readonly type: 'Endorsed';
   }
 
-  /** @name SpCoreVoid (656) */
+  /** @name SpCoreVoid (655) */
   export type SpCoreVoid = Null;
 
-  /** @name PalletSchedulerError (657) */
+  /** @name PalletSchedulerError (656) */
   export interface PalletSchedulerError extends Enum {
     readonly isFailedToSchedule: boolean;
     readonly isNotFound: boolean;
@@ -6584,13 +6610,13 @@ declare module '@polkadot/types/lookup' {
       | 'RescheduleNoChange';
   }
 
-  /** @name PalletSettlementVenue (658) */
+  /** @name PalletSettlementVenue (657) */
   export interface PalletSettlementVenue extends Struct {
     readonly creator: PolymeshPrimitivesIdentityId;
     readonly venueType: PalletSettlementVenueType;
   }
 
-  /** @name PalletSettlementInstruction (661) */
+  /** @name PalletSettlementInstruction (660) */
   export interface PalletSettlementInstruction extends Struct {
     readonly instructionId: u64;
     readonly venueId: u64;
@@ -6601,7 +6627,7 @@ declare module '@polkadot/types/lookup' {
     readonly valueDate: Option<u64>;
   }
 
-  /** @name PalletSettlementInstructionStatus (662) */
+  /** @name PalletSettlementInstructionStatus (661) */
   export interface PalletSettlementInstructionStatus extends Enum {
     readonly isUnknown: boolean;
     readonly isPending: boolean;
@@ -6609,7 +6635,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Unknown' | 'Pending' | 'Failed';
   }
 
-  /** @name PalletSettlementLegStatus (664) */
+  /** @name PalletSettlementLegStatus (663) */
   export interface PalletSettlementLegStatus extends Enum {
     readonly isPendingTokenLock: boolean;
     readonly isExecutionPending: boolean;
@@ -6618,7 +6644,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'PendingTokenLock' | 'ExecutionPending' | 'ExecutionToBeSkipped';
   }
 
-  /** @name PalletSettlementAffirmationStatus (666) */
+  /** @name PalletSettlementAffirmationStatus (665) */
   export interface PalletSettlementAffirmationStatus extends Enum {
     readonly isUnknown: boolean;
     readonly isPending: boolean;
@@ -6626,7 +6652,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Unknown' | 'Pending' | 'Affirmed';
   }
 
-  /** @name PalletSettlementError (670) */
+  /** @name PalletSettlementError (669) */
   export interface PalletSettlementError extends Enum {
     readonly isInvalidVenue: boolean;
     readonly isUnauthorized: boolean;
@@ -6653,6 +6679,9 @@ declare module '@polkadot/types/lookup' {
     readonly isLegCountTooSmall: boolean;
     readonly isUnknownInstruction: boolean;
     readonly isInstructionHasTooManyLegs: boolean;
+    readonly isSignerAlreadyExists: boolean;
+    readonly isSignerDoesNotExist: boolean;
+    readonly isZeroAmount: boolean;
     readonly type:
       | 'InvalidVenue'
       | 'Unauthorized'
@@ -6678,22 +6707,25 @@ declare module '@polkadot/types/lookup' {
       | 'FailedToSchedule'
       | 'LegCountTooSmall'
       | 'UnknownInstruction'
-      | 'InstructionHasTooManyLegs';
+      | 'InstructionHasTooManyLegs'
+      | 'SignerAlreadyExists'
+      | 'SignerDoesNotExist'
+      | 'ZeroAmount';
   }
 
-  /** @name PolymeshPrimitivesStatisticsStat1stKey (672) */
+  /** @name PolymeshPrimitivesStatisticsStat1stKey (671) */
   export interface PolymeshPrimitivesStatisticsStat1stKey extends Struct {
     readonly asset: PolymeshPrimitivesStatisticsAssetScope;
     readonly statType: PolymeshPrimitivesStatisticsStatType;
   }
 
-  /** @name PolymeshPrimitivesTransferComplianceAssetTransferCompliance (673) */
+  /** @name PolymeshPrimitivesTransferComplianceAssetTransferCompliance (672) */
   export interface PolymeshPrimitivesTransferComplianceAssetTransferCompliance extends Struct {
     readonly paused: bool;
     readonly requirements: BTreeSet<PolymeshPrimitivesTransferComplianceTransferCondition>;
   }
 
-  /** @name PalletStatisticsError (676) */
+  /** @name PalletStatisticsError (675) */
   export interface PalletStatisticsError extends Enum {
     readonly isInvalidTransfer: boolean;
     readonly isStatTypeMissing: boolean;
@@ -6710,7 +6742,7 @@ declare module '@polkadot/types/lookup' {
       | 'TransferConditionLimitReached';
   }
 
-  /** @name PalletStoError (678) */
+  /** @name PalletStoError (677) */
   export interface PalletStoError extends Enum {
     readonly isUnauthorized: boolean;
     readonly isOverflow: boolean;
@@ -6739,14 +6771,14 @@ declare module '@polkadot/types/lookup' {
       | 'InvestmentAmountTooLow';
   }
 
-  /** @name PalletTreasuryError (679) */
+  /** @name PalletTreasuryError (678) */
   export interface PalletTreasuryError extends Enum {
     readonly isInsufficientBalance: boolean;
     readonly isInvalidIdentity: boolean;
     readonly type: 'InsufficientBalance' | 'InvalidIdentity';
   }
 
-  /** @name PalletUtilityError (680) */
+  /** @name PalletUtilityError (679) */
   export interface PalletUtilityError extends Enum {
     readonly isInvalidSignature: boolean;
     readonly isTargetCddMissing: boolean;
@@ -6754,14 +6786,14 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'InvalidSignature' | 'TargetCddMissing' | 'InvalidNonce';
   }
 
-  /** @name PalletBaseError (681) */
+  /** @name PalletBaseError (680) */
   export interface PalletBaseError extends Enum {
     readonly isTooLong: boolean;
     readonly isCounterOverflow: boolean;
     readonly type: 'TooLong' | 'CounterOverflow';
   }
 
-  /** @name PalletExternalAgentsError (683) */
+  /** @name PalletExternalAgentsError (682) */
   export interface PalletExternalAgentsError extends Enum {
     readonly isNoSuchAG: boolean;
     readonly isUnauthorizedAgent: boolean;
@@ -6778,13 +6810,13 @@ declare module '@polkadot/types/lookup' {
       | 'SecondaryKeyNotAuthorizedForAsset';
   }
 
-  /** @name PalletRelayerSubsidy (684) */
+  /** @name PalletRelayerSubsidy (683) */
   export interface PalletRelayerSubsidy extends Struct {
     readonly payingKey: AccountId32;
     readonly remaining: u128;
   }
 
-  /** @name PalletRelayerError (685) */
+  /** @name PalletRelayerError (684) */
   export interface PalletRelayerError extends Enum {
     readonly isUserKeyCddMissing: boolean;
     readonly isPayingKeyCddMissing: boolean;
@@ -6803,7 +6835,7 @@ declare module '@polkadot/types/lookup' {
       | 'Overflow';
   }
 
-  /** @name PalletRewardsError (686) */
+  /** @name PalletRewardsError (685) */
   export interface PalletRewardsError extends Enum {
     readonly isUnknownItnAddress: boolean;
     readonly isItnRewardAlreadyClaimed: boolean;
@@ -6816,7 +6848,7 @@ declare module '@polkadot/types/lookup' {
       | 'UnableToCovertBalance';
   }
 
-  /** @name PalletContractsWasmPrefabWasmModule (687) */
+  /** @name PalletContractsWasmPrefabWasmModule (686) */
   export interface PalletContractsWasmPrefabWasmModule extends Struct {
     readonly instructionWeightsVersion: Compact<u32>;
     readonly initial: Compact<u32>;
@@ -6824,33 +6856,33 @@ declare module '@polkadot/types/lookup' {
     readonly code: Bytes;
   }
 
-  /** @name PalletContractsWasmOwnerInfo (688) */
+  /** @name PalletContractsWasmOwnerInfo (687) */
   export interface PalletContractsWasmOwnerInfo extends Struct {
     readonly owner: AccountId32;
     readonly deposit: Compact<u128>;
     readonly refcount: Compact<u64>;
   }
 
-  /** @name PalletContractsStorageRawContractInfo (689) */
+  /** @name PalletContractsStorageRawContractInfo (688) */
   export interface PalletContractsStorageRawContractInfo extends Struct {
     readonly trieId: Bytes;
     readonly codeHash: H256;
     readonly storageDeposit: u128;
   }
 
-  /** @name PalletContractsStorageDeletedContract (691) */
+  /** @name PalletContractsStorageDeletedContract (690) */
   export interface PalletContractsStorageDeletedContract extends Struct {
     readonly trieId: Bytes;
   }
 
-  /** @name PalletContractsSchedule (692) */
+  /** @name PalletContractsSchedule (691) */
   export interface PalletContractsSchedule extends Struct {
     readonly limits: PalletContractsScheduleLimits;
     readonly instructionWeights: PalletContractsScheduleInstructionWeights;
     readonly hostFnWeights: PalletContractsScheduleHostFnWeights;
   }
 
-  /** @name PalletContractsScheduleLimits (693) */
+  /** @name PalletContractsScheduleLimits (692) */
   export interface PalletContractsScheduleLimits extends Struct {
     readonly eventTopics: u32;
     readonly stackHeight: Option<u32>;
@@ -6865,7 +6897,7 @@ declare module '@polkadot/types/lookup' {
     readonly codeLen: u32;
   }
 
-  /** @name PalletContractsScheduleInstructionWeights (694) */
+  /** @name PalletContractsScheduleInstructionWeights (693) */
   export interface PalletContractsScheduleInstructionWeights extends Struct {
     readonly version: u32;
     readonly i64const: u32;
@@ -6921,7 +6953,7 @@ declare module '@polkadot/types/lookup' {
     readonly i64rotr: u32;
   }
 
-  /** @name PalletContractsScheduleHostFnWeights (695) */
+  /** @name PalletContractsScheduleHostFnWeights (694) */
   export interface PalletContractsScheduleHostFnWeights extends Struct {
     readonly caller: u64;
     readonly isContract: u64;
@@ -6979,7 +7011,7 @@ declare module '@polkadot/types/lookup' {
     readonly ecdsaToEthAddress: u64;
   }
 
-  /** @name PalletContractsError (696) */
+  /** @name PalletContractsError (695) */
   export interface PalletContractsError extends Enum {
     readonly isInvalidScheduleVersion: boolean;
     readonly isInvalidCallFlags: boolean;
@@ -7042,7 +7074,7 @@ declare module '@polkadot/types/lookup' {
       | 'CodeRejected';
   }
 
-  /** @name PolymeshContractsError (697) */
+  /** @name PolymeshContractsError (696) */
   export interface PolymeshContractsError extends Enum {
     readonly isRuntimeCallNotFound: boolean;
     readonly isDataLeftAfterDecoding: boolean;
@@ -7055,7 +7087,7 @@ declare module '@polkadot/types/lookup' {
       | 'InstantiatorWithNoIdentity';
   }
 
-  /** @name PalletPreimageRequestStatus (698) */
+  /** @name PalletPreimageRequestStatus (697) */
   export interface PalletPreimageRequestStatus extends Enum {
     readonly isUnrequested: boolean;
     readonly asUnrequested: Option<ITuple<[AccountId32, u128]>>;
@@ -7064,7 +7096,7 @@ declare module '@polkadot/types/lookup' {
     readonly type: 'Unrequested' | 'Requested';
   }
 
-  /** @name PalletPreimageError (701) */
+  /** @name PalletPreimageError (700) */
   export interface PalletPreimageError extends Enum {
     readonly isTooLarge: boolean;
     readonly isAlreadyNoted: boolean;
@@ -7081,33 +7113,33 @@ declare module '@polkadot/types/lookup' {
       | 'NotRequested';
   }
 
-  /** @name PalletTestUtilsError (702) */
+  /** @name PalletTestUtilsError (701) */
   export type PalletTestUtilsError = Null;
 
-  /** @name FrameSystemExtensionsCheckSpecVersion (705) */
+  /** @name FrameSystemExtensionsCheckSpecVersion (704) */
   export type FrameSystemExtensionsCheckSpecVersion = Null;
 
-  /** @name FrameSystemExtensionsCheckTxVersion (706) */
+  /** @name FrameSystemExtensionsCheckTxVersion (705) */
   export type FrameSystemExtensionsCheckTxVersion = Null;
 
-  /** @name FrameSystemExtensionsCheckGenesis (707) */
+  /** @name FrameSystemExtensionsCheckGenesis (706) */
   export type FrameSystemExtensionsCheckGenesis = Null;
 
-  /** @name FrameSystemExtensionsCheckNonce (710) */
+  /** @name FrameSystemExtensionsCheckNonce (709) */
   export interface FrameSystemExtensionsCheckNonce extends Compact<u32> {}
 
-  /** @name PolymeshExtensionsCheckWeight (711) */
+  /** @name PolymeshExtensionsCheckWeight (710) */
   export interface PolymeshExtensionsCheckWeight extends FrameSystemExtensionsCheckWeight {}
 
-  /** @name FrameSystemExtensionsCheckWeight (712) */
+  /** @name FrameSystemExtensionsCheckWeight (711) */
   export type FrameSystemExtensionsCheckWeight = Null;
 
-  /** @name PalletTransactionPaymentChargeTransactionPayment (713) */
+  /** @name PalletTransactionPaymentChargeTransactionPayment (712) */
   export interface PalletTransactionPaymentChargeTransactionPayment extends Compact<u128> {}
 
-  /** @name PalletPermissionsStoreCallMetadata (714) */
+  /** @name PalletPermissionsStoreCallMetadata (713) */
   export type PalletPermissionsStoreCallMetadata = Null;
 
-  /** @name PolymeshRuntimeDevelopRuntime (715) */
+  /** @name PolymeshRuntimeDevelopRuntime (714) */
   export type PolymeshRuntimeDevelopRuntime = Null;
 } // declare module

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -45,8 +45,8 @@ import {
   SignedBlock,
 } from '@polkadot/types/interfaces';
 import {
-  ConfidentialIdentityClaimProofsScopeClaimProof,
-  ConfidentialIdentityClaimProofsZkProofData,
+  ConfidentialIdentityV2ClaimProofsScopeClaimProof,
+  ConfidentialIdentityV2ClaimProofsZkProofData,
   PalletAssetClassicTickerRegistration,
   PalletCorporateActionsCaId,
   PalletCorporateActionsCaKind,
@@ -3462,13 +3462,13 @@ export const createMockSignature = (signature?: string | Signature): MockCodec<S
  */
 export const createMockZkProofData = (
   zkProofData?:
-    | ConfidentialIdentityClaimProofsZkProofData
+    | ConfidentialIdentityV2ClaimProofsZkProofData
     | {
         challengeResponses: [Scalar, Scalar] | [string, string];
         subtractExpressionsRes: RistrettoPoint | string;
         blindedScopeDidHash: RistrettoPoint | string;
       }
-): MockCodec<ConfidentialIdentityClaimProofsZkProofData> => {
+): MockCodec<ConfidentialIdentityV2ClaimProofsZkProofData> => {
   const { challengeResponses, subtractExpressionsRes, blindedScopeDidHash } = zkProofData || {
     challengeResponses: [createMockScalar(), createMockScalar()],
     subtractExpressionsRes: createMockRistrettoPoint(),
@@ -3534,7 +3534,7 @@ export const createMockTargetIdentities = (
  */
 export const createMockScopeClaimProof = (
   scopeClaimProof?:
-    | ConfidentialIdentityClaimProofsScopeClaimProof
+    | ConfidentialIdentityV2ClaimProofsScopeClaimProof
     | {
         proofScopeIdWellformed: Signature | string;
         proofScopeIdCddIdMatch:
@@ -3546,7 +3546,7 @@ export const createMockScopeClaimProof = (
             };
         scopeId: RistrettoPoint | string;
       }
-): MockCodec<ConfidentialIdentityClaimProofsScopeClaimProof> => {
+): MockCodec<ConfidentialIdentityV2ClaimProofsScopeClaimProof> => {
   const { proofScopeIdWellformed, proofScopeIdCddIdMatch, scopeId } = scopeClaimProof || {
     proofScopeIdWellformed: createMockSignature(),
     proofScopeIdCddIdMatch: createMockZkProofData(),
@@ -3557,7 +3557,7 @@ export const createMockScopeClaimProof = (
     {
       proofScopeIdWellformed: createMockSignature(proofScopeIdWellformed as Signature),
       proofScopeIdCddIdMatch: createMockZkProofData(
-        proofScopeIdCddIdMatch as ConfidentialIdentityClaimProofsZkProofData
+        proofScopeIdCddIdMatch as ConfidentialIdentityV2ClaimProofsZkProofData
       ),
       scopeId: createMockRistrettoPoint(scopeId as RistrettoPoint),
     },

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -7523,7 +7523,7 @@ describe('scopeClaimProofToConfidentialIdentityClaimProof', () => {
     context.createType.withArgs('RistrettoPoint', scopeId).returns(rawScopeId);
 
     context.createType
-      .withArgs('ConfidentialIdentityClaimProofsScopeClaimProof', scopeClaimProof)
+      .withArgs('ConfidentialIdentityV2ClaimProofsScopeClaimProof', scopeClaimProof)
       .returns(fakeResult);
 
     const result = scopeClaimProofToConfidentialIdentityClaimProof(proof, scopeId, context);

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -1079,12 +1079,12 @@ describe('assertExpectedChainVersion', () => {
 
   it('should log a warning given a minor or patch RPC node version mismatch', async () => {
     const signal = assertExpectedChainVersion('ws://example.com');
-    client.sendSpecVersion('5000002');
-    client.sendRpcVersion('5.1.0');
+    client.sendSpecVersion('5001000');
+    client.sendRpcVersion('5.1.7');
     await signal;
     sinon.assert.calledWith(
       warnStub,
-      'This version of the SDK supports Polymesh RPC node version 5.0.2. The node is at version 5.1.0. Please upgrade the SDK'
+      'This version of the SDK supports Polymesh RPC node version 5.1.0. The node is at version 5.1.7. Please upgrade the SDK'
     );
   });
 
@@ -1100,12 +1100,12 @@ describe('assertExpectedChainVersion', () => {
 
   it('should log a warning given a minor or patch chain spec version mismatch', async () => {
     const signal = assertExpectedChainVersion('ws://example.com');
-    client.sendSpecVersion('5001000');
-    client.sendRpcVersion('5.0.2');
+    client.sendSpecVersion('5001007');
+    client.sendRpcVersion('5.1.0');
     await signal;
     sinon.assert.calledWith(
       warnStub,
-      'This version of the SDK supports Polymesh chain spec version 5.0.2. The chain spec is at version 5.1.0. Please upgrade the SDK'
+      'This version of the SDK supports Polymesh chain spec version 5.1.0. The chain spec is at version 5.1.7. Please upgrade the SDK'
     );
   });
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -109,12 +109,12 @@ export const ROOT_TYPES = rootTypes;
 /**
  * The Polymesh RPC node version range that is compatible with this version of the SDK
  */
-export const SUPPORTED_NODE_VERSION_RANGE = '5.0.2';
+export const SUPPORTED_NODE_VERSION_RANGE = '5.1.0';
 
 /**
  * The Polymesh chain spec version range that is compatible with this version of the SDK
  */
-export const SUPPORTED_SPEC_VERSION_RANGE = '5.0.2';
+export const SUPPORTED_SPEC_VERSION_RANGE = '5.1.0';
 
 export const SYSTEM_VERSION_RPC_CALL = {
   jsonrpc: '2.0',

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -8,7 +8,7 @@ import {
   Signature,
 } from '@polkadot/types/interfaces';
 import {
-  ConfidentialIdentityClaimProofsScopeClaimProof,
+  ConfidentialIdentityV2ClaimProofsScopeClaimProof,
   PalletCorporateActionsCaId,
   PalletCorporateActionsCorporateAction,
   PalletCorporateActionsDistribution,
@@ -3594,7 +3594,7 @@ export function scopeClaimProofToConfidentialIdentityClaimProof(
   proof: ScopeClaimProof,
   scopeId: string,
   context: Context
-): ConfidentialIdentityClaimProofsScopeClaimProof {
+): ConfidentialIdentityV2ClaimProofsScopeClaimProof {
   const {
     proofScopeIdWellFormed,
     proofScopeIdCddIdMatch: { challengeResponses, subtractExpressionsRes, blindedScopeDidHash },
@@ -3608,7 +3608,7 @@ export function scopeClaimProofToConfidentialIdentityClaimProof(
     /* eslint-enable @typescript-eslint/naming-convention */
   });
 
-  return context.createType('ConfidentialIdentityClaimProofsScopeClaimProof', {
+  return context.createType('ConfidentialIdentityV2ClaimProofsScopeClaimProof', {
     proofScopeIdWellformed: stringToSignature(proofScopeIdWellFormed, context),
     proofScopeIdCddIdMatch: zkProofData,
     scopeId: stringToRistrettoPoint(scopeId, context),


### PR DESCRIPTION
### Description

* Update types and definitions using latest polymesh_schema
* Refactors all ConfidentialIdentity types with ConfidentialIdentityV2 types
* Pass `IdentityId` instead of `Signatory` for target attribute for `createGroupAndAddAuth` tx
* Use `signatory` from entry arguments instead of the query response in `multiSig.multiSigSigners` query
* Update chain and spec version supported by SDK to 5.1.0

### Breaking Changes

NA

### JIRA Link

DA-423

### Checklist

- [ ] Updated the Readme.md (if required) ?
