### PR TITLE
feat: 🎸 add NonFungible details method

### DIFF
--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -226,6 +226,27 @@ export class Assets {
   }
 
   /**
+   * Retrieve an NftCollection
+   *
+   * @param args.ticker - NftCollection ticker
+   */
+  public async getNftCollection(args: { ticker: string }): Promise<NftCollection> {
+    const { ticker } = args;
+
+    const nftCollection = new NftCollection({ ticker }, this.context);
+    const exists = await nftCollection.exists();
+
+    if (!exists) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: `There is no NftCollection with ticker "${ticker}"`,
+      });
+    }
+
+    return nftCollection;
+  }
+
+  /**
    * Retrieve all the Assets on chain
    *
    * @note supports pagination

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -35,7 +35,6 @@ import {
   AccountBalance,
   ActiveTransferRestrictions,
   AgentWithGroup,
-  AssetDetails,
   AssetWithGroup,
   Authorization,
   AuthorizationType,
@@ -49,6 +48,7 @@ import {
   DistributionParticipant,
   DividendDistributionDetails,
   ExtrinsicData,
+  FungibleAssetDetails,
   GroupPermissions,
   IdentityBalance,
   InstructionDetails,
@@ -151,7 +151,7 @@ interface TickerReservationOptions extends EntityOptions {
 interface AssetOptions extends EntityOptions {
   ticker?: string;
   did?: string;
-  details?: EntityGetter<AssetDetails>;
+  details?: EntityGetter<FungibleAssetDetails>;
   currentFundingRound?: EntityGetter<string>;
   isFrozen?: EntityGetter<boolean>;
   transfersCanTransfer?: EntityGetter<TransferStatus>;


### PR DESCRIPTION
### Description

moves current `asset.details` method into `BaseAsset`. `NftCollection` wraps the base call to return `totalSupply` property.

NftCollection needs to make an additional call to the chain and iterate all holders to calculate `totalSupply` of the Nfts, which is the number of held NFTs in the collection.

A deferred optimization is to leverage middleware (SubQuery) when provided. However it is expected a single collection would need hundreds of unique holders before performance improvements become noticable.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
