### PR TITLE
fix: 🐛 update path for package.json "main" and "types" files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       - name: build
         run: |
           yarn build:ts
-          cp package.json dist/package.json
+          sed 's/dist\//.\//' package.json > dist/package.json
           cp README.md dist/README.md
           cp -R node_modules dist/node_modules
       - name: release

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "High-level API to interact with the Polymesh blockchain",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "author": "Polymath Studios Inc.",
+  "author": "Polymesh Association",
   "license": "ISC",
   "scripts": {
     "start": "cross-env node scripts/generateTsconfigDev.js && cross-env webpack-dev-server --config=webpack.config.dev.js",


### PR DESCRIPTION


### Description

when moving package.json into `dist` relative paths need to be updated

I was trying to bring the SDK in with [Skypack](https://www.skypack.dev/) and the message that prints is:

```
[Package Error] "@polymeshassociation/polymesh-sdk@v18.1.0" could not be built. 
[1/5] Verifying package is valid…
[2/5] Installing dependencies from npm…
[3/5] Building package using esinstall…
Running esinstall...
We resolved "@polymeshassociation/polymesh-sdk" to @polymeshassociation/polymesh-sdk/dist/index.js, but the file does not exist on disk.
We resolved "@polymeshassociation/polymesh-sdk" to /tmp/cdn/_74a1lUfzbqwqneABTBpY/node_modules/@polymeshassociation**/polymesh-sdk/dist/index.js,** but the file does not exist on disk.
```

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
