### PR TITLE
feat: 🎸 remove react dependency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "@typescript-eslint/no-useless-constructor": "error",
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "@typescript-eslint/no-shadow": ["error"],    
+    "@typescript-eslint/no-shadow": ["error"],
     "@typescript-eslint/naming-convention": [
       "error",
       {
@@ -82,7 +82,18 @@
     "no-dupe-class-members": "off",
     "no-shadow": "off",
     "arrow-parens": "off",
-    "camelcase": "off"
+    "camelcase": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@apollo/client",
+            "message": "@apollo/client/core must be used instead (default client requires react, which isn't suitable for a library)"
+          }
+        ]
+      }
+    ]
   },
   "plugins": ["@typescript-eslint", "simple-import-sort"],
   "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "prettier": "2.5.1",
     "prettier-eslint": "13.0.0",
     "prettier-eslint-cli": "5.0.1",
-    "react": "^18.2.0",
     "replace-in-file": "^6.2.0",
     "semantic-release": "^19.0.2",
     "stream-browserify": "^3.0.0",

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -1,11 +1,9 @@
 import {
   ApolloClient,
-  ApolloLink,
-  HttpLink,
+  createHttpLink,
   InMemoryCache,
   NormalizedCacheObject,
-} from '@apollo/client';
-import { setContext } from '@apollo/client/link/context';
+} from '@apollo/client/core';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { SigningManager } from '@polymeshassociation/signing-manager-types';
 import BigNumber from 'bignumber.js';
@@ -52,22 +50,12 @@ function createMiddlewareApi(
 ): ApolloClient<NormalizedCacheObject> | null {
   return middleware
     ? new ApolloClient({
-        link: setContext((_, { headers }) => {
-          return {
-            headers: {
-              ...headers,
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              'x-api-key': middleware.key,
-            },
-          };
-        }).concat(
-          ApolloLink.from([
-            new HttpLink({
-              uri: middleware.link,
-              fetch,
-            }),
-          ])
-        ),
+        link: createHttpLink({
+          uri: middleware.link,
+          fetch,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          headers: { 'x-api-key': middleware.key },
+        }),
         cache: new InMemoryCache(),
         defaultOptions: {
           watchQuery: {

--- a/src/api/client/__tests__/Polymesh.ts
+++ b/src/api/client/__tests__/Polymesh.ts
@@ -1,4 +1,3 @@
-import { ApolloLink, GraphQLRequest } from '@apollo/client';
 import { SigningManager } from '@polymeshassociation/signing-manager-types';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
@@ -12,14 +11,6 @@ import { SUPPORTED_NODE_VERSION_RANGE } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as internalUtils from '~/utils/internal';
 
-jest.mock('@apollo/client/react', () => ({}));
-
-jest.mock('@apollo/client/link/context', () => ({
-  ...jest.requireActual('@apollo/client/link/context'),
-  setContext: jest.fn().mockImplementation(cbFunc => {
-    return new ApolloLink(cbFunc({} as GraphQLRequest, {}));
-  }),
-}));
 jest.mock(
   '@polkadot/api',
   require('~/testUtils/mocks/dataSources').mockPolkadotModule('@polkadot/api')
@@ -29,8 +20,8 @@ jest.mock(
   require('~/testUtils/mocks/dataSources').mockContextModule('~/base/Context')
 );
 jest.mock(
-  '@apollo/client',
-  require('~/testUtils/mocks/dataSources').mockApolloModule('@apollo/client')
+  '@apollo/client/core',
+  require('~/testUtils/mocks/dataSources').mockApolloModule('@apollo/client/core')
 );
 jest.mock(
   '~/api/entities/TickerReservation',

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -4,7 +4,7 @@ import {
   NormalizedCacheObject,
   OperationVariables,
   QueryOptions,
-} from '@apollo/client';
+} from '@apollo/client/core';
 import { ApiPromise } from '@polkadot/api';
 import { UnsubscribePromise } from '@polkadot/api/types';
 import { getTypeDef, Option } from '@polkadot/types';

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from '@apollo/client';
+import { QueryOptions } from '@apollo/client/core';
 import { Signer as PolkadotSigner } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 import P from 'bluebird';

--- a/src/middleware/queries.ts
+++ b/src/middleware/queries.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from '@apollo/client';
+import { QueryOptions } from '@apollo/client/core';
 import gql from 'graphql-tag';
 
 import {

--- a/src/middleware/queriesV2.ts
+++ b/src/middleware/queriesV2.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from '@apollo/client';
+import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { ApolloClient, NormalizedCacheObject, QueryOptions } from '@apollo/client';
+import { ApolloClient, NormalizedCacheObject, QueryOptions } from '@apollo/client/core';
 import { ApiPromise } from '@polkadot/api';
 import { DecoratedRpc } from '@polkadot/api/types';
 import { RpcInterface } from '@polkadot/rpc-core/types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8120,7 +8120,7 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
   integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9830,13 +9830,6 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
-react@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
-  dependencies:
-    loose-envify "^1.1.0"
 
 read-cmd-shim@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
### Description

The apollo default import implictly depends on react. by only importing from `@apollo/client/core` instead of `@apollo/client` react is not needed.

https://github.com/apollographql/apollo-client/issues/7005#issuecomment-691248887


### Breaking Changes

None

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
