### PR TITLE
fix: 🐛 Handle queryMulti params correctly

### DIFF
--- a/src/api/procedures/__tests__/registerMetadata.ts
+++ b/src/api/procedures/__tests__/registerMetadata.ts
@@ -105,9 +105,11 @@ describe('registerMetadata procedure', () => {
       name,
       specs: {},
     };
+
     dsMockUtils.createQueryMock('asset', 'assetMetadataGlobalNameToKey');
     dsMockUtils.createQueryMock('asset', 'assetMetadataLocalNameToKey');
     queryMultiMock = dsMockUtils.getQueryMultiMock();
+
     registerAssetMetadataLocalTypeTxMock = dsMockUtils.createTxMock(
       'asset',
       'registerAssetMetadataLocalType'

--- a/src/api/procedures/registerMetadata.ts
+++ b/src/api/procedures/registerMetadata.ts
@@ -79,7 +79,7 @@ export async function prepareRegisterMetadata(
     [typeof assetMetadataGlobalNameToKey, typeof assetMetadataLocalNameToKey]
   >(context, [
     [assetMetadataGlobalNameToKey, rawName],
-    [assetMetadataLocalNameToKey, rawTicker, rawName],
+    [assetMetadataLocalNameToKey, [rawTicker, rawName]],
   ]);
 
   if (rawGlobalId.isSome || rawLocalId.isSome) {

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -528,7 +528,11 @@ export async function getApiAtBlock(
 
 type QueryMultiParam<T extends AugmentedQuery<'promise', AnyFunction>[]> = {
   [index in keyof T]: T[index] extends AugmentedQuery<'promise', infer Fun>
-    ? [T[index], ...Parameters<Fun>]
+    ? Fun extends (firstArg: infer First, ...restArg: infer Rest) => ReturnType<Fun>
+      ? Rest extends never[]
+        ? [T[index], First]
+        : [T[index], Parameters<Fun>]
+      : never
     : never;
 };
 


### PR DESCRIPTION
### Description

Following error was currently thrown 
```
2022-11-29 16:38:36             VEC: Unable to decode on index 1 Expected an array of 2 values as params to a Map query
2022-11-29 16:38:36        RPC-CORE: subscribeStorage(keys?: Vec<StorageKey>): StorageChangeSet:: createType(Vec<StorageKey>):: Expected an array of 2 values as params to a Map query
2022-11-29 16:38:36             DRR: createType(Vec<StorageKey>):: Expected an array of 2 values as params to a Map query

~/polymesh-rest-api-cloned/node_modules/@polkadot/types-create/cjs/create/type.js:73
    firstError = new Error(`createType(${type}):: ${error.message}`);
                 ^
Error: createType(Vec<StorageKey>):: Expected an array of 2 values as params to a Map query
```

`queryMulti` expects an array of arguments with query storage allows more than one arguments. This change fixes the generic type for `requestMulti` internal function to infer the same. 

### Breaking Changes

NA

### JIRA Link

DA-452

### Checklist

- [ ] Updated the Readme.md (if required) ?
