### PR TITLE
fix: 🐛 Add new procedure to handle `AddRelayerPayingKey` auth

### DIFF
--- a/src/api/entities/AuthorizationRequest.ts
+++ b/src/api/entities/AuthorizationRequest.ts
@@ -3,6 +3,8 @@ import BigNumber from 'bignumber.js';
 import {
   consumeAddMultiSigSignerAuthorization,
   ConsumeAddMultiSigSignerAuthorizationParams,
+  consumeAddRelayerPayingKeyAuthorization,
+  ConsumeAddRelayerPayingKeyAuthorizationParams,
   consumeAuthorizationRequests,
   ConsumeAuthorizationRequestsParams,
   consumeJoinOrRotateAuthorization,
@@ -115,7 +117,8 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
     this.accept = createProcedureMethod<
       | ConsumeAuthorizationRequestsParams
       | ConsumeJoinOrRotateAuthorizationParams
-      | ConsumeAddMultiSigSignerAuthorizationParams,
+      | ConsumeAddMultiSigSignerAuthorizationParams
+      | ConsumeAddRelayerPayingKeyAuthorizationParams,
       void,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       any
@@ -123,6 +126,9 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
       {
         getProcedureAndArgs: () => {
           switch (this.data.type) {
+            case AuthorizationType.AddRelayerPayingKey: {
+              return [consumeAddRelayerPayingKeyAuthorization, { authRequest: this, accept: true }];
+            }
             case AuthorizationType.JoinIdentity:
             case AuthorizationType.RotatePrimaryKey:
             case AuthorizationType.RotatePrimaryKeyToSecondary: {
@@ -144,7 +150,8 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
     this.remove = createProcedureMethod<
       | ConsumeAuthorizationRequestsParams
       | ConsumeJoinOrRotateAuthorizationParams
-      | ConsumeAddMultiSigSignerAuthorizationParams,
+      | ConsumeAddMultiSigSignerAuthorizationParams
+      | ConsumeAddRelayerPayingKeyAuthorizationParams,
       void,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       any
@@ -152,9 +159,13 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
       {
         getProcedureAndArgs: () => {
           switch (this.data.type) {
-            case AuthorizationType.JoinIdentity: {
-              return [consumeJoinOrRotateAuthorization, { authRequest: this, accept: false }];
+            case AuthorizationType.AddRelayerPayingKey: {
+              return [
+                consumeAddRelayerPayingKeyAuthorization,
+                { authRequest: this, accept: false },
+              ];
             }
+            case AuthorizationType.JoinIdentity:
             case AuthorizationType.RotatePrimaryKeyToSecondary: {
               return [consumeJoinOrRotateAuthorization, { authRequest: this, accept: false }];
             }

--- a/src/api/entities/__tests__/AuthorizationRequest.ts
+++ b/src/api/entities/__tests__/AuthorizationRequest.ts
@@ -278,7 +278,7 @@ describe('AuthorizationRequest class', () => {
 
       const args = {
         authRequest: authorizationRequest,
-        accept: true,
+        accept: false,
       };
 
       const expectedQueue = 'someQueue' as unknown as TransactionQueue<void>;

--- a/src/api/entities/__tests__/AuthorizationRequest.ts
+++ b/src/api/entities/__tests__/AuthorizationRequest.ts
@@ -1,13 +1,24 @@
 import BigNumber from 'bignumber.js';
 import sinon from 'sinon';
 
-import { AuthorizationRequest, Context, Entity, Identity, TransactionQueue } from '~/internal';
+import {
+  Account,
+  AuthorizationRequest,
+  Context,
+  Entity,
+  Identity,
+  TransactionQueue,
+} from '~/internal';
 import { dsMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Authorization, AuthorizationType, SignerType } from '~/types';
 
 jest.mock(
   '~/base/Procedure',
   require('~/testUtils/mocks/procedure').mockProcedureModule('~/base/Procedure')
+);
+jest.mock(
+  '~/api/entities/Account',
+  require('~/testUtils/mocks/entities').mockAccountModule('~/api/entities/Account')
 );
 
 describe('AuthorizationRequest class', () => {
@@ -208,6 +219,42 @@ describe('AuthorizationRequest class', () => {
   describe('method: remove', () => {
     afterAll(() => {
       sinon.restore();
+    });
+
+    it('should prepare the consumeAddRelayerPayingKeyAuthorization procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const authorizationRequest = new AuthorizationRequest(
+        {
+          authId: new BigNumber(1),
+          expiry: null,
+          target: new Identity({ did: 'someDid' }, context),
+          issuer: new Identity({ did: 'otherDid' }, context),
+          data: {
+            type: AuthorizationType.AddRelayerPayingKey,
+            value: {
+              beneficiary: new Account({ address: 'beneficiary' }, context),
+              subsidizer: new Account({ address: 'subsidizer' }, context),
+              allowance: new BigNumber(100),
+            },
+          },
+        },
+        context
+      );
+
+      const args = {
+        authRequest: authorizationRequest,
+        accept: true,
+      };
+
+      const expectedQueue = 'someQueue' as unknown as TransactionQueue<void>;
+
+      procedureMockUtils
+        .getPrepareStub()
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
+
+      const queue = await authorizationRequest.accept();
+
+      expect(queue).toBe(expectedQueue);
     });
 
     it('should prepare the consumeAuthorizationRequest procedure with the correct arguments and context, and return the resulting transaction queue', async () => {

--- a/src/api/entities/__tests__/AuthorizationRequest.ts
+++ b/src/api/entities/__tests__/AuthorizationRequest.ts
@@ -80,6 +80,42 @@ describe('AuthorizationRequest class', () => {
       sinon.restore();
     });
 
+    it('should prepare the consumeAddRelayerPayingKeyAuthorization procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const authorizationRequest = new AuthorizationRequest(
+        {
+          authId: new BigNumber(1),
+          expiry: null,
+          target: new Identity({ did: 'someDid' }, context),
+          issuer: new Identity({ did: 'otherDid' }, context),
+          data: {
+            type: AuthorizationType.AddRelayerPayingKey,
+            value: {
+              beneficiary: new Account({ address: 'beneficiary' }, context),
+              subsidizer: new Account({ address: 'subsidizer' }, context),
+              allowance: new BigNumber(100),
+            },
+          },
+        },
+        context
+      );
+
+      const args = {
+        authRequest: authorizationRequest,
+        accept: true,
+      };
+
+      const expectedQueue = 'someQueue' as unknown as TransactionQueue<void>;
+
+      procedureMockUtils
+        .getPrepareStub()
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
+
+      const queue = await authorizationRequest.accept();
+
+      expect(queue).toBe(expectedQueue);
+    });
+
     it('should prepare the consumeAuthorizationRequests procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
       const authorizationRequest = new AuthorizationRequest(
         {
@@ -252,7 +288,7 @@ describe('AuthorizationRequest class', () => {
         .withArgs({ args, transformer: undefined }, context)
         .resolves(expectedQueue);
 
-      const queue = await authorizationRequest.accept();
+      const queue = await authorizationRequest.remove();
 
       expect(queue).toBe(expectedQueue);
     });

--- a/src/api/procedures/__tests__/consumeAddRelayerPayingKeyAuthorization.ts
+++ b/src/api/procedures/__tests__/consumeAddRelayerPayingKeyAuthorization.ts
@@ -1,0 +1,324 @@
+import { bool, u64 } from '@polkadot/types';
+import BigNumber from 'bignumber.js';
+import sinon from 'sinon';
+
+import {
+  ConsumeAddRelayerPayingKeyAuthorizationParams,
+  getAuthorization,
+  prepareConsumeAddRelayerPayingKeyAuthorization,
+  prepareStorage,
+  Storage,
+} from '~/api/procedures/consumeAddRelayerPayingKeyAuthorization';
+import * as utilsProcedureModule from '~/api/procedures/utils';
+import { Account, AuthorizationRequest, Context, Identity, KnownPermissionGroup } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { Authorization, AuthorizationType, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
+  let mockContext: Mocked<Context>;
+  let targetAddress: string;
+  let bigNumberToU64Stub: sinon.SinonStub<[BigNumber, Context], u64>;
+  let booleanToBoolStub: sinon.SinonStub<[boolean, Context], bool>;
+
+  let rawTrue: bool;
+  let rawFalse: bool;
+  let authId: BigNumber;
+  let rawAuthId: u64;
+
+  let targetAccount: Account;
+  let issuerIdentity: Identity;
+  let addTransactionStub: sinon.SinonStub;
+
+  beforeAll(() => {
+    targetAddress = 'someAddress';
+    dsMockUtils.initMocks({
+      contextOptions: {
+        signingAddress: targetAddress,
+      },
+    });
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    jest.spyOn(utilsProcedureModule, 'assertAuthorizationRequestValid').mockImplementation();
+
+    bigNumberToU64Stub = sinon.stub(utilsConversionModule, 'bigNumberToU64');
+    booleanToBoolStub = sinon.stub(utilsConversionModule, 'booleanToBool');
+
+    authId = new BigNumber(1);
+    rawAuthId = dsMockUtils.createMockU64(authId);
+
+    rawFalse = dsMockUtils.createMockBool(false);
+    rawTrue = dsMockUtils.createMockBool(true);
+
+    jest.spyOn(utilsConversionModule, 'addressToKey').mockImplementation();
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance();
+    addTransactionStub = procedureMockUtils.getAddTransactionStub();
+
+    bigNumberToU64Stub.withArgs(authId, mockContext).returns(rawAuthId);
+    booleanToBoolStub.withArgs(true, mockContext).returns(rawTrue);
+    booleanToBoolStub.withArgs(false, mockContext).returns(rawFalse);
+
+    targetAccount = entityMockUtils.getAccountInstance({ address: targetAddress });
+
+    issuerIdentity = entityMockUtils.getIdentityInstance();
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw if called with an Authorization other than AddRelayerPayingKey', () => {
+    const proc = procedureMockUtils.getInstance<
+      ConsumeAddRelayerPayingKeyAuthorizationParams,
+      void,
+      Storage
+    >(mockContext, {
+      signingAccount: targetAccount,
+      calledByTarget: true,
+    });
+
+    return expect(
+      prepareConsumeAddRelayerPayingKeyAuthorization.call(proc, {
+        authRequest: new AuthorizationRequest(
+          {
+            target: targetAccount,
+            issuer: issuerIdentity,
+            authId,
+            expiry: null,
+            data: {
+              type: AuthorizationType.BecomeAgent,
+              value: {} as KnownPermissionGroup,
+            },
+          },
+          mockContext
+        ),
+        accept: true,
+      })
+    ).rejects.toThrow(
+      'Unrecognized auth type: "BecomeAgent" for consumeAddRelayerPayingKeyAuthorization method'
+    );
+  });
+
+  it('should return an acceptPayingKey transaction spec if accept is set to true', async () => {
+    const proc = procedureMockUtils.getInstance<
+      ConsumeAddRelayerPayingKeyAuthorizationParams,
+      void,
+      Storage
+    >(mockContext, {
+      signingAccount: targetAccount,
+      calledByTarget: true,
+    });
+
+    const transaction = dsMockUtils.createTxStub('relayer', 'acceptPayingKey');
+
+    await prepareConsumeAddRelayerPayingKeyAuthorization.call(proc, {
+      authRequest: new AuthorizationRequest(
+        {
+          target: targetAccount,
+          issuer: issuerIdentity,
+          authId,
+          expiry: null,
+          data: {
+            type: AuthorizationType.AddRelayerPayingKey,
+            value: {
+              subsidizer: entityMockUtils.getAccountInstance(),
+              beneficiary: targetAccount,
+              allowance: new BigNumber(100),
+            },
+          },
+        },
+        mockContext
+      ),
+      accept: true,
+    });
+
+    sinon.assert.calledWith(addTransactionStub, {
+      transaction,
+      paidForBy: issuerIdentity,
+      args: [rawAuthId],
+    });
+  });
+
+  it('should return a removeAuthorization transaction spec if accept is set to false', async () => {
+    let proc = procedureMockUtils.getInstance<
+      ConsumeAddRelayerPayingKeyAuthorizationParams,
+      void,
+      Storage
+    >(mockContext, {
+      signingAccount: targetAccount,
+      calledByTarget: false,
+    });
+
+    const transaction = dsMockUtils.createTxStub('identity', 'removeAuthorization');
+
+    const rawSignatory = dsMockUtils.createMockSignatory({
+      Account: dsMockUtils.createMockAccountId(targetAccount.address),
+    });
+
+    sinon.stub(utilsConversionModule, 'signerValueToSignatory').returns(rawSignatory);
+
+    const params = {
+      authRequest: new AuthorizationRequest(
+        {
+          target: targetAccount,
+          issuer: issuerIdentity,
+          authId,
+          expiry: null,
+          data: {
+            type: AuthorizationType.AddRelayerPayingKey,
+            value: {
+              subsidizer: entityMockUtils.getAccountInstance(),
+              beneficiary: targetAccount,
+              allowance: new BigNumber(100),
+            },
+          },
+        },
+        mockContext
+      ),
+      accept: false,
+    };
+
+    await prepareConsumeAddRelayerPayingKeyAuthorization.call(proc, params);
+
+    sinon.assert.calledWith(addTransactionStub, {
+      transaction,
+      args: [rawSignatory, rawAuthId, rawFalse],
+    });
+
+    proc = procedureMockUtils.getInstance<
+      ConsumeAddRelayerPayingKeyAuthorizationParams,
+      void,
+      Storage
+    >(mockContext, {
+      signingAccount: targetAccount,
+      calledByTarget: true,
+    });
+
+    await prepareConsumeAddRelayerPayingKeyAuthorization.call(proc, params);
+
+    sinon.assert.calledWith(addTransactionStub, {
+      transaction,
+      paidForBy: issuerIdentity,
+      args: [rawSignatory, rawAuthId, rawTrue],
+    });
+  });
+
+  describe('prepareStorage', () => {
+    it("should return the signing Account, whether the target is the caller and the target's Identity (if any)", async () => {
+      const proc = procedureMockUtils.getInstance<
+        ConsumeAddRelayerPayingKeyAuthorizationParams,
+        void,
+        Storage
+      >(mockContext);
+      const boundFunc = prepareStorage.bind(proc);
+
+      const result = await boundFunc({
+        authRequest: { target: targetAccount },
+      } as unknown as ConsumeAddRelayerPayingKeyAuthorizationParams);
+
+      expect(result).toEqual({
+        signingAccount: mockContext.getSigningAccount(),
+        calledByTarget: true,
+      });
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', async () => {
+      let proc = procedureMockUtils.getInstance<
+        ConsumeAddRelayerPayingKeyAuthorizationParams,
+        void,
+        Storage
+      >(mockContext, {
+        signingAccount: targetAccount,
+        calledByTarget: true,
+      });
+      const constructorParams = {
+        authId,
+        expiry: null,
+        target: targetAccount,
+        issuer: issuerIdentity,
+        data: {
+          type: AuthorizationType.AddRelayerPayingKey,
+        } as Authorization,
+      };
+      const args = {
+        authRequest: new AuthorizationRequest(constructorParams, mockContext),
+        accept: true,
+      };
+
+      let boundFunc = getAuthorization.bind(proc);
+      let result = await boundFunc(args);
+      expect(result).toEqual({
+        roles: true,
+      });
+
+      args.accept = false;
+
+      result = await boundFunc(args);
+      expect(result).toEqual({
+        roles: true,
+        permissions: {
+          transactions: [TxTags.identity.RemoveAuthorization],
+        },
+      });
+
+      proc = procedureMockUtils.getInstance<
+        ConsumeAddRelayerPayingKeyAuthorizationParams,
+        void,
+        Storage
+      >(mockContext, {
+        signingAccount: targetAccount,
+        calledByTarget: false,
+      });
+      boundFunc = getAuthorization.bind(proc);
+
+      result = await boundFunc(args);
+      expect(result).toEqual({
+        roles: true,
+        permissions: {
+          transactions: [TxTags.identity.RemoveAuthorization],
+        },
+      });
+
+      proc = procedureMockUtils.getInstance<
+        ConsumeAddRelayerPayingKeyAuthorizationParams,
+        void,
+        Storage
+      >(mockContext, {
+        signingAccount: entityMockUtils.getAccountInstance({
+          address: 'someOtherAddress',
+          getIdentity: entityMockUtils.getIdentityInstance({ did: 'someOtherDid', isEqual: false }),
+        }),
+        calledByTarget: false,
+      });
+      boundFunc = getAuthorization.bind(proc);
+
+      result = await boundFunc(args);
+      expect(result).toEqual({
+        roles:
+          '"AddRelayerPayingKey" Authorization Requests can only be removed by the issuer Identity or the target Account',
+        permissions: {
+          transactions: [TxTags.identity.RemoveAuthorization],
+        },
+      });
+
+      result = await boundFunc({ ...args, accept: true });
+      expect(result).toEqual({
+        roles:
+          '"AddRelayerPayingKey" Authorization Requests must be accepted by the target Account',
+      });
+    });
+  });
+});

--- a/src/api/procedures/__tests__/consumeAddRelayerPayingKeyAuthorization.ts
+++ b/src/api/procedures/__tests__/consumeAddRelayerPayingKeyAuthorization.ts
@@ -299,6 +299,28 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
       >(mockContext, {
         signingAccount: entityMockUtils.getAccountInstance({
           address: 'someOtherAddress',
+          getIdentity: undefined,
+        }),
+        calledByTarget: false,
+      });
+      boundFunc = getAuthorization.bind(proc);
+
+      result = await boundFunc(args);
+      expect(result).toEqual({
+        roles:
+          '"AddRelayerPayingKey" Authorization Requests can only be removed by the issuer Identity or the target Account',
+        permissions: {
+          transactions: [TxTags.identity.RemoveAuthorization],
+        },
+      });
+
+      proc = procedureMockUtils.getInstance<
+        ConsumeAddRelayerPayingKeyAuthorizationParams,
+        void,
+        Storage
+      >(mockContext, {
+        signingAccount: entityMockUtils.getAccountInstance({
+          address: 'someOtherAddress',
           getIdentity: entityMockUtils.getIdentityInstance({ did: 'someOtherDid', isEqual: false }),
         }),
         calledByTarget: false,

--- a/src/api/procedures/__tests__/consumeAuthorizationRequests.ts
+++ b/src/api/procedures/__tests__/consumeAuthorizationRequests.ts
@@ -44,7 +44,6 @@ describe('consumeAuthorizationRequests procedure', () => {
   let rawFalseBool: bool;
 
   let acceptAssetOwnershipTransferTransaction: sinon.SinonStub;
-  let acceptPayingKeyTransaction: sinon.SinonStub;
   let acceptBecomeAgentTransaction: sinon.SinonStub;
   let acceptPortfolioCustodyTransaction: sinon.SinonStub;
   let acceptTickerTransferTransaction: sinon.SinonStub;
@@ -86,20 +85,6 @@ describe('consumeAuthorizationRequests procedure', () => {
         data: {
           type: AuthorizationType.TransferAssetOwnership,
           value: 'SOME_TICKER1',
-        },
-      },
-      {
-        authId: new BigNumber(2),
-        expiry: null,
-        target: entityMockUtils.getAccountInstance({ address: 'targetAddress2' }),
-        issuer: entityMockUtils.getIdentityInstance({ did: 'issuerDid2' }),
-        data: {
-          type: AuthorizationType.AddRelayerPayingKey,
-          value: {
-            beneficiary: entityMockUtils.getAccountInstance({ address: 'targetAddress2' }),
-            subsidizer: entityMockUtils.getAccountInstance({ address: 'payingKey' }),
-            allowance: new BigNumber(1000),
-          },
         },
       },
       {
@@ -169,7 +154,6 @@ describe('consumeAuthorizationRequests procedure', () => {
       'asset',
       'acceptAssetOwnershipTransfer'
     );
-    acceptPayingKeyTransaction = dsMockUtils.createTxStub('relayer', 'acceptPayingKey');
     acceptBecomeAgentTransaction = dsMockUtils.createTxStub('externalAgents', 'acceptBecomeAgent');
     acceptPortfolioCustodyTransaction = dsMockUtils.createTxStub(
       'portfolio',
@@ -207,20 +191,12 @@ describe('consumeAuthorizationRequests procedure', () => {
         },
       ],
     });
-    sinon.assert.calledWith(addBatchTransactionStub, {
-      transactions: [
-        {
-          transaction: acceptPayingKeyTransaction,
-          args: rawAuthIds[1],
-        },
-      ],
-    });
 
     sinon.assert.calledWith(addBatchTransactionStub, {
       transactions: [
         {
           transaction: acceptBecomeAgentTransaction,
-          args: rawAuthIds[2],
+          args: rawAuthIds[1],
         },
       ],
     });
@@ -228,7 +204,7 @@ describe('consumeAuthorizationRequests procedure', () => {
       transactions: [
         {
           transaction: acceptPortfolioCustodyTransaction,
-          args: rawAuthIds[3],
+          args: rawAuthIds[2],
         },
       ],
     });
@@ -236,7 +212,7 @@ describe('consumeAuthorizationRequests procedure', () => {
       transactions: [
         {
           transaction: acceptTickerTransferTransaction,
-          args: rawAuthIds[4],
+          args: rawAuthIds[3],
         },
       ],
     });

--- a/src/api/procedures/consumeAddRelayerPayingKeyAuthorization.ts
+++ b/src/api/procedures/consumeAddRelayerPayingKeyAuthorization.ts
@@ -1,0 +1,156 @@
+import { assertAuthorizationRequestValid } from '~/api/procedures/utils';
+import { Account, AuthorizationRequest, Identity, PolymeshError, Procedure } from '~/internal';
+import { AuthorizationType, ErrorCode, TxTags } from '~/types';
+import { ProcedureAuthorization } from '~/types/internal';
+import {
+  bigNumberToU64,
+  booleanToBool,
+  signerToSignerValue,
+  signerValueToSignatory,
+} from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export interface ConsumeAddRelayerPayingKeyAuthorizationParams {
+  authRequest: AuthorizationRequest;
+  accept: boolean;
+}
+
+export interface Storage {
+  signingAccount: Account;
+  calledByTarget: boolean;
+}
+
+/**
+ * @hidden
+ *
+ * Consumes AddRelayerPayingKey Authorizations
+ */
+export async function prepareConsumeAddRelayerPayingKeyAuthorization(
+  this: Procedure<ConsumeAddRelayerPayingKeyAuthorizationParams, void, Storage>,
+  args: ConsumeAddRelayerPayingKeyAuthorizationParams
+): Promise<void> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: { relayer, identity },
+      },
+    },
+    storage: { calledByTarget },
+    context,
+  } = this;
+  const { authRequest, accept } = args;
+
+  const {
+    target,
+    authId,
+    issuer,
+    data: { type },
+  } = authRequest;
+
+  if (type !== AuthorizationType.AddRelayerPayingKey) {
+    throw new PolymeshError({
+      code: ErrorCode.UnexpectedError,
+      message: `Unrecognized auth type: "${type}" for consumeAddRelayerPayingKeyAuthorization method`,
+    });
+  }
+
+  const rawAuthId = bigNumberToU64(authId, context);
+
+  if (!accept) {
+    const baseArgs: { paidForBy?: Identity } = {};
+
+    if (calledByTarget) {
+      baseArgs.paidForBy = issuer;
+    }
+
+    this.addTransaction({
+      transaction: identity.removeAuthorization,
+      ...baseArgs,
+      args: [
+        signerValueToSignatory(signerToSignerValue(target), context),
+        rawAuthId,
+        booleanToBool(calledByTarget, context),
+      ],
+    });
+
+    return;
+  }
+
+  await assertAuthorizationRequestValid(authRequest, context);
+
+  this.addTransaction({
+    transaction: relayer.acceptPayingKey,
+    paidForBy: issuer,
+    args: [rawAuthId],
+  });
+}
+
+/**
+ * @hidden
+ *
+ * - If the auth is being accepted, we check that the caller is the target
+ * - If the auth is being rejected, we check that the caller is either the target or the issuer
+ */
+export async function getAuthorization(
+  this: Procedure<ConsumeAddRelayerPayingKeyAuthorizationParams, void, Storage>,
+  { authRequest, accept }: ConsumeAddRelayerPayingKeyAuthorizationParams
+): Promise<ProcedureAuthorization> {
+  const { issuer } = authRequest;
+  const {
+    storage: { signingAccount, calledByTarget },
+  } = this;
+  let hasRoles = calledByTarget;
+
+  if (accept) {
+    return {
+      roles:
+        hasRoles ||
+        `"${AuthorizationType.AddRelayerPayingKey}" Authorization Requests must be accepted by the target Account`,
+    };
+  }
+
+  const identity = await signingAccount.getIdentity();
+
+  hasRoles = hasRoles || !!identity?.isEqual(issuer);
+
+  return {
+    roles:
+      hasRoles ||
+      `"${AuthorizationType.AddRelayerPayingKey}" Authorization Requests can only be removed by the issuer Identity or the target Account`,
+    permissions: {
+      transactions: [TxTags.identity.RemoveAuthorization],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export async function prepareStorage(
+  this: Procedure<ConsumeAddRelayerPayingKeyAuthorizationParams, void, Storage>,
+  { authRequest: { target } }: ConsumeAddRelayerPayingKeyAuthorizationParams
+): Promise<Storage> {
+  const { context } = this;
+
+  // AddRelayerPayingKey Authorizations always target an Account
+  const targetAccount = target as Account;
+  const signingAccount = context.getSigningAccount();
+  const calledByTarget = targetAccount.isEqual(signingAccount);
+
+  return {
+    signingAccount,
+    calledByTarget,
+  };
+}
+
+/**
+ * @hidden
+ */
+export const consumeAddRelayerPayingKeyAuthorization = (): Procedure<
+  ConsumeAddRelayerPayingKeyAuthorizationParams,
+  void,
+  Storage
+> =>
+  new Procedure(prepareConsumeAddRelayerPayingKeyAuthorization, getAuthorization, prepareStorage);

--- a/src/api/procedures/consumeAuthorizationRequests.ts
+++ b/src/api/procedures/consumeAuthorizationRequests.ts
@@ -46,7 +46,6 @@ export async function prepareConsumeAuthorizationRequests(
   if (accept) {
     // auth types not present in this object should not be possible in this procedure
     const typesToExtrinsics = {
-      [AuthorizationType.AddRelayerPayingKey]: tx.relayer.acceptPayingKey,
       [AuthorizationType.BecomeAgent]: tx.externalAgents.acceptBecomeAgent,
       [AuthorizationType.PortfolioCustody]: tx.portfolio.acceptPortfolioCustody,
       [AuthorizationType.TransferAssetOwnership]: tx.asset.acceptAssetOwnershipTransfer,
@@ -139,7 +138,6 @@ export async function getAuthorization(
 
   if (accept) {
     const typesToTags = {
-      [AuthorizationType.AddRelayerPayingKey]: TxTags.relayer.AcceptPayingKey,
       [AuthorizationType.BecomeAgent]: TxTags.externalAgents.AcceptBecomeAgent,
       [AuthorizationType.PortfolioCustody]: TxTags.portfolio.AcceptPortfolioCustody,
       [AuthorizationType.TransferAssetOwnership]: TxTags.asset.AcceptAssetOwnershipTransfer,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -14,6 +14,10 @@ export {
   ConsumeAddMultiSigSignerAuthorizationParams,
 } from '~/api/procedures/consumeAddMultiSigSignerAuthorization';
 export {
+  consumeAddRelayerPayingKeyAuthorization,
+  ConsumeAddRelayerPayingKeyAuthorizationParams,
+} from '~/api/procedures/consumeAddRelayerPayingKeyAuthorization';
+export {
   consumeJoinOrRotateAuthorization,
   ConsumeJoinOrRotateAuthorizationParams,
 } from '~/api/procedures/consumeJoinOrRotateAuthorization';


### PR DESCRIPTION
### Description

As of now, when the beneficiary with zero amount tried accepting the subsidy auth for adding paying key, SDK threw an error, preventing the target to accept the subsidy. This PR adds a separate procedure to handle AddRelayerPayingKey type of authorization, where now the issuer pays for the acceptance/rejection of authorization by the target beneficiary.

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
