### PR TITLE
feat: 🎸 Remove middleware v1 ordering

### DIFF
--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -10,7 +10,6 @@ import { Account, Context, Entity } from '~/internal';
 import { CallIdEnum, ModuleIdEnum } from '~/middleware/enums';
 import { extrinsicsByArgs } from '~/middleware/queries';
 import { ExtrinsicsOrderBy } from '~/middleware/types';
-import { Order, TransactionOrderFields } from '~/middleware/typesV1';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import {
   createMockAccountId,
@@ -429,10 +428,7 @@ describe('Account class', () => {
 
       result = await account.getTransactionHistory({
         success: true,
-        orderBy: {
-          order: Order.Asc,
-          field: TransactionOrderFields.ModuleId,
-        },
+        orderBy: ExtrinsicsOrderBy.ModuleIdAsc,
       });
 
       expect(result.data[0].blockNumber).toEqual(blockNumber1);

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -17,7 +17,6 @@ import { Authorizations, Context, Entity, Identity, MultiSig, PolymeshError } fr
 import { CallIdEnum, ModuleIdEnum } from '~/middleware/enums';
 import { extrinsicsByArgs } from '~/middleware/queries';
 import { ExtrinsicsOrderBy, Query } from '~/middleware/types';
-import { TransactionOrderByInput } from '~/middleware/typesV1';
 import {
   AccountBalance,
   CheckPermissionsResult,
@@ -175,7 +174,9 @@ export class Account extends Entity<UniqueIdentifiers, string> {
   /**
    * Retrieve a list of transactions signed by this Account. Can be filtered using parameters
    *
-   * @note if both `blockNumber` and `blockHash` are passed, only `blockNumber` is taken into account
+   * @note if both `blockNumber` and `blockHash` are passed, only `blockNumber` is taken into account.
+   * Also, for ordering by block_id, one should pass `ExtrinsicsOrderBy.CreatedAtAsc` or `ExtrinsicsOrderBy.CreatedAtDesc`
+   * in order of their choice (since block ID is a string field in middleware v2)
    *
    * @param filters.tag - tag associated with the transaction
    * @param filters.success - whether the transaction was successful or not
@@ -192,14 +193,17 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       success?: boolean;
       size?: BigNumber;
       start?: BigNumber;
-      orderBy?: TransactionOrderByInput;
+      orderBy?: ExtrinsicsOrderBy;
     } = {}
   ): Promise<ResultSet<ExtrinsicData>> {
-    const { tag, success, size, start, orderBy, blockHash } = filters;
-    let order: ExtrinsicsOrderBy = ExtrinsicsOrderBy.CreatedAtAsc;
-    if (orderBy) {
-      order = `${orderBy.field}_${orderBy.order}`.toUpperCase() as ExtrinsicsOrderBy;
-    }
+    const {
+      tag,
+      success,
+      size,
+      start,
+      orderBy = ExtrinsicsOrderBy.CreatedAtAsc,
+      blockHash,
+    } = filters;
 
     const { context, address } = this;
 
@@ -241,7 +245,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
         },
         size,
         start,
-        order
+        orderBy
       )
     );
 

--- a/src/middleware/typesV1.ts
+++ b/src/middleware/typesV1.ts
@@ -13,20 +13,3 @@ export enum SettlementDirectionEnum {
   Incoming = 'Incoming',
   Outgoing = 'Outgoing',
 }
-
-export enum Order {
-  Asc = 'ASC',
-  Desc = 'DESC',
-}
-
-export enum TransactionOrderFields {
-  BlockId = 'block_id',
-  Address = 'address',
-  ModuleId = 'module_id',
-  CallId = 'call_id',
-}
-
-export type TransactionOrderByInput = {
-  field: TransactionOrderFields;
-  order: Order;
-};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,15 +40,8 @@ export * from '~/base/types';
 export * from '~/generated/types';
 export * from '~/middleware/enums';
 
-export {
-  ClaimScopeTypeEnum,
-  MiddlewareScope,
-  SettlementDirectionEnum,
-  TransactionOrderByInput,
-  Order,
-  TransactionOrderFields,
-} from '~/middleware/typesV1';
-export { AssetHoldersOrderBy, Scalars } from '~/middleware/types';
+export { AssetHoldersOrderBy, ExtrinsicsOrderBy, Scalars } from '~/middleware/types';
+export { ClaimScopeTypeEnum, MiddlewareScope, SettlementDirectionEnum } from '~/middleware/typesV1';
 export { CountryCode, ModuleName, TxTag, TxTags };
 
 export enum TransactionStatus {


### PR DESCRIPTION
### Description

The type of the argument `orderBy` in `account.getTransactionHistory` has been changed from `TransactionOrderByInput` to `ExtrinsicsOrderBy`

### Breaking Changes

🧨 `TransactionOrderByInput` has been removed in favour of `ExtrinsicsOrderBy`

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
