### PR TITLE
feat: 🎸 select portfolio on asset issuance

### DIFF
--- a/src/api/procedures/__tests__/issueTokens.ts
+++ b/src/api/procedures/__tests__/issueTokens.ts
@@ -10,8 +10,9 @@ import {
   prepareStorage,
   Storage,
 } from '~/api/procedures/issueTokens';
-import { Asset, Context } from '~/internal';
+import { Asset, Context, Portfolio } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { EntityGetter } from '~/testUtils/mocks/entities';
 import { Mocked } from '~/testUtils/types';
 import { TxTags } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
@@ -29,12 +30,14 @@ describe('issueTokens procedure', () => {
   let rawTicker: PolymeshPrimitivesTicker;
   let amount: BigNumber;
   let rawAmount: Balance;
+  let portfolioToPortfolioKindSpy: jest.SpyInstance;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
     procedureMockUtils.initMocks();
     entityMockUtils.initMocks();
     stringToTickerSpy = jest.spyOn(utilsConversionModule, 'stringToTicker');
+    portfolioToPortfolioKindSpy = jest.spyOn(utilsConversionModule, 'portfolioToPortfolioKind');
     bigNumberToBalance = jest.spyOn(utilsConversionModule, 'bigNumberToBalance');
     ticker = 'SOME_TICKER';
     rawTicker = dsMockUtils.createMockTicker(ticker);
@@ -142,6 +145,149 @@ describe('issueTokens procedure', () => {
       transaction,
       args: [rawTicker, rawAmount],
       resolver: expect.objectContaining({ ticker }),
+    });
+  });
+
+  describe('issue tokens to portfolio', () => {
+    const defaultPortfolioId = new BigNumber(0);
+    const numberedPortfolioId = new BigNumber(1);
+
+    const defaultPortfolioKind = dsMockUtils.createMockPortfolioKind('Default');
+    const numberedPortfolioKind = dsMockUtils.createMockPortfolioKind({
+      User: dsMockUtils.createMockU64(numberedPortfolioId),
+    });
+
+    const getPortfolio: EntityGetter<Portfolio> = jest.fn();
+    const mockDefaultPortfolio = entityMockUtils.getDefaultPortfolioInstance();
+    const mockNumberedPortfolio = entityMockUtils.getNumberedPortfolioInstance({
+      did: 'did',
+      id: numberedPortfolioId,
+    });
+
+    beforeEach(() => {
+      when(mockContext.createType)
+        .calledWith('PolymeshPrimitivesIdentityIdPortfolioKind', 'Default')
+        .mockReturnValue(defaultPortfolioKind);
+      when(mockContext.createType)
+        .calledWith('PolymeshPrimitivesIdentityIdPortfolioKind', numberedPortfolioKind)
+        .mockReturnValue(numberedPortfolioKind);
+      when(getPortfolio)
+        .calledWith()
+        .mockResolvedValue(mockDefaultPortfolio)
+        .calledWith({ portfolioId: defaultPortfolioId })
+        .mockResolvedValue(mockDefaultPortfolio)
+        .calledWith({ portfolioId: numberedPortfolioId })
+        .mockResolvedValue(mockNumberedPortfolio);
+
+      when(portfolioToPortfolioKindSpy)
+        .calledWith(mockDefaultPortfolio, mockContext)
+        .mockReturnValue(defaultPortfolioKind)
+        .calledWith(mockNumberedPortfolio, mockContext)
+        .mockReturnValue(numberedPortfolioKind);
+    });
+
+    it('should issue tokens to Default portfolio if portfolioId is not specified', async () => {
+      const isDivisible = true;
+
+      const args = {
+        amount,
+        ticker,
+      };
+      mockContext.getSigningIdentity.mockResolvedValue(
+        entityMockUtils.getIdentityInstance({ portfoliosGetPortfolio: getPortfolio })
+      );
+      entityMockUtils.configureMocks({
+        assetOptions: {
+          ticker,
+          details: {
+            isDivisible,
+          },
+        },
+      });
+      when(bigNumberToBalance)
+        .calledWith(amount, mockContext, isDivisible)
+        .mockReturnValue(rawAmount);
+      const transaction = dsMockUtils.createTxMock('asset', 'issue');
+      const proc = procedureMockUtils.getInstance<IssueTokensParams, Asset, Storage>(mockContext, {
+        asset: entityMockUtils.getAssetInstance(),
+      });
+      const result = await prepareIssueTokens.call(proc, args);
+
+      expect(result).toEqual({
+        transaction,
+        args: [rawTicker, rawAmount, defaultPortfolioKind],
+        resolver: expect.objectContaining({ ticker }),
+      });
+    });
+
+    it('should issue tokens to Default portfolio if default portfolioId is provided', async () => {
+      const isDivisible = true;
+
+      const args = {
+        amount,
+        ticker,
+        portfolioId: defaultPortfolioId,
+      };
+      mockContext.getSigningIdentity.mockResolvedValue(
+        entityMockUtils.getIdentityInstance({ portfoliosGetPortfolio: getPortfolio })
+      );
+      entityMockUtils.configureMocks({
+        assetOptions: {
+          ticker,
+          details: {
+            isDivisible,
+          },
+        },
+      });
+      when(bigNumberToBalance)
+        .calledWith(amount, mockContext, isDivisible)
+        .mockReturnValue(rawAmount);
+      const transaction = dsMockUtils.createTxMock('asset', 'issue');
+      const proc = procedureMockUtils.getInstance<IssueTokensParams, Asset, Storage>(mockContext, {
+        asset: entityMockUtils.getAssetInstance(),
+      });
+      const result = await prepareIssueTokens.call(proc, args);
+
+      expect(result).toEqual({
+        transaction,
+        args: [rawTicker, rawAmount, defaultPortfolioKind],
+        resolver: expect.objectContaining({ ticker }),
+      });
+    });
+
+    it('should issue tokens to the Numbered portfolio that is specified', async () => {
+      const isDivisible = true;
+
+      const args = {
+        amount,
+        ticker,
+        portfolioId: numberedPortfolioId,
+      };
+      mockContext.getSigningIdentity.mockResolvedValue(
+        entityMockUtils.getIdentityInstance({ portfoliosGetPortfolio: getPortfolio })
+      );
+      entityMockUtils.configureMocks({
+        assetOptions: {
+          ticker,
+          details: {
+            isDivisible,
+          },
+        },
+      });
+      when(bigNumberToBalance)
+        .calledWith(amount, mockContext, isDivisible)
+        .mockReturnValue(rawAmount);
+      const transaction = dsMockUtils.createTxMock('asset', 'issue');
+      const proc = procedureMockUtils.getInstance<IssueTokensParams, Asset, Storage>(mockContext, {
+        asset: entityMockUtils.getAssetInstance(),
+      });
+      const result = await prepareIssueTokens.call(proc, args);
+
+      expect(result).toEqual({
+        transaction,
+        args: [rawTicker, rawAmount, numberedPortfolioKind],
+        resolver: expect.objectContaining({ ticker }),
+      });
     });
   });
 

--- a/src/api/procedures/issueTokens.ts
+++ b/src/api/procedures/issueTokens.ts
@@ -51,7 +51,6 @@ export async function prepareIssueTokens(
     });
   }
 
-  console.log({ portfolioId: portfolioId?.toString() });
 
   const portfolio = portfolioId
     ? await signingIdentity.portfolios.getPortfolio({ portfolioId })

--- a/src/api/procedures/issueTokens.ts
+++ b/src/api/procedures/issueTokens.ts
@@ -9,6 +9,7 @@ import { bigNumberToBalance, portfolioToPortfolioKind, stringToTicker } from '~/
 export interface IssueTokensParams {
   amount: BigNumber;
   ticker: string;
+  portfolioId?: BigNumber;
 }
 
 export interface Storage {
@@ -31,7 +32,7 @@ export async function prepareIssueTokens(
     context,
     storage: { asset: assetEntity },
   } = this;
-  const { ticker, amount } = args;
+  const { ticker, amount, portfolioId } = args;
 
   const [{ isDivisible, totalSupply }, signingIdentity] = await Promise.all([
     assetEntity.details(),
@@ -50,11 +51,15 @@ export async function prepareIssueTokens(
     });
   }
 
-  const defaultPortfolio = await signingIdentity.portfolios.getPortfolio();
+  console.log({ portfolioId: portfolioId?.toString() });
+
+  const portfolio = portfolioId
+    ? await signingIdentity.portfolios.getPortfolio({ portfolioId })
+    : await signingIdentity.portfolios.getPortfolio();
 
   const rawTicker = stringToTicker(ticker, context);
   const rawValue = bigNumberToBalance(amount, context, isDivisible);
-  const rawPortfolio = portfolioToPortfolioKind(defaultPortfolio, context);
+  const rawPortfolio = portfolioToPortfolioKind(portfolio, context);
 
   return {
     transaction: asset.issue,

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -280,6 +280,10 @@ export interface CreateAssetParams {
    */
   initialSupply?: BigNumber;
   /**
+   * portfolio to which the Asset tokens will be issued on creation (optional, default is the default portfolio)
+   */
+  portfolioId?: BigNumber;
+  /**
    * whether a single Asset token can be divided into decimal parts
    */
   isDivisible: boolean;

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -113,7 +113,7 @@ interface EntityOptions {
   toHuman?: any;
 }
 
-type EntityGetter<Result> = Partial<Result> | ((...args: any) => any) | jest.Mock;
+export type EntityGetter<Result> = Partial<Result> | ((...args: any) => any) | jest.Mock;
 
 interface IdentityOptions extends EntityOptions {
   did?: string;


### PR DESCRIPTION
### Description

Adds posibility to set portfolio to which the Asset will be issued when creating asset (if the initial supply gt 0) and when issuing tokens;

### JIRA Link

https://polymesh.atlassian.net/browse/DA-833

### Checklist

- [x] Updated the Readme.md (if required) ?
