### PR TITLE
fix: 🐛 instruction affirmation does not need leg count

### DIFF
--- a/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
@@ -220,7 +220,7 @@ describe('modifyInstructionAffirmation procedure', () => {
     expect(result).toEqual({
       transaction,
       feeMultiplier: new BigNumber(2),
-      args: [rawInstructionId, [rawPortfolioId, rawPortfolioId], rawLegAmount],
+      args: [rawInstructionId, [rawPortfolioId, rawPortfolioId]],
       resolver: expect.objectContaining({ id }),
     });
   });
@@ -283,7 +283,7 @@ describe('modifyInstructionAffirmation procedure', () => {
     expect(result).toEqual({
       transaction,
       feeMultiplier: new BigNumber(2),
-      args: [rawInstructionId, [rawPortfolioId, rawPortfolioId], rawLegAmount],
+      args: [rawInstructionId, [rawPortfolioId, rawPortfolioId]],
       resolver: expect.objectContaining({ id }),
     });
   });
@@ -331,7 +331,7 @@ describe('modifyInstructionAffirmation procedure', () => {
     expect(result).toEqual({
       transaction,
       feeMultiplier: new BigNumber(2),
-      args: [rawInstructionId, rawPortfolioId, rawLegAmount],
+      args: [rawInstructionId, rawPortfolioId],
       resolver: expect.objectContaining({ id }),
     });
   });

--- a/src/api/procedures/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/modifyInstructionAffirmation.ts
@@ -89,7 +89,7 @@ export async function prepareModifyInstructionAffirmation(
 
   const excludeCriteria: AffirmationStatus[] = [];
   let errorMessage: string;
-  let transaction: PolymeshTx<[u64, PolymeshPrimitivesIdentityIdPortfolioId[], u32]> | null = null;
+  let transaction: PolymeshTx<[u64, PolymeshPrimitivesIdentityIdPortfolioId[]]> | null = null;
 
   switch (operation) {
     case InstructionAffirmationOperation.Affirm: {
@@ -134,14 +134,14 @@ export async function prepareModifyInstructionAffirmation(
       transaction,
       resolver: instruction,
       feeMultiplier: senderLegAmount,
-      args: [rawInstructionId, validPortfolioIds, bigNumberToU32(senderLegAmount, context)],
+      args: [rawInstructionId, validPortfolioIds],
     };
   }
   return {
     transaction: settlementTx.rejectInstruction,
     resolver: instruction,
     feeMultiplier: totalLegAmount,
-    args: [rawInstructionId, validPortfolioIds[0], bigNumberToU32(totalLegAmount, context)],
+    args: [rawInstructionId, validPortfolioIds[0]],
   };
 }
 

--- a/src/api/procedures/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/modifyInstructionAffirmation.ts
@@ -1,4 +1,4 @@
-import { u32, u64 } from '@polkadot/types';
+import { u64 } from '@polkadot/types';
 import { PolymeshPrimitivesIdentityIdPortfolioId } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 import P from 'bluebird';
@@ -26,7 +26,6 @@ import {
 } from '~/types/internal';
 import { tuple } from '~/types/utils';
 import {
-  bigNumberToU32,
   bigNumberToU64,
   meshAffirmationStatusToAffirmationStatus,
   portfolioIdToMeshPortfolioId,


### PR DESCRIPTION
### Description

6.0 removes the need to specify leg count for affirmations. Previously would fail with expecting 2 got 3 args error

### Breaking Changes

None

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
