### PR TITLE
fix: 🐛 `asset.details` on v5.4

### DIFF
--- a/src/api/entities/Asset/index.ts
+++ b/src/api/entities/Asset/index.ts
@@ -269,7 +269,7 @@ export class Asset extends Entity<UniqueIdentifiers, string> {
       return {
         assetType,
         isDivisible: boolToBoolean(divisible),
-        name: bytesToString(assetName.unwrapOrDefault()),
+        name: bytesToString(isV5 ? (assetName as unknown as Bytes) : assetName.unwrap()),
         owner,
         totalSupply: balanceToBigNumber(totalSupply),
         fullAgents,


### PR DESCRIPTION
### Description

5.4 should not unwrap the already `Bytes` name

### Breaking Changes

None

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
