### PR TITLE
feat: 🎸 Support account type string for secondary accounts

### DIFF
--- a/src/api/client/AccountManagement.ts
+++ b/src/api/client/AccountManagement.ts
@@ -26,7 +26,7 @@ import {
   UnsubCallback,
 } from '~/types';
 import { stringToAccountId } from '~/utils/conversion';
-import { createProcedureMethod } from '~/utils/internal';
+import { asAccount, createProcedureMethod } from '~/utils/internal';
 
 /**
  * Handles functionality related to Account Management
@@ -206,8 +206,8 @@ export class AccountManagement {
 
     if (!account) {
       account = context.getSigningAccount();
-    } else if (typeof account === 'string') {
-      account = new Account({ address: account }, context);
+    } else {
+      account = asAccount(account, context);
     }
 
     if (cb) {

--- a/src/api/procedures/inviteAccount.ts
+++ b/src/api/procedures/inviteAccount.ts
@@ -1,5 +1,5 @@
 import { createAuthorizationResolver } from '~/api/procedures/utils';
-import { Account, AuthorizationRequest, PolymeshError, Procedure } from '~/internal';
+import { AuthorizationRequest, PolymeshError, Procedure } from '~/internal';
 import {
   Authorization,
   AuthorizationType,
@@ -18,7 +18,7 @@ import {
   signerToString,
   signerValueToSignatory,
 } from '~/utils/conversion';
-import { optionize } from '~/utils/internal';
+import { asAccount, optionize } from '~/utils/internal';
 
 /**
  * @hidden
@@ -40,13 +40,7 @@ export async function prepareInviteAccount(
 
   const address = signerToString(targetAccount);
 
-  let account: Account;
-
-  if (targetAccount instanceof Account) {
-    account = targetAccount;
-  } else {
-    account = new Account({ address: targetAccount }, context);
-  }
+  const account = asAccount(targetAccount, context);
 
   const [authorizationRequests, existingIdentity] = await Promise.all([
     identity.authorizations.getSent(),

--- a/src/api/procedures/modifySignerPermissions.ts
+++ b/src/api/procedures/modifySignerPermissions.ts
@@ -9,7 +9,7 @@ import {
   signerToSignerValue,
   signerValueToSignatory,
 } from '~/utils/conversion';
-import { getSecondaryAccountPermissions } from '~/utils/internal';
+import { asAccount, getSecondaryAccountPermissions } from '~/utils/internal';
 
 /**
  * @hidden
@@ -34,7 +34,7 @@ export async function prepareModifySignerPermissions(
   } = this;
 
   const { secondaryAccounts } = args;
-  const accounts = secondaryAccounts.map(({ account }) => account);
+  const accounts = secondaryAccounts.map(({ account }) => asAccount(account, context));
   const existingSecondaryAccounts = await getSecondaryAccountPermissions(
     { accounts, identity },
     context
@@ -46,7 +46,10 @@ export async function prepareModifySignerPermissions(
 
     const rawPermissions = permissionsToMeshPermissions(permissions, context);
 
-    return tuple(signerValueToSignatory(signerToSignerValue(account), context), rawPermissions);
+    return tuple(
+      signerValueToSignatory(signerToSignerValue(asAccount(account, context)), context),
+      rawPermissions
+    );
   });
 
   const transaction = tx.identity.setPermissionToSigner;

--- a/src/api/procedures/subsidizeAccount.ts
+++ b/src/api/procedures/subsidizeAccount.ts
@@ -1,5 +1,5 @@
 import { createAuthorizationResolver } from '~/api/procedures/utils';
-import { Account, AuthorizationRequest, PolymeshError, Procedure } from '~/internal';
+import { AuthorizationRequest, PolymeshError, Procedure } from '~/internal';
 import {
   AddRelayerPayingKeyAuthorizationData,
   AuthorizationType,
@@ -9,6 +9,7 @@ import {
 } from '~/types';
 import { ExtrinsicParams, TransactionSpec } from '~/types/internal';
 import { bigNumberToBalance, signerToString, stringToAccountId } from '~/utils/conversion';
+import { asAccount } from '~/utils/internal';
 
 /**
  * @hidden
@@ -26,13 +27,7 @@ export async function prepareSubsidizeAccount(
 
   const { beneficiary, allowance } = args;
 
-  let account: Account;
-
-  if (beneficiary instanceof Account) {
-    account = beneficiary;
-  } else {
-    account = new Account({ address: beneficiary }, context);
-  }
+  const account = asAccount(beneficiary, context);
 
   const { address: beneficiaryAddress } = account;
 

--- a/src/api/procedures/transferPolyx.ts
+++ b/src/api/procedures/transferPolyx.ts
@@ -1,4 +1,4 @@
-import { Account, PolymeshError, Procedure } from '~/internal';
+import { PolymeshError, Procedure } from '~/internal';
 import { ErrorCode, TransferPolyxParams, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import {
@@ -7,6 +7,7 @@ import {
   stringToAccountId,
   stringToMemo,
 } from '~/utils/conversion';
+import { asAccount } from '~/utils/internal';
 
 /**
  * @hidden
@@ -27,13 +28,7 @@ export async function prepareTransferPolyx(
 
   const { to, amount, memo } = args;
 
-  let toAccount: Account;
-
-  if (to instanceof Account) {
-    toAccount = to;
-  } else {
-    toAccount = new Account({ address: to }, context);
-  }
+  const toAccount = asAccount(to, context);
 
   const rawAccountId = stringToAccountId(signerToString(to), context);
 

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -239,7 +239,10 @@ export interface ModifySignerPermissionsParams {
   /**
    * list of secondary Accounts
    */
-  secondaryAccounts: Modify<PermissionedAccount, { permissions: PermissionsLike }>[];
+  secondaryAccounts: Modify<
+    PermissionedAccount,
+    { account: string | Account; permissions: PermissionsLike }
+  >[];
 }
 
 export interface RemoveSecondaryAccountsParams {

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -10,7 +10,7 @@ import BigNumber from 'bignumber.js';
 import { IdentityId } from 'polymesh-types/types';
 import sinon from 'sinon';
 
-import { Asset, Context, Identity, PolymeshError, Procedure } from '~/internal';
+import { Account, Asset, Context, Identity, PolymeshError, Procedure } from '~/internal';
 import { ClaimScopeTypeEnum } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
 import {
@@ -20,7 +20,6 @@ import {
   MockWebSocket,
 } from '~/testUtils/mocks/dataSources';
 import {
-  Account,
   CaCheckpointType,
   CalendarPeriod,
   CalendarUnit,
@@ -41,6 +40,7 @@ import { MAX_TICKER_LENGTH } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';
 
 import {
+  asAccount,
   assertAddressValid,
   assertExpectedChainVersion,
   assertIsInteger,
@@ -77,9 +77,14 @@ import {
   sliceBatchReceipt,
   unserialize,
 } from '../internal';
+
 jest.mock(
   '~/api/entities/Asset',
   require('~/testUtils/mocks/entities').mockAssetModule('~/api/entities/Asset')
+);
+jest.mock(
+  '~/api/entities/Account',
+  require('~/testUtils/mocks/entities').mockAccountModule('~/api/entities/Account')
 );
 jest.mock('websocket', require('~/testUtils/mocks/dataSources').mockWebSocketModule());
 
@@ -188,6 +193,43 @@ describe('getDid', () => {
     const result = await getDid(undefined, context);
 
     expect(result).toBe((await context.getSigningIdentity()).did);
+  });
+});
+
+describe('asAccount', () => {
+  let context: Context;
+  let address: string;
+  let account: Account;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    address = 'someAddress';
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+    account = new Account({ address }, context);
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should return Account for given address', async () => {
+    const result = asAccount(address, context);
+
+    expect(result).toEqual(expect.objectContaining({ address }));
+  });
+
+  it('should return the passed Account', async () => {
+    const result = asAccount(account, context);
+
+    expect(result).toBe(account);
   });
 });
 

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -27,6 +27,7 @@ import { major, satisfies } from 'semver';
 import { w3cwebsocket as W3CWebSocket } from 'websocket';
 
 import {
+  Account,
   Asset,
   Checkpoint,
   CheckpointSchedule,
@@ -36,7 +37,6 @@ import {
 } from '~/internal';
 import { Scope as MiddlewareScope } from '~/middleware/types';
 import {
-  Account,
   CaCheckpointType,
   CalendarPeriod,
   CalendarUnit,
@@ -179,6 +179,14 @@ export async function getDid(
  */
 export function asIdentity(value: string | Identity, context: Context): Identity {
   return typeof value === 'string' ? new Identity({ did: value }, context) : value;
+}
+
+/**
+ * @hidden
+ * Given an address return the corresponding Account, given an Account return the Account
+ */
+export function asAccount(value: string | Account, context: Context): Account {
+  return typeof value === 'string' ? new Account({ address: value }, context) : value;
 }
 
 /**


### PR DESCRIPTION

### Description

Changes the account type in `ModifySignerPermissionsParams` from `Account` to `string | Account`. This allows us to pass address of the account directly while modifying/revoking permissions for a secondary account.

This change is required for REST API

### Breaking Changes

NA

### JIRA Link

DA-47

### Checklist

- [ ] Updated the Readme.md (if required) ?
