### PR TITLE
perf: ⚡️ improve startup time

### DIFF
--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -146,7 +146,7 @@ export class Polymesh {
     let context: Context;
     let polymeshApi: ApiPromise;
 
-    const { metadata, noInitWarn, typesBundle } = polkadot || {};
+    const { metadata, noInitWarn, typesBundle } = polkadot ?? {};
 
     // Defer `await` on any checks to minimize total startup time
     const requiredChecks: Promise<void>[] = [assertExpectedChainVersion(nodeUrl)];

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -180,15 +180,10 @@ export class Polymesh {
 
     if (middlewareV2) {
       let middlewareMetadata = null;
-      let genesisHash;
 
       const checkMiddleware = async (): Promise<void> => {
         try {
-          const rawGenesisBlock = bigNumberToU32(new BigNumber(0), context);
-          [middlewareMetadata, genesisHash] = await Promise.all([
-            context.getMiddlewareMetadata(),
-            polymeshApi.rpc.chain.getBlockHash(rawGenesisBlock),
-          ]);
+          middlewareMetadata = await context.getMiddlewareMetadata();
         } catch (err) {
           throw new PolymeshError({
             code: ErrorCode.FatalError,
@@ -196,7 +191,10 @@ export class Polymesh {
           });
         }
 
-        if (!middlewareMetadata || middlewareMetadata.genesisHash !== genesisHash.toString()) {
+        if (
+          !middlewareMetadata ||
+          middlewareMetadata.genesisHash !== polymeshApi.genesisHash.toString()
+        ) {
           throw new PolymeshError({
             code: ErrorCode.FatalError,
             message: 'Middleware V2 URL is for a different chain than the given node URL',

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -6,7 +6,6 @@ import {
 } from '@apollo/client/core';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { SigningManager } from '@polymeshassociation/signing-manager-types';
-import BigNumber from 'bignumber.js';
 import fetch from 'cross-fetch';
 import schema from 'polymesh-types/schema';
 
@@ -18,7 +17,7 @@ import {
   PolkadotConfig,
   UnsubCallback,
 } from '~/types';
-import { bigNumberToU32, signerToString } from '~/utils/conversion';
+import { signerToString } from '~/utils/conversion';
 import {
   assertExpectedChainVersion,
   assertExpectedSqVersion,

--- a/src/api/client/__tests__/Polymesh.ts
+++ b/src/api/client/__tests__/Polymesh.ts
@@ -1,5 +1,4 @@
 import { SigningManager } from '@polymeshassociation/signing-manager-types';
-import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
 import { Polymesh } from '~/api/client/Polymesh';
@@ -7,7 +6,6 @@ import { PolymeshError, PolymeshTransactionBatch } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { ErrorCode, TransactionArray } from '~/types';
 import { SUPPORTED_NODE_VERSION_RANGE } from '~/utils/constants';
-import * as utilsConversionModule from '~/utils/conversion';
 import * as internalUtils from '~/utils/internal';
 
 jest.mock(
@@ -47,7 +45,6 @@ jest.mock(
 
 describe('Polymesh Class', () => {
   let versionSpy: jest.SpyInstance;
-  let bigNumberToU32Spy: jest.SpyInstance;
   beforeEach(() => {
     versionSpy = jest
       .spyOn(internalUtils, 'assertExpectedChainVersion')
@@ -55,17 +52,7 @@ describe('Polymesh Class', () => {
       .mockImplementation()
       .mockResolvedValue(undefined);
     jest.spyOn(internalUtils, 'assertExpectedSqVersion').mockImplementation();
-    bigNumberToU32Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU32');
     dsMockUtils.configureMocks({ contextOptions: undefined });
-
-    const rawGenesisBlock = dsMockUtils.createMockU32(new BigNumber(0));
-    bigNumberToU32Spy.mockResolvedValue(rawGenesisBlock);
-
-    const genesisHash = 'someGenesisHash';
-    const rawGenesisHash = dsMockUtils.createMockBlockHash(genesisHash);
-
-    const getBlockHashMock = dsMockUtils.createRpcMock('chain', 'getBlockHash');
-    getBlockHashMock.mockResolvedValue(rawGenesisHash);
   });
 
   beforeAll(() => {
@@ -204,10 +191,10 @@ describe('Polymesh Class', () => {
 
     it('should throw an error if the middleware V2 URL is incompatible with given node URl', async () => {
       const genesisHash = 'someOtherHash';
-      const rawGenesisHash = dsMockUtils.createMockBlockHash(genesisHash);
 
-      const getBlockHashMock = dsMockUtils.createRpcMock('chain', 'getBlockHash');
-      getBlockHashMock.mockResolvedValue(rawGenesisHash);
+      const context = dsMockUtils.getContextInstance();
+      jest.spyOn(context.polymeshApi.genesisHash, 'toString').mockReturnValue(genesisHash);
+      dsMockUtils.getContextCreateMock().mockResolvedValue(context);
 
       const connection = Polymesh.connect({
         nodeUrl: 'wss://some.url',

--- a/src/api/client/__tests__/Polymesh.ts
+++ b/src/api/client/__tests__/Polymesh.ts
@@ -128,6 +128,25 @@ describe('Polymesh Class', () => {
       expect(createMock).toHaveBeenCalledTimes(1);
     });
 
+    it('should instantiate Context with Polkadot config and return  Polymesh instance', async () => {
+      const createMock = dsMockUtils.getContextCreateMock();
+
+      const metadata = {
+        someHashAndVersion: '0x00',
+      } as const;
+
+      const polkadot = {
+        metadata,
+      };
+
+      await Polymesh.connect({
+        nodeUrl: 'wss://some.url',
+        polkadot,
+      });
+
+      expect(createMock).toHaveBeenCalledTimes(1);
+    });
+
     it('should throw if the Polymesh version does not satisfy the supported version range', async () => {
       const error = new PolymeshError({
         code: ErrorCode.FatalError,

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -202,6 +202,7 @@ function createApi(): Mutable<ApiPromise> & EventEmitter {
       apiEmitter.off(event, listener),
     disconnect: jest.fn() as () => Promise<void>,
     setSigner: jest.fn() as (signer: PolkadotSigner) => void,
+    genesisHash: { toString: jest.fn().mockReturnValue('someGenesisHash') } as unknown as Hash,
   } as Mutable<ApiPromise> & EventEmitter;
 }
 

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -416,7 +416,7 @@ interface ContextOptions {
   middlewareAvailable?: boolean;
   getMiddlewareMetadata?: MiddlewareMetadata;
   sentAuthorizations?: ResultSet<AuthorizationRequest>;
-  isArchiveNode?: boolean;
+  isCurrentNodeArchive?: boolean;
   ss58Format?: BigNumber;
   areSecondaryAccountsFrozen?: boolean;
   getDividendDistributionsForAssets?: DistributionWithDetails[];
@@ -734,7 +734,7 @@ const defaultContextOptions: ContextOptions = {
     next: new BigNumber(1),
     count: new BigNumber(1),
   },
-  isArchiveNode: true,
+  isCurrentNodeArchive: true,
   ss58Format: new BigNumber(42),
   getDividendDistributionsForAssets: [],
   areSecondaryAccountsFrozen: false,
@@ -858,7 +858,7 @@ function configureContext(opts: ContextOptions): void {
     isMiddlewareEnabled: jest.fn().mockReturnValue(opts.middlewareEnabled),
     isMiddlewareAvailable: jest.fn().mockResolvedValue(opts.middlewareAvailable),
     getMiddlewareMetadata: jest.fn().mockResolvedValue(opts.getMiddlewareMetadata),
-    isArchiveNode: opts.isArchiveNode,
+    isCurrentNodeArchive: jest.fn().mockResolvedValue(opts.isCurrentNodeArchive),
     ss58Format: opts.ss58Format,
     disconnect: jest.fn(),
     getDividendDistributionsForAssets: jest

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 
+import { ApiOptions } from '@polkadot/api/types';
 import { TypeDef } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
@@ -674,6 +675,40 @@ export type UnsubCallback = () => void;
 export interface MiddlewareConfig {
   link: string;
   key: string;
+}
+
+export interface PolkadotConfig {
+  /**
+   * provide a locally saved metadata file for a modestly fast startup time (e.g. 1 second when provided, 1.5 seconds without).
+   *
+   * @note if not provided the SDK will read the needed data from chain during startup
+   *
+   * @note format is key as genesis hash and spec version and the value hex encoded chain metadata
+   *
+   * @example creating valid metadata
+   * ```ts
+   const meta = _polkadotApi.runtimeMetadata.toHex();
+   const genesisHash = _polkadotApi.genesisHash;
+   const specVersion = _polkadotApi.runtimeVersion.specVersion;
+
+  const metadata = {
+    [`${genesisHash}-${specVersion}`]: meta,
+  };
+  ```
+   */
+  metadata?: ApiOptions['metadata'];
+
+  /**
+   * set to `true` to disable polkadot start up warnings
+   */
+  noInitWarn?: boolean;
+
+  /**
+   * allows for types to be provided for multiple chain specs at once
+   *
+   * @note shouldn't be needed for most use cases
+   */
+  typesBundle?: ApiOptions['typesBundle'];
 }
 
 export interface EventIdentifier {

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -521,7 +521,7 @@ describe('getApiAtBlock', () => {
 
   it('should throw an error if the node is not archive', () => {
     const context = dsMockUtils.getContextInstance({
-      isArchiveNode: false,
+      isCurrentNodeArchive: false,
     });
 
     return expect(getApiAtBlock(context, 'blockHash')).rejects.toThrow(
@@ -554,7 +554,7 @@ describe('requestAtBlock', () => {
 
   it('should fetch and return the value at a certain block (current if left empty)', async () => {
     const context = dsMockUtils.getContextInstance({
-      isArchiveNode: true,
+      isCurrentNodeArchive: true,
     });
     const returnValue = dsMockUtils.createMockU32(new BigNumber(5));
     const queryMock = dsMockUtils.createQueryMock('asset', 'tickers', {

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -510,7 +510,9 @@ export async function getApiAtBlock(
   context: Context,
   blockHash: string | BlockHash
 ): Promise<ApiDecoration<'promise'>> {
-  const { polymeshApi, isArchiveNode } = context;
+  const { polymeshApi } = context;
+
+  const isArchiveNode = await context.isCurrentNodeArchive();
 
   if (!isArchiveNode) {
     throw new PolymeshError({


### PR DESCRIPTION
add polkadot options so people can provide metadata to improve startup time. optimizes the rest of `Polymesh.connect` to further improve startup time

- parallizes version checks on connect
- lazy evaluates `isArchiveNode` when needed
- add `polkadot` option to connect. consumer can provide metadata

✅ Closes: DA-838

### Description

<!-- Describe your changes in detail -->

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
