### PR TITLE
feat: 🎸 Remove option to add investor uniqueness for an asset

### DIFF
--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -10,6 +10,9 @@ export interface AssetDetails {
   owner: Identity;
   totalSupply: BigNumber;
   fullAgents: Identity[];
+  /**
+   * @deprecated This attribute will be removed in the future
+   */
   requiresInvestorUniqueness: boolean;
 }
 

--- a/src/api/procedures/__tests__/createAsset.ts
+++ b/src/api/procedures/__tests__/createAsset.ts
@@ -128,7 +128,7 @@ describe('createAsset procedure', () => {
     ticker = 'TICKER';
     name = 'someName';
     initialSupply = new BigNumber(100);
-    isDivisible = true;
+    isDivisible = false;
     assetType = KnownAssetType.EquityCommon;
     securityIdentifiers = [
       {
@@ -323,7 +323,7 @@ describe('createAsset procedure', () => {
       transactions: [
         {
           transaction: createAssetTransaction,
-          args: [rawName, rawTicker, rawIsDivisible, rawType, [], null, rawIsDivisible], // disable IU = true
+          args: [rawName, rawTicker, rawIsDivisible, rawType, [], null, rawDisableIu], // disable IU = true
         },
       ],
       fee: undefined,

--- a/src/api/procedures/__tests__/createAsset.ts
+++ b/src/api/procedures/__tests__/createAsset.ts
@@ -77,7 +77,6 @@ describe('createAsset procedure', () => {
   let assetType: string;
   let securityIdentifiers: SecurityIdentifier[];
   let fundingRound: string;
-  let requireInvestorUniqueness: boolean;
   let documents: AssetDocument[];
   let rawTicker: PolymeshPrimitivesTicker;
   let rawName: Bytes;
@@ -138,7 +137,6 @@ describe('createAsset procedure', () => {
       },
     ];
     fundingRound = 'Series A';
-    requireInvestorUniqueness = true;
     documents = [
       {
         name: 'someDocument',
@@ -170,7 +168,7 @@ describe('createAsset procedure', () => {
       })
     );
     rawFundingRound = dsMockUtils.createMockBytes(fundingRound);
-    rawDisableIu = dsMockUtils.createMockBool(!requireInvestorUniqueness);
+    rawDisableIu = dsMockUtils.createMockBool(true);
     args = {
       ticker,
       name,
@@ -178,7 +176,6 @@ describe('createAsset procedure', () => {
       assetType,
       securityIdentifiers,
       fundingRound,
-      requireInvestorUniqueness,
       reservationRequired: true,
     };
     protocolFees = [new BigNumber(250), new BigNumber(150), new BigNumber(100)];
@@ -212,9 +209,7 @@ describe('createAsset procedure', () => {
       .mockReturnValue(rawInitialSupply);
     when(nameToAssetNameSpy).calledWith(name, mockContext).mockReturnValue(rawName);
     when(booleanToBoolSpy).calledWith(isDivisible, mockContext).mockReturnValue(rawIsDivisible);
-    when(booleanToBoolSpy)
-      .calledWith(!requireInvestorUniqueness, mockContext)
-      .mockReturnValue(rawDisableIu);
+    when(booleanToBoolSpy).calledWith(true, mockContext).mockReturnValue(rawDisableIu);
     when(stringToTickerKeySpy)
       .calledWith(ticker, mockContext)
       .mockReturnValue({ Ticker: rawTicker });

--- a/src/api/procedures/createAsset.ts
+++ b/src/api/procedures/createAsset.ts
@@ -128,7 +128,6 @@ export async function prepareCreateAsset(
     securityIdentifiers = [],
     fundingRound,
     documents,
-    requireInvestorUniqueness,
     reservationRequired,
     initialStatistics,
   } = args;
@@ -142,7 +141,7 @@ export async function prepareCreateAsset(
     securityIdentifierToAssetIdentifier(identifier, context)
   );
   const rawFundingRound = optionize(fundingRoundToAssetFundingRound)(fundingRound, context);
-  const rawDisableIu = booleanToBool(!requireInvestorUniqueness, context);
+  const rawDisableIu = booleanToBool(true, context);
 
   const newAsset = new Asset({ ticker }, context);
 

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -287,11 +287,6 @@ export interface CreateAssetParams {
    */
   fundingRound?: string;
   documents?: AssetDocument[];
-  /**
-   * whether this asset requires investors to have a Investor Uniqueness Claim in order
-   *   to hold it. More information about Investor Uniqueness and PUIS [here](https://developers.polymesh.live/introduction/identity#polymesh-unique-identity-system-puis)
-   */
-  requireInvestorUniqueness: boolean;
 
   /**
    * (optional) type of statistics that should be enabled for the Asset


### PR DESCRIPTION
### Description

Remove option to add investor uniqueness for an asset

### Breaking Changes

🧨 `requiresInvestorUniqueness` is now removed from `CreateAssetParams`

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
