### PR TITLE
fix: 🐛 allow non default signer to quit portfolios

### DIFF
--- a/src/api/procedures/__tests__/quitCustody.ts
+++ b/src/api/procedures/__tests__/quitCustody.ts
@@ -70,6 +70,7 @@ describe('quitCustody procedure', () => {
 
   it('should throw an error if the signing Identity is the Portfolio owner', async () => {
     const portfolio = new NumberedPortfolio({ id, did }, mockContext);
+    const identity = await mockContext.getSigningIdentity();
 
     const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
       portfolioId: { did, number: id },
@@ -86,6 +87,7 @@ describe('quitCustody procedure', () => {
     }
 
     expect(error.message).toBe('The Portfolio owner cannot quit custody');
+    expect(portfolio.isOwnedBy).toHaveBeenCalledWith({ identity });
   });
 
   it('should return a quit portfolio custody transaction spec', async () => {

--- a/src/api/procedures/quitCustody.ts
+++ b/src/api/procedures/quitCustody.ts
@@ -33,9 +33,9 @@ export async function prepareQuitCustody(
   const { portfolio } = args;
 
   const signer = await context.getSigningIdentity();
-  const isOwnedBy = await portfolio.isOwnedBy({ identity: signer });
+  const isOwnedBySigner = await portfolio.isOwnedBy({ identity: signer });
 
-  if (isOwnedBy) {
+  if (isOwnedBySigner) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
       message: 'The Portfolio owner cannot quit custody',

--- a/src/api/procedures/quitCustody.ts
+++ b/src/api/procedures/quitCustody.ts
@@ -32,7 +32,8 @@ export async function prepareQuitCustody(
 
   const { portfolio } = args;
 
-  const isOwnedBy = await portfolio.isOwnedBy();
+  const signer = await context.getSigningIdentity();
+  const isOwnedBy = await portfolio.isOwnedBy({ identity: signer });
 
   if (isOwnedBy) {
     throw new PolymeshError({


### PR DESCRIPTION
### Description

fix bug where the procedure context differs from the portfolio context

The issue happens when using the non default signer to leave the default signer's portfolio since the `context` variable is different between the objects.

### Breaking Changes

n/a

### JIRA Link

n/a

### Checklist

- [ ] Updated the Readme.md (if required) ?
