### PR TITLE
fix: 🐛 Use `9.0.1` version for `bignumber.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@polkadot/api": "10.9.1",
     "@polkadot/util": "12.4.2",
     "@polkadot/util-crypto": "12.4.2",
-    "bignumber.js": "9.1.2",
+    "bignumber.js": "9.0.1",
     "bluebird": "^3.7.2",
     "cross-fetch": "^4.0.0",
     "dayjs": "1.11.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3909,10 +3909,10 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
   integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
-bignumber.js@9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
-  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+bignumber.js@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
 
 bin-links@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
### Description

The `9.1.2` version of `bignumber.js` doesn't export `./bignumber` path in it's package.json file which errors as `Error
[ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './bignumber' is not defined by "exports"`

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
