### PR TITLE
feat: 🎸 Add method to get involved portfolios in an instruction 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: test
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
-        run: yarn test --runInBand --shard=${{ matrix.shard }}/${{ strategy.job-total }} --verbose
+        run: yarn test --runInBand --shard=${{ matrix.shard }}/${{ strategy.job-total }}
       - name: Rename coverage to shard coverage
         run: |
           mv coverage/clover.xml coverage/clover-${{matrix.shard}}.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: test
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
-        run: yarn test --runInBand --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: yarn test --runInBand --shard=${{ matrix.shard }}/${{ strategy.job-total }} --verbose
       - name: Rename coverage to shard coverage
         run: |
           mv coverage/clover.xml coverage/clover-${{matrix.shard}}.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import P from 'bluebird';
 
 import { executeManualInstruction } from '~/api/procedures/executeManualInstruction';
 import {
@@ -18,10 +19,12 @@ import { EventIdEnum, ModuleIdEnum, Query } from '~/middleware/types';
 import { Query as QueryV2 } from '~/middleware/typesV2';
 import { InstructionStatus as MeshInstructionStatus } from '~/polkadot/polymesh';
 import {
+  DefaultPortfolio,
   ErrorCode,
   EventIdentifier,
   InstructionAffirmationOperation,
   NoArgsProcedureMethod,
+  NumberedPortfolio,
   PaginationOptions,
   ResultSet,
   SubCallback,
@@ -561,5 +564,50 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
    */
   public toHuman(): string {
     return this.id.toString();
+  }
+
+  /**
+   * Retrieve all the involved portfolios in this Instruction where the given identity is a custodian of
+   */
+  public async getInvolvedPortfolios(args: {
+    did: string;
+  }): Promise<(DefaultPortfolio | NumberedPortfolio)[]> {
+    const { did } = args;
+
+    const { data: legs } = await this.getLegs();
+
+    const assemblePortfolios = async (
+      involvedPortfolios: (DefaultPortfolio | NumberedPortfolio)[],
+      from: DefaultPortfolio | NumberedPortfolio,
+      to: DefaultPortfolio | NumberedPortfolio
+    ): Promise<(DefaultPortfolio | NumberedPortfolio)[]> => {
+      const [fromExists, toExists] = await Promise.all([from.exists(), to.exists()]);
+
+      const checkCustody = async (
+        legPortfolio: DefaultPortfolio | NumberedPortfolio,
+        exists: boolean
+      ): Promise<void> => {
+        if (exists) {
+          const isCustodied = await legPortfolio.isCustodiedBy({ identity: did });
+          if (isCustodied) {
+            involvedPortfolios.push(legPortfolio);
+          }
+        } else if (legPortfolio.owner.did === did) {
+          involvedPortfolios.push(legPortfolio);
+        }
+      };
+
+      await Promise.all([checkCustody(from, fromExists), checkCustody(to, toExists)]);
+
+      return involvedPortfolios;
+    };
+
+    const portfolios = await P.reduce<Leg, (DefaultPortfolio | NumberedPortfolio)[]>(
+      legs,
+      async (result, { from, to }) => assemblePortfolios(result, from, to),
+      []
+    );
+
+    return portfolios;
   }
 }


### PR DESCRIPTION
### Description

This adds `getInvolvedPortfolios` to Instruction entity which returns all the portfolios in an Instruction, where a given DID is custodian of

### Breaking Changes

NA

### JIRA Link

DA-757

### Checklist

- [ ] Updated the Readme.md (if required) ?
