### PR TITLE
chore: 🤖 Get rid of polkadot js warning

### DIFF
--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -146,6 +146,12 @@ export class Polymesh {
         provider: new WsProvider(nodeUrl),
         types,
         rpc,
+        signedExtensions: {
+          StoreCallMetadata: {
+            extrinsic: {},
+            payload: {},
+          },
+        },
       });
 
       context = await Context.create({

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -140,18 +140,13 @@ export class Polymesh {
     await assertExpectedChainVersion(nodeUrl);
 
     try {
-      const { types, rpc } = schema;
+      const { types, rpc, signedExtensions } = schema;
 
       const polymeshApi = await ApiPromise.create({
         provider: new WsProvider(nodeUrl),
         types,
         rpc,
-        signedExtensions: {
-          StoreCallMetadata: {
-            extrinsic: {},
-            payload: {},
-          },
-        },
+        signedExtensions,
       });
 
       context = await Context.create({

--- a/src/polkadot/augment-api-rpc.ts
+++ b/src/polkadot/augment-api-rpc.ts
@@ -107,6 +107,7 @@ import type {
   GranularCanTransferResult,
   IdentityId,
   KeyIdentityData,
+  Member,
   PipId,
   PortfolioId,
   ProtocolOp,
@@ -765,6 +766,20 @@ declare module '@polkadot/rpc-core/types/jsonrpc' {
        * Subscribes to grandpa justifications
        **/
       subscribeJustifications: AugmentedRpc<() => Observable<JustificationNotification>>;
+    };
+    group: {
+      /**
+       * Get the CDD members
+       **/
+      getCDDValidMembers: AugmentedRpc<
+        (blockHash?: Hash | string | Uint8Array) => Observable<Vec<Member>>
+      >;
+      /**
+       * Get the GC members
+       **/
+      getGCValidMembers: AugmentedRpc<
+        (blockHash?: Hash | string | Uint8Array) => Observable<Vec<Member>>
+      >;
     };
     identity: {
       /**

--- a/src/polkadot/augment-types.ts
+++ b/src/polkadot/augment-types.ts
@@ -1141,6 +1141,7 @@ import type {
   LegStatus,
   LocalCAId,
   MaybeBlock,
+  Member,
   Memo,
   Motion,
   MotionInfoLink,
@@ -1822,6 +1823,7 @@ declare module '@polkadot/types/types/registry' {
     MaybeBlock: MaybeBlock;
     MaybeRandomness: MaybeRandomness;
     MaybeVrf: MaybeVrf;
+    Member: Member;
     MemberCount: MemberCount;
     MembershipProof: MembershipProof;
     Memo: Memo;

--- a/src/polkadot/definitions.ts
+++ b/src/polkadot/definitions.ts
@@ -7,3 +7,4 @@ export { default as pips } from './pips/definitions';
 export { default as protocolFee } from './protocolFee/definitions';
 export { default as staking } from './staking/definitions';
 export { default as asset } from './asset/definitions';
+export { default as group } from './group/definitions';

--- a/src/polkadot/group/definitions.ts
+++ b/src/polkadot/group/definitions.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+export default {
+  rpc: {
+    getCDDValidMembers: {
+      description: 'Get the CDD members',
+      params: [
+        {
+          name: 'blockHash',
+          type: 'Hash',
+          isOptional: true,
+        },
+      ],
+      type: 'Vec<Member>',
+    },
+    getGCValidMembers: {
+      description: 'Get the GC members',
+      params: [
+        {
+          name: 'blockHash',
+          type: 'Hash',
+          isOptional: true,
+        },
+      ],
+      type: 'Vec<Member>',
+    },
+  },
+  types: {},
+};

--- a/src/polkadot/group/index.ts
+++ b/src/polkadot/group/index.ts
@@ -1,0 +1,4 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+export * from './types';

--- a/src/polkadot/group/types.ts
+++ b/src/polkadot/group/types.ts
@@ -1,0 +1,4 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+export type PHANTOM_GROUP = 'group';

--- a/src/polkadot/polymesh/definitions.ts
+++ b/src/polkadot/polymesh/definitions.ts
@@ -1170,6 +1170,11 @@ export default {
         PolymeshV1PIA: '',
       },
     },
+    Member: {
+      id: 'IdentityId',
+      expiry_at: 'Option<Moment>',
+      inactive_from: 'Option<Moment>',
+    },
     ItnRewardStatus: {
       _enum: {
         Unclaimed: 'Balance',

--- a/src/polkadot/polymesh/types.ts
+++ b/src/polkadot/polymesh/types.ts
@@ -1409,6 +1409,13 @@ export interface MaybeBlock extends Enum {
   readonly type: 'Some' | 'None';
 }
 
+/** @name Member */
+export interface Member extends Struct {
+  readonly id: IdentityId;
+  readonly expiry_at: Option<Moment>;
+  readonly inactive_from: Option<Moment>;
+}
+
 /** @name Memo */
 export interface Memo extends U8aFixed {}
 

--- a/src/polkadot/schema.ts
+++ b/src/polkadot/schema.ts
@@ -1491,5 +1491,17 @@ export default {
         type: 'GranularCanTransferResult',
       },
     },
+    group: {
+      getCDDValidMembers: {
+        description: 'Something',
+        params: [],
+        type: 'Vec<Member>',
+      },
+      getGCValidMembers: {
+        description: 'Something',
+        params: [],
+        type: 'Vec<Member>',
+      },
+    },
   },
 };

--- a/src/polkadot/schema.ts
+++ b/src/polkadot/schema.ts
@@ -1169,6 +1169,11 @@ export default {
         PolymeshV1PIA: '',
       },
     },
+    Member: {
+      id: 'IdentityId',
+      expiry_at: 'Option<Moment>',
+      inactive_from: 'Option<Moment>',
+    },
     ItnRewardStatus: {
       _enum: {
         Unclaimed: 'Balance',
@@ -1493,15 +1498,33 @@ export default {
     },
     group: {
       getCDDValidMembers: {
-        description: 'Something',
-        params: [],
+        description: 'Get the CDD members',
+        params: [
+          {
+            name: 'blockHash',
+            type: 'Hash',
+            isOptional: true,
+          },
+        ],
         type: 'Vec<Member>',
       },
       getGCValidMembers: {
-        description: 'Something',
-        params: [],
+        description: 'Get the GC members',
+        params: [
+          {
+            name: 'blockHash',
+            type: 'Hash',
+            isOptional: true,
+          },
+        ],
         type: 'Vec<Member>',
       },
+    },
+  },
+  signedExtensions: {
+    StoreCallMetadata: {
+      extrinsic: {},
+      payload: {},
     },
   },
 };

--- a/src/polkadot/types.ts
+++ b/src/polkadot/types.ts
@@ -8,3 +8,4 @@ export * from './pips/types';
 export * from './protocolFee/types';
 export * from './staking/types';
 export * from './asset/types';
+export * from './group/types';


### PR DESCRIPTION
### Description

On running the SDK, following warning were logged in console - 
```
2022-10-07 16:38:14        REGISTRY: Unknown signed extensions StoreCallMetadata found, treating them as no-effect
2022-10-07 16:38:14        API/INIT: RPC methods not decorated: group_getCDDValidMembers, group_getGCValidMembers
2022-10-07 16:38:15        REGISTRY: Unknown signed extensions StoreCallMetadata found, treating them as no-effect
```

Apparently, group pallet was missing and polkadot wasn't able to find the custom signed extension.

Updated rpcs to with missing group pallet and passed custom signed extensions while initialising polkadot

### Breaking Changes

NA

### JIRA Link

DA-431

### Checklist

- [ ] Updated the Readme.md (if required) ?
