### PR TITLE
fix: 🐛 move patch-package to dependency from devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "jest": "28.1.3",
     "lint-staged": "11.0.0",
     "os-browserify": "^0.3.0",
-    "patch-package": "^6.5.0",
     "path-browserify": "^1.0.1",
     "prettier": "2.5.1",
     "prettier-eslint": "13.0.0",
@@ -126,6 +125,7 @@
     "iso-7064": "^1.0.2",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.15",
+    "patch-package": "^6.5.0",
     "semver": "^7.3.5",
     "websocket": "^1.0.31"
   },


### PR DESCRIPTION
### Description

as a dev dependency users need patch-package installed globally when installing

### Breaking Changes

None

### JIRA Link

None

### Checklist

- [ ] Updated the Readme.md (if required) ?
