### PR TITLE
feat: 🎸 Change implementation of `getCddClaims` to use RPC

### DIFF
--- a/src/api/client/__tests__/Claims.ts
+++ b/src/api/client/__tests__/Claims.ts
@@ -19,6 +19,7 @@ import {
   ScopeType,
 } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
+import * as utilsInternalModule from '~/utils/internal';
 
 jest.mock(
   '~/api/entities/Identity',
@@ -416,34 +417,77 @@ describe('Claims Class', () => {
   });
 
   describe('method: getCddClaims', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
     it('should return a list of cdd claims', async () => {
       const target = 'someTarget';
+      jest.spyOn(utilsInternalModule, 'getDid').mockResolvedValue(target);
 
-      const identityClaims: ClaimData[] = [
-        {
-          target: entityMockUtils.getIdentityInstance({ did: target }),
-          issuer: entityMockUtils.getIdentityInstance({ did: 'otherDid' }),
-          issuedAt: new Date(),
-          lastUpdatedAt: new Date(),
-          expiry: null,
-          claim: {
-            type: ClaimType.CustomerDueDiligence,
-            id: 'someId',
-          },
-        },
-      ];
+      const rawTarget = dsMockUtils.createMockIdentityId(target);
+      jest.spyOn(utilsConversionModule, 'stringToIdentityId').mockReturnValue(rawTarget);
 
-      dsMockUtils.configureMocks({
-        contextOptions: {
-          getIdentityClaimsFromChain: identityClaims,
-        },
+      const claimIssuer = 'someClaimIssuer';
+      const issuanceDate = new Date('2023/01/01');
+      const lastUpdateDate = new Date('2023/06/01');
+      const claim = {
+        type: ClaimType.CustomerDueDiligence,
+        id: 'someCddId',
+      };
+
+      /* eslint-disable @typescript-eslint/naming-convention */
+      const rawIdentityClaim = {
+        claim_issuer: dsMockUtils.createMockIdentityId(claimIssuer),
+        issuance_date: dsMockUtils.createMockMoment(new BigNumber(issuanceDate.getTime())),
+        last_update_date: dsMockUtils.createMockMoment(new BigNumber(lastUpdateDate.getTime())),
+        expiry: dsMockUtils.createMockOption(),
+        claim: dsMockUtils.createMockClaim({
+          CustomerDueDiligence: dsMockUtils.createMockCddId(claim.id),
+        }),
+      };
+      /* eslint-enable @typescript-eslint/naming-convention */
+
+      jest.spyOn(utilsConversionModule, 'identityIdToString').mockReturnValue(claimIssuer);
+      dsMockUtils.createRpcMock('identity', 'validCDDClaims', {
+        returnValue: [rawIdentityClaim],
       });
 
-      let result = await claims.getCddClaims({ target });
-      expect(result).toEqual(identityClaims);
+      const mockResult = {
+        target: expect.objectContaining({
+          did: target,
+        }),
+        issuer: expect.objectContaining({
+          did: claimIssuer,
+        }),
+        issuedAt: issuanceDate,
+        lastUpdatedAt: lastUpdateDate,
+        expiry: null,
+        claim,
+      };
+      let result = await claims.getCddClaims();
 
-      result = await claims.getCddClaims();
-      expect(result).toEqual(identityClaims);
+      expect(result).toEqual([mockResult]);
+
+      const expiry = new Date('2030/01/01');
+      dsMockUtils.createRpcMock('identity', 'validCDDClaims', {
+        returnValue: [
+          {
+            ...rawIdentityClaim,
+            expiry: dsMockUtils.createMockOption(
+              dsMockUtils.createMockMoment(new BigNumber(expiry.getTime()))
+            ),
+          },
+        ],
+      });
+
+      result = await claims.getCddClaims({ target, includeExpired: false });
+
+      expect(result).toEqual([
+        {
+          ...mockResult,
+          expiry,
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
### Description

Changes the implementation of `getCddClaims` to  replaces the use of query storage of `identity.claims` with RPC `identity.validCDDClaims`

### Breaking Changes

NA

### JIRA Link

DA-888

### Checklist

- [ ] Updated the Readme.md (if required) ?
