### PR TITLE
feat: 🎸 Add Subsidies namespace

### DIFF
--- a/src/api/entities/Account.ts
+++ b/src/api/entities/Account.ts
@@ -321,6 +321,8 @@ export class Account extends Entity<UniqueIdentifiers, string> {
    *   this Account isn't being subsidized, return null
    *
    * @note can be subscribed to
+   *
+   * @deprecated in favour of {@link api/entities/Subsidies!Subsidies.getSubsidizer | subsidies.getSubsidizer}
    */
   public getSubsidy(): Promise<SubsidyWithAllowance | null>;
   public getSubsidy(callback: SubCallback<SubsidyWithAllowance | null>): Promise<UnsubCallback>;

--- a/src/api/entities/Account.ts
+++ b/src/api/entities/Account.ts
@@ -11,6 +11,7 @@ import {
   union,
 } from 'lodash';
 
+import { Subsidies } from '~/api/entities/Subsidies';
 import {
   Asset,
   Authorizations,
@@ -276,6 +277,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
 
   // Namespaces
   public authorizations: Authorizations<Account>;
+  public subsidies: Subsidies;
 
   /**
    * @hidden
@@ -290,6 +292,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
     this.address = address;
     this.key = addressToKey(address, context);
     this.authorizations = new Authorizations(this, context);
+    this.subsidies = new Subsidies(this, context);
   }
 
   /**

--- a/src/api/entities/Subsidies.ts
+++ b/src/api/entities/Subsidies.ts
@@ -1,0 +1,79 @@
+import { Account, Namespace, Subsidy } from '~/internal';
+import { SubCallback, SubsidyWithAllowance, UnsubCallback } from '~/types';
+import { accountIdToString, balanceToBigNumber, stringToAccountId } from '~/utils/conversion';
+
+/**
+ * Handles all Account Subsidies related functionality
+ */
+export class Subsidies extends Namespace<Account> {
+  /**
+   * Get the list of Subsidy relationship along with their subsidized amount for which this Account is the subsidizer
+   */
+  public async getBeneficiaries(): Promise<SubsidyWithAllowance[]> {
+    const {
+      context: {
+        polymeshApi: {
+          query: {
+            relayer: { subsidies },
+          },
+        },
+      },
+      context,
+      parent: { address: subsidizer },
+    } = this;
+
+    const rawSubsidizer = stringToAccountId(subsidizer, context);
+
+    const entries = await subsidies.entries();
+
+    return entries.reduce<SubsidyWithAllowance[]>(
+      (
+        result,
+        [
+          {
+            args: [rawBeneficiary],
+          },
+          rawSubsidy,
+        ]
+      ) => {
+        const { payingKey, remaining } = rawSubsidy.unwrap();
+
+        if (rawSubsidizer.eq(payingKey)) {
+          const beneficiary = accountIdToString(rawBeneficiary);
+          const subsidy = new Subsidy({ beneficiary, subsidizer }, context);
+          const allowance = balanceToBigNumber(remaining);
+
+          return [...result, { subsidy, allowance }];
+        }
+
+        return result;
+      },
+      []
+    );
+  }
+
+  /**
+   * Get the Subsidy relationship along with the subsidized amount for this Account is the beneficiary.
+   * If this Account isn't being subsidized, return null
+   *
+   * @note can be subscribed to
+   */
+  public getSubsidizer(): Promise<SubsidyWithAllowance | null>;
+  public getSubsidizer(callback: SubCallback<SubsidyWithAllowance | null>): Promise<UnsubCallback>;
+
+  // eslint-disable-next-line require-jsdoc
+  public getSubsidizer(
+    callback?: SubCallback<SubsidyWithAllowance | null>
+  ): Promise<SubsidyWithAllowance | null | UnsubCallback> {
+    const {
+      context,
+      parent: { address },
+    } = this;
+
+    if (callback) {
+      return context.accountSubsidy(address, callback);
+    }
+
+    return context.accountSubsidy(address);
+  }
+}

--- a/src/api/entities/__tests__/Subsidies.ts
+++ b/src/api/entities/__tests__/Subsidies.ts
@@ -1,0 +1,140 @@
+import { AccountId } from '@polkadot/types/interfaces';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import { Subsidies } from '~/api/entities/Subsidies';
+import { Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { Account, SubsidyWithAllowance, UnsubCallback } from '~/types';
+import { tuple } from '~/types/utils';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Account',
+  require('~/testUtils/mocks/entities').mockAccountModule('~/api/entities/Account')
+);
+jest.mock(
+  '~/api/entities/Subsidy',
+  require('~/testUtils/mocks/entities').mockSubsidyModule('~/api/entities/Subsidy')
+);
+
+describe('Subsidies Class', () => {
+  let context: Mocked<Context>;
+  let address: string;
+  let account: Account;
+  let rawAccount: AccountId;
+  let subsidies: Subsidies;
+
+  let stringToAccountIdSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+    address = 'address';
+    account = entityMockUtils.getAccountInstance({ address });
+    subsidies = new Subsidies(account, context);
+
+    rawAccount = dsMockUtils.createMockAccountId(address);
+
+    stringToAccountIdSpy = jest.spyOn(utilsConversionModule, 'stringToAccountId');
+
+    when(stringToAccountIdSpy).calledWith(address, context).mockReturnValue(rawAccount);
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  describe('method: getBeneficiaries', () => {
+    it('should return a list of Subsidy relationship along with remaining subsidized amount', async () => {
+      const beneficiary = 'beneficiary';
+      const rawBeneficiary = dsMockUtils.createMockAccountId(beneficiary);
+      rawAccount.eq = jest.fn();
+      when(rawAccount.eq).calledWith(rawAccount).mockReturnValue(true);
+      const allowance = new BigNumber(100);
+      const rawBalance = dsMockUtils.createMockBalance(allowance);
+      when(jest.spyOn(utilsConversionModule, 'balanceToBigNumber'))
+        .calledWith(rawBalance)
+        .mockReturnValue(allowance);
+
+      dsMockUtils.createQueryMock('relayer', 'subsidies', {
+        entries: [
+          tuple(
+            [rawBeneficiary],
+            dsMockUtils.createMockOption(
+              dsMockUtils.createMockSubsidy({ payingKey: rawAccount, remaining: rawBalance })
+            )
+          ),
+          tuple(
+            [dsMockUtils.createMockAccountId('someBeneficiary')],
+            dsMockUtils.createMockOption(
+              dsMockUtils.createMockSubsidy({
+                payingKey: dsMockUtils.createMockAccountId('someAccount'),
+                remaining: rawBalance,
+              })
+            )
+          ),
+        ],
+      });
+
+      const beneficiaries = await subsidies.getBeneficiaries();
+
+      expect(beneficiaries).toHaveLength(1);
+      expect(beneficiaries[0].allowance).toEqual(allowance);
+      expect(beneficiaries[0].subsidy.beneficiary.address).toEqual(beneficiary);
+      expect(beneficiaries[0].subsidy.subsidizer.address).toEqual(address);
+    });
+  });
+
+  describe('method: getSubsidizer', () => {
+    let fakeResult: SubsidyWithAllowance;
+
+    beforeEach(() => {
+      fakeResult = {
+        subsidy: entityMockUtils.getSubsidyInstance({
+          beneficiary: address,
+          subsidizer: 'someSubsidizer',
+        }),
+        allowance: new BigNumber(1000),
+      };
+
+      context = dsMockUtils.getContextInstance({
+        subsidy: fakeResult,
+      });
+    });
+
+    it('should return the Subsidy with allowance', async () => {
+      const result = await subsidies.getSubsidizer();
+
+      expect(result).toEqual(fakeResult);
+    });
+
+    it('should allow subscription', async () => {
+      const unsubCallback = 'unsubCallback' as unknown as Promise<UnsubCallback>;
+      const callback = jest.fn();
+
+      context.accountSubsidy.mockImplementation(
+        async (_, cbFunc: (balance: SubsidyWithAllowance) => void) => {
+          cbFunc(fakeResult);
+          return unsubCallback;
+        }
+      );
+
+      const result = await subsidies.getSubsidizer(callback);
+
+      expect(result).toEqual(unsubCallback);
+      expect(callback).toBeCalledWith(fakeResult);
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds `Subsidies` namespace which contains two methods -
* `getBeneficiaries` - to get list of all subsidy relationship along with allowance where the Account is the subsidizer
* `getSubsidizer` - get the Subsidy relationship along with allowance where the Account is the beneficiary

### Breaking Changes

NA

### JIRA Link

DA-196

### Checklist

- [ ] Updated the Readme.md (if required) ?
