### PR TITLE
feat: 🎸 add validate account method

### DIFF
--- a/src/api/client/AccountManagement.ts
+++ b/src/api/client/AccountManagement.ts
@@ -27,7 +27,7 @@ import {
   UnsubCallback,
 } from '~/types';
 import { stringToAccountId } from '~/utils/conversion';
-import { asAccount, createProcedureMethod } from '~/utils/internal';
+import { asAccount, assertAddressValid, createProcedureMethod } from '~/utils/internal';
 
 /**
  * Handles functionality related to Account Management
@@ -275,5 +275,18 @@ export class AccountManagement {
     const { address: subsidizerAddress } = asAccount(subsidizer, context);
 
     return new Subsidy({ beneficiary: beneficiaryAddress, subsidizer: subsidizerAddress }, context);
+  }
+
+  /**
+   * Returns validation error if @param args.address is not a valid ss58 string for the connected network
+   */
+  public validateAddress(args: { address: string }): Error | null {
+    try {
+      assertAddressValid(args.address, this.context.ss58Format);
+    } catch (error) {
+      return error;
+    }
+
+    return null;
   }
 }

--- a/src/api/client/AccountManagement.ts
+++ b/src/api/client/AccountManagement.ts
@@ -280,13 +280,13 @@ export class AccountManagement {
   /**
    * Returns validation error if @param args.address is not a valid ss58 string for the connected network
    */
-  public validateAddress(args: { address: string }): Error | null {
+  public isValidAddress(args: { address: string }): boolean {
     try {
       assertAddressValid(args.address, this.context.ss58Format);
     } catch (error) {
-      return error;
+      return false;
     }
 
-    return null;
+    return true;
   }
 }

--- a/src/api/client/AccountManagement.ts
+++ b/src/api/client/AccountManagement.ts
@@ -278,7 +278,7 @@ export class AccountManagement {
   }
 
   /**
-   * Returns validation error if @param args.address is not a valid ss58 string for the connected network
+   * Returns `true` @param args.address is a valid ss58 address for the connected network
    */
   public isValidAddress(args: { address: string }): boolean {
     try {

--- a/src/api/client/__tests__/AccountManagement.ts
+++ b/src/api/client/__tests__/AccountManagement.ts
@@ -357,24 +357,24 @@ describe('AccountManagement class', () => {
         .mockImplementation();
     });
 
-    it('should return the error with if assert address valid throws', () => {
+    it('should return the false if assert address valid throws', () => {
       const expectedError = new Error('some error');
 
       assertAddressValidSpy.mockImplementationOnce(() => {
         throw expectedError;
       });
 
-      const error = accountManagement.validateAddress({ address: 'someAddress' });
+      const isValid = accountManagement.isValidAddress({ address: 'someAddress' });
 
-      expect(error).toEqual(expectedError);
+      expect(isValid).toEqual(isValid);
     });
 
     it('should return true if assert address valid does not throw', () => {
       assertAddressValidSpy.mockReturnValue(undefined);
 
-      const error = accountManagement.validateAddress({ address: 'someAddress' });
+      const isValid = accountManagement.isValidAddress({ address: 'someAddress' });
 
-      expect(error).toEqual(null);
+      expect(isValid).toEqual(true);
     });
   });
 });

--- a/src/api/client/__tests__/AccountManagement.ts
+++ b/src/api/client/__tests__/AccountManagement.ts
@@ -7,6 +7,7 @@ import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mo
 import { MockContext } from '~/testUtils/mocks/dataSources';
 import { AccountBalance, PermissionType, SubCallback } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
+import * as utilsInternalModule from '~/utils/internal';
 
 jest.mock(
   '~/base/Procedure',
@@ -345,6 +346,35 @@ describe('AccountManagement class', () => {
       const result = accountManagement.getSubsidy(params);
 
       expect(result).toBeInstanceOf(Subsidy);
+    });
+  });
+
+  describe('method: validateAddress', () => {
+    let assertAddressValidSpy: jest.SpyInstance;
+    beforeAll(() => {
+      assertAddressValidSpy = jest
+        .spyOn(utilsInternalModule, 'assertAddressValid')
+        .mockImplementation();
+    });
+
+    it('should return the error with if assert address valid throws', () => {
+      const expectedError = new Error('some error');
+
+      assertAddressValidSpy.mockImplementationOnce(() => {
+        throw expectedError;
+      });
+
+      const error = accountManagement.validateAddress({ address: 'someAddress' });
+
+      expect(error).toEqual(expectedError);
+    });
+
+    it('should return true if assert address valid does not throw', () => {
+      assertAddressValidSpy.mockReturnValue(undefined);
+
+      const error = accountManagement.validateAddress({ address: 'someAddress' });
+
+      expect(error).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
### Description

add sync method to validate address strings. `getAccount` implicitly validates the address, however is async making it less versatile

When I added multisig, I made `getAccount` async, which adds extra checks. This lets people check just the address is OK

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
