### PR TITLE
fix: 🐛 allow 500ms for chain connections to drain

### DIFF
--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -83,7 +83,13 @@ import {
   u16ToBigNumber,
   u32ToBigNumber,
 } from '~/utils/conversion';
-import { assertAddressValid, calculateNextKey, createClaim, getApiAtBlock } from '~/utils/internal';
+import {
+  assertAddressValid,
+  calculateNextKey,
+  createClaim,
+  delay,
+  getApiAtBlock,
+} from '~/utils/internal';
 
 interface ConstructorParams {
   polymeshApi: ApiPromise;
@@ -1395,7 +1401,7 @@ export class Context {
    * @note after disconnecting, trying to access any property in this object will result
    *   in an error
    */
-  public disconnect(): Promise<void> {
+  public async disconnect(): Promise<void> {
     const { polymeshApi } = this;
     let middlewareApi, middlewareApiV2;
 
@@ -1411,6 +1417,8 @@ export class Context {
 
     middlewareApi && middlewareApi.stop();
     middlewareApiV2 && middlewareApiV2.stop();
+
+    await delay(500); // allow pending requests to complete
 
     return polymeshApi.disconnect();
   }


### PR DESCRIPTION
### Description

some subscriptions to the chain may reject on disconnect if WS is closed immediately after submitting a transaction. 500ms is conservative, generally a little over the ping time to the node should suffice.

polkadot.js will [reject any pending subscription](https://github.com/polkadot-js/api/pull/3197/files#diff-871752a27c655476527379eacbc4f66b71eb08a5bb1639acbcf8e380c57cda6cR355) when disconnect is called.

While reasonable and efficient, our procedure middleware emitter runs async and can prevent a clean shutdown if disconnect is called too quickly.

### Breaking Changes

None

### JIRA Link

✅ Closes: [DA-483](https://polymesh.atlassian.net/browse/DA-483)

### Checklist

- [ ] Updated the Readme.md (if required) ?
