### PR TITLE
fix: 🐛 Handle 0 locked balance in Portfolio's getAssetBalances

### DIFF
--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -181,16 +181,20 @@ describe('Portfolio class', () => {
     let id: BigNumber;
     let ticker0: string;
     let ticker1: string;
+    let ticker2: string;
     let total0: BigNumber;
     let total1: BigNumber;
     let locked0: BigNumber;
     let locked1: BigNumber;
+    let locked2: BigNumber;
     let rawTicker0: PolymeshPrimitivesTicker;
     let rawTicker1: PolymeshPrimitivesTicker;
+    let rawTicker2: PolymeshPrimitivesTicker;
     let rawTotal0: Balance;
     let rawTotal1: Balance;
     let rawLocked0: Balance;
     let rawLocked1: Balance;
+    let rawLocked2: Balance;
     let rawPortfolioId: PolymeshPrimitivesIdentityIdPortfolioId;
 
     beforeAll(() => {
@@ -198,16 +202,20 @@ describe('Portfolio class', () => {
       id = new BigNumber(1);
       ticker0 = 'TICKER0';
       ticker1 = 'TICKER1';
+      ticker2 = 'TICKER2';
       total0 = new BigNumber(100);
       total1 = new BigNumber(200);
       locked0 = new BigNumber(50);
       locked1 = new BigNumber(25);
+      locked2 = new BigNumber(0);
       rawTicker0 = dsMockUtils.createMockTicker(ticker0);
       rawTicker1 = dsMockUtils.createMockTicker(ticker1);
+      rawTicker2 = dsMockUtils.createMockTicker(ticker2);
       rawTotal0 = dsMockUtils.createMockBalance(total0.shiftedBy(6));
       rawTotal1 = dsMockUtils.createMockBalance(total1.shiftedBy(6));
       rawLocked0 = dsMockUtils.createMockBalance(locked0.shiftedBy(6));
       rawLocked1 = dsMockUtils.createMockBalance(locked1.shiftedBy(6));
+      rawLocked2 = dsMockUtils.createMockBalance(locked2.shiftedBy(6));
       rawPortfolioId = dsMockUtils.createMockPortfolioId({
         did: dsMockUtils.createMockIdentityId(did),
         kind: dsMockUtils.createMockPortfolioKind({
@@ -229,6 +237,7 @@ describe('Portfolio class', () => {
         entries: [
           tuple([rawPortfolioId, rawTicker0], rawLocked0),
           tuple([rawPortfolioId, rawTicker1], rawLocked1),
+          tuple([rawPortfolioId, rawTicker2], rawLocked2),
         ],
       });
     });

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -190,10 +190,12 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
       const ticker = tickerToString(key.args[1]);
       const locked = balanceToBigNumber(balance);
 
-      const tickerBalance = assetBalances[ticker];
+      if (!locked.isZero()) {
+        const tickerBalance = assetBalances[ticker];
 
-      tickerBalance.locked = locked;
-      tickerBalance.free = assetBalances[ticker].total.minus(locked);
+        tickerBalance.locked = locked;
+        tickerBalance.free = assetBalances[ticker].total.minus(locked);
+      }
     });
 
     const mask: PortfolioBalance[] | undefined = args?.assets.map(asset => ({


### PR DESCRIPTION
### Description

This PR correctly handles 0 locked asset balance state while getting assetBalances for a specific portfolio.

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
