### PR TITLE
chore: 🤖 update build to use node v18

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '18.x'
       - name: install dependencies
         run: yarn --frozen-lockfile
       - name: generate docs
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -6,6 +6,19 @@
   "types": "dist/index.d.ts",
   "author": "Polymesh Association",
   "license": "ISC",
+  "homepage": "https://github.com/PolymeshAssociation/polymesh-sdk/wiki",
+  "bugs": {
+    "url": "https://github.com/PolymeshAssociation/polymesh-sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PolymeshAssociation/polymesh-sdk"
+  },
+  "keywords": [
+    "polymesh",
+    "blockchain",
+    "sdk"
+  ],
   "scripts": {
     "start": "cross-env node scripts/generateTsconfigDev.js && cross-env webpack-dev-server --config=webpack.config.dev.js",
     "generate:polkadot-types": "yarn fetch-metadata && yarn fetch-definitions && yarn generate:defs && yarn generate:meta && yarn generate:consts && yarn generate:post-process",


### PR DESCRIPTION
### Description

update tooling to use node v18 since node v14 is approaching end of life. Also add some package.json fields

there shouldn't be any user impact because we only reference node version for our build tooling

I saw there was an "engines" field for package.json, but it seems to cause some issues with the browser. We know the SDK works with v14 at the moment, so I don't think its worth risking issues with front end repos.

This also lead me to discovering some other fields I think we should have though.

### Breaking Changes

None

### JIRA Link

✅ Closes: [DA-546](https://polymesh.atlassian.net/browse/DA-546)

### Checklist

- [ ] Updated the Readme.md (if required) ?
