### PR TITLE
feat: 🎸 support chain node v5.1.3

### DIFF
--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -1171,7 +1171,7 @@ describe('assertExpectedChainVersion', () => {
     client.sendRpcVersion('5.1.7');
     await signal;
     expect(warnSpy).toHaveBeenCalledWith(
-      'This version of the SDK supports Polymesh RPC node version 5.1.1. The node is at version 5.1.7. Please upgrade the SDK'
+      'This version of the SDK supports Polymesh RPC node version 5.1.3. The node is at version 5.1.7. Please upgrade the SDK'
     );
   });
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -109,7 +109,7 @@ export const ROOT_TYPES = rootTypes;
 /**
  * The Polymesh RPC node version range that is compatible with this version of the SDK
  */
-export const SUPPORTED_NODE_VERSION_RANGE = '5.1.1';
+export const SUPPORTED_NODE_VERSION_RANGE = '5.1.3';
 
 /**
  * The Polymesh chain spec version range that is compatible with this version of the SDK


### PR DESCRIPTION
### Description

The node version is v5.1.3 now. I think it will take a while to get operators to upgrade, but alpha shouldn't error with latest from chain imo.

[Change](https://github.com/PolymeshAssociation/Polymesh/commit/27ab6d5548cd4d220fb3119f312c2d8868466743#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3)

### Breaking Changes

### JIRA Link

### Checklist

