### PR TITLE
fix: 🐛 `canTransfer` method for 5.4 with dual version

### DIFF
--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -139,10 +139,21 @@ export class Context {
     this.polymeshApi = polymeshApi;
     this.ss58Format = ss58Format;
 
+    // `CanTransferGranularReturn` is a 6.0 type. We patch the types here to accommodate the breaking change
+    const registry = polymeshApi.registry;
+    const transferReturnDef = registry.get('CanTransferGranularReturn');
+
     this.unsubChainVersion = polymeshApi.query.system.lastRuntimeUpgrade(upgrade => {
       if (upgrade.isSome) {
         const { specVersion } = upgrade.unwrap();
         this.isV5 = specVersion.toNumber() < 6000000;
+
+        if (this.isV5) {
+          const transferResultDef = registry.get('GranularCanTransferResult');
+          registry.register('CanTransferGranularReturn', transferResultDef);
+        } else {
+          registry.register('CanTransferGranularReturn', transferReturnDef);
+        }
       }
     });
   }

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -1003,7 +1003,10 @@ function initQueryMulti(): void {
  * @hidden
  */
 function initApi(): void {
-  mockInstanceContainer.apiInstance.registry = 'registry' as unknown as Registry;
+  mockInstanceContainer.apiInstance.registry = {
+    get: jest.fn(),
+    register: jest.fn(),
+  } as unknown as Registry;
   mockInstanceContainer.apiInstance.createType = jest.fn();
   mockInstanceContainer.apiInstance.runtimeVersion = {} as RuntimeVersion;
 


### PR DESCRIPTION
### Description

bug was introduced with dual version support because RPC methods are not automatically generated. 5.4 was expecting newer return type. fix works by aliasing the new type name to old response on 5.4

### Breaking Changes

None

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
