### PR TITLE
feat: 🎸 allow for skiping affirm for manual execution

### DIFF
--- a/src/api/client/Settlements.ts
+++ b/src/api/client/Settlements.ts
@@ -12,10 +12,10 @@ import {
 } from '~/internal';
 import {
   AddInstructionWithVenueIdParams,
-  AffirmInstructionParams,
   CreateVenueParams,
   ErrorCode,
   InstructionAffirmationOperation,
+  InstructionIdParams,
   ProcedureMethod,
 } from '~/types';
 import { createProcedureMethod } from '~/utils/internal';
@@ -118,5 +118,5 @@ export class Settlements {
   /**
    * Affirm an Instruction (authorize)
    */
-  public affirmInstruction: ProcedureMethod<AffirmInstructionParams, Instruction>;
+  public affirmInstruction: ProcedureMethod<InstructionIdParams, Instruction>;
 }

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -827,7 +827,7 @@ describe('Instruction class', () => {
       when(procedureMockUtils.getPrepareMock())
         .calledWith(
           {
-            args: { id },
+            args: { id, skipAffirmationCheck: false },
             transformer: undefined,
           },
           context,
@@ -835,7 +835,7 @@ describe('Instruction class', () => {
         )
         .mockResolvedValue(expectedTransaction);
 
-      const tx = await instruction.executeManually();
+      const tx = await instruction.executeManually({ id, skipAffirmationCheck: false });
 
       expect(tx).toBe(expectedTransaction);
     });

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -23,6 +23,7 @@ import {
   DefaultPortfolio,
   ErrorCode,
   EventIdentifier,
+  ExecuteManualInstructionParams,
   InstructionAffirmationOperation,
   NoArgsProcedureMethod,
   NumberedPortfolio,
@@ -139,8 +140,8 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
 
     this.executeManually = createProcedureMethod(
       {
-        getProcedureAndArgs: () => [executeManualInstruction, { id }],
-        voidArgs: true,
+        getProcedureAndArgs: args => [executeManualInstruction, { id, ...args }],
+        optionalArgs: true,
       },
       context
     );
@@ -505,7 +506,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
   /**
    * Executes an Instruction of type `SettleManual`
    */
-  public executeManually: NoArgsProcedureMethod<Instruction>;
+  public executeManually: OptionalArgsProcedureMethod<ExecuteManualInstructionParams, Instruction>;
 
   /**
    * @hidden

--- a/src/api/procedures/__tests__/executeManualInstruction.ts
+++ b/src/api/procedures/__tests__/executeManualInstruction.ts
@@ -135,6 +135,7 @@ describe('executeManualInstruction procedure', () => {
     return expect(
       prepareExecuteManualInstruction.call(proc, {
         id,
+        skipAffirmationCheck: false,
       })
     ).rejects.toThrow('The signing identity is not involved in this Instruction');
   });
@@ -158,8 +159,33 @@ describe('executeManualInstruction procedure', () => {
     return expect(
       prepareExecuteManualInstruction.call(proc, {
         id,
+        skipAffirmationCheck: false,
       })
     ).rejects.toThrow('Instruction needs to be affirmed by all parties before it can be executed');
+  });
+
+  it('should not throw an error if there are some pending affirmations but skipAffirmationCheck is `true`', () => {
+    dsMockUtils.createQueryMock('settlement', 'instructionAffirmsPending', {
+      returnValue: dsMockUtils.createMockU64(new BigNumber(1)),
+    });
+
+    const proc = procedureMockUtils.getInstance<
+      ExecuteManualInstructionParams,
+      Instruction,
+      Storage
+    >(mockContext, {
+      portfolios: [portfolio, portfolio],
+      totalLegAmount: legAmount,
+      instructionDetails,
+      signerDid: did,
+    });
+
+    return expect(
+      prepareExecuteManualInstruction.call(proc, {
+        id,
+        skipAffirmationCheck: true,
+      })
+    ).resolves.not.toThrow();
   });
 
   it('should return an execute manual instruction transaction spec', async () => {
@@ -181,6 +207,7 @@ describe('executeManualInstruction procedure', () => {
 
     let result = await prepareExecuteManualInstruction.call(proc, {
       id,
+      skipAffirmationCheck: false,
       operation: InstructionAffirmationOperation.Affirm,
     });
 
@@ -202,6 +229,7 @@ describe('executeManualInstruction procedure', () => {
 
     result = await prepareExecuteManualInstruction.call(proc, {
       id,
+      skipAffirmationCheck: false,
       operation: InstructionAffirmationOperation.Affirm,
     });
 
@@ -266,6 +294,7 @@ describe('executeManualInstruction procedure', () => {
       });
       const result = await boundFunc({
         id: new BigNumber(1),
+        skipAffirmationCheck: false,
       });
 
       expect(result).toEqual({
@@ -299,6 +328,7 @@ describe('executeManualInstruction procedure', () => {
 
       const result = await boundFunc({
         id: new BigNumber(1),
+        skipAffirmationCheck: false,
       });
 
       expect(result).toEqual({

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -526,9 +526,12 @@ export type ModifyInstructionAffirmationParams = AffirmInstructionParams &
       } & RejectInstructionParams)
   );
 
-export interface ExecuteManualInstructionParams {
-  id: BigNumber;
-}
+export type ExecuteManualInstructionParams = AffirmInstructionParams & {
+  /**
+   * (optional) Set to `true` to skip affirmation check, useful for batch transactions
+   */
+  skipAffirmationCheck?: boolean;
+};
 
 export interface CreateVenueParams {
   description: string;

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -488,7 +488,7 @@ export type AddInstructionWithVenueIdParams = AddInstructionParams & {
   venueId: BigNumber;
 };
 
-export interface AffirmInstructionParams {
+export interface InstructionIdParams {
   id: BigNumber;
 }
 
@@ -514,7 +514,7 @@ export type AffirmOrWithdrawInstructionParams = {
   portfolios?: PortfolioLike[];
 };
 
-export type ModifyInstructionAffirmationParams = AffirmInstructionParams &
+export type ModifyInstructionAffirmationParams = InstructionIdParams &
   (
     | ({
         operation:
@@ -526,7 +526,7 @@ export type ModifyInstructionAffirmationParams = AffirmInstructionParams &
       } & RejectInstructionParams)
   );
 
-export type ExecuteManualInstructionParams = AffirmInstructionParams & {
+export type ExecuteManualInstructionParams = InstructionIdParams & {
   /**
    * (optional) Set to `true` to skip affirmation check, useful for batch transactions
    */


### PR DESCRIPTION
### Description

instruction `executeManually` method now accepts optional `skipAffirmationCheck` param. Useful when processing the affirmation earlier in the batch transaction.

### Breaking Changes

None

### JIRA Link

[DA-756](https://polymesh.atlassian.net/browse/DA-756)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-756]: https://polymesh.atlassian.net/browse/DA-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ