### PR TITLE
docs: ✏️ Add backtick around <T> and export missing v2 types

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1627,4 +1627,11 @@ export {
   SettlementResultEnum,
   SettlementDirectionEnum,
 } from '~/middleware/types';
+export * from '~/middleware/enumsV2';
+export {
+  PublicEnum8F5A39C8Ee,
+  PublicEnum7A0B4Cc03E,
+  ExtrinsicsOrderBy,
+  AssetHoldersOrderBy,
+} from '~/middleware/typesV2';
 export * from '~/api/procedures/types';

--- a/src/types/utils/index.ts
+++ b/src/types/utils/index.ts
@@ -24,7 +24,7 @@ export type UnionOfProcedureFuncs<Args, ReturnValue, Storage> = Args extends unk
   : never;
 
 /**
- * Less strict version of Parameters<T\>
+ * Less strict version of `Parameters<T>`
  */
 export type ArgsType<T> = T extends (...args: infer A) => unknown ? A : never;
 

--- a/src/types/utils/index.ts
+++ b/src/types/utils/index.ts
@@ -24,7 +24,7 @@ export type UnionOfProcedureFuncs<Args, ReturnValue, Storage> = Args extends unk
   : never;
 
 /**
- * Less strict version of Parameters<T>
+ * Less strict version of Parameters<T\>
  */
 export type ArgsType<T> = T extends (...args: infer A) => unknown ? A : never;
 


### PR DESCRIPTION
### Description

Adds `\` for proper rendering of <T> in docs + exports missing v2 types needed in documentation

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
