### PR TITLE
fix: 🐛 Update the logic around `agIdSequence`

### DIFF
--- a/scripts/postProcessTypes.js
+++ b/scripts/postProcessTypes.js
@@ -2,12 +2,6 @@ const path = require('path');
 const replace = require('replace-in-file');
 const definitionsDir = path.resolve('src', 'polkadot');
 
-replace.sync({
-  files: path.resolve(definitionsDir, 'augment-api-query.ts'),
-  from: [/agIdSequence/g, /caIdSequence/g, /caDocLink/g],
-  to: ['aGIdSequence', 'cAIdSequence', 'cADocLink'],
-});
-
 // Add in import for modified schema
 replace.sync({
   files: path.resolve(definitionsDir, 'augment-api-rpc.ts'),

--- a/src/api/entities/CustomPermissionGroup.ts
+++ b/src/api/entities/CustomPermissionGroup.ts
@@ -98,12 +98,12 @@ export class CustomPermissionGroup extends PermissionGroup {
       context,
     } = this;
 
-    const nextId = await context.polymeshApi.query.externalAgents.aGIdSequence(
+    const currentId = await context.polymeshApi.query.externalAgents.agIdSequence(
       stringToTicker(ticker, context)
     );
 
-    // 1 < id < next
-    return u32ToBigNumber(nextId).gt(id) && id.gte(1);
+    // 1 <= id <= currentId
+    return u32ToBigNumber(currentId).gte(id) && id.gte(1);
   }
 
   /**

--- a/src/api/entities/__tests__/CustomPermissionGroup.ts
+++ b/src/api/entities/__tests__/CustomPermissionGroup.ts
@@ -145,14 +145,20 @@ describe('CustomPermissionGroup class', () => {
     it('should return whether the Custom Permission Group exists', async () => {
       const customPermissionGroup = new CustomPermissionGroup({ id, ticker }, context);
 
-      dsMockUtils.createQueryStub('externalAgents', 'aGIdSequence', {
+      dsMockUtils.createQueryStub('externalAgents', 'agIdSequence', {
         returnValue: dsMockUtils.createMockU32(new BigNumber(0)),
       });
 
       await expect(customPermissionGroup.exists()).resolves.toBe(false);
 
-      dsMockUtils.createQueryStub('externalAgents', 'aGIdSequence', {
+      dsMockUtils.createQueryStub('externalAgents', 'agIdSequence', {
         returnValue: dsMockUtils.createMockU32(new BigNumber(10)),
+      });
+
+      await expect(customPermissionGroup.exists()).resolves.toBe(true);
+
+      dsMockUtils.createQueryStub('externalAgents', 'agIdSequence', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(1)),
       });
 
       await expect(customPermissionGroup.exists()).resolves.toBe(true);

--- a/src/polkadot/augment-api-query.ts
+++ b/src/polkadot/augment-api-query.ts
@@ -982,7 +982,7 @@ declare module '@polkadot/api-base/types/storage' {
        * The `CorporateActions` map stores `Ticker => LocalId => The CA`,
        * so we can infer `Ticker => CAId`. Therefore, we don't need a double map.
        **/
-      cADocLink: AugmentedQuery<
+      caDocLink: AugmentedQuery<
         ApiType,
         (
           arg: PalletCorporateActionsCaId | { ticker?: any; localId?: any } | string | Uint8Array
@@ -993,7 +993,7 @@ declare module '@polkadot/api-base/types/storage' {
        * The next per-`Ticker` CA ID in the sequence.
        * The full ID is defined as a combination of `Ticker` and a number in this sequence.
        **/
-      cAIdSequence: AugmentedQuery<
+      caIdSequence: AugmentedQuery<
         ApiType,
         (arg: PolymeshPrimitivesTicker | string | Uint8Array) => Observable<u32>,
         [PolymeshPrimitivesTicker]
@@ -1188,7 +1188,7 @@ declare module '@polkadot/api-base/types/storage' {
        * The full ID is defined as a combination of `Ticker` and a number in this sequence,
        * which starts from 1, rather than 0.
        **/
-      aGIdSequence: AugmentedQuery<
+      agIdSequence: AugmentedQuery<
         ApiType,
         (arg: PolymeshPrimitivesTicker | string | Uint8Array) => Observable<u32>,
         [PolymeshPrimitivesTicker]


### PR DESCRIPTION
### Description

This prevents `CustomPermissionGroup.exists()` from breaking for id equal to max sequence value and also removes post processing of query states. 

Error - 
```
TypeError: context.polymeshApi.query.externalAgents.aGIdSequence is not a function
```

### Breaking Changes

NA

### JIRA Link

DA-443

### Checklist

- [ ] Updated the Readme.md (if required) ?
