### PR TITLE
feat: 🎸 add NFT support for portfolios

### DIFF
--- a/src/api/entities/Asset/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/NonFungible/Nft.ts
@@ -18,8 +18,6 @@ export type NftUniqueIdentifiers = {
  * Class used to manage Nft functionality
  */
 export class Nft extends Entity<NftUniqueIdentifiers, string> {
-  public ticker: string;
-
   public id: BigNumber;
 
   public collection: NftCollection;
@@ -44,7 +42,6 @@ export class Nft extends Entity<NftUniqueIdentifiers, string> {
 
     const { ticker, id } = identifiers;
 
-    this.ticker = ticker;
     this.id = id;
 
     this.collection = new NftCollection({ ticker }, context);
@@ -107,7 +104,10 @@ export class Nft extends Entity<NftUniqueIdentifiers, string> {
    * @hidden
    */
   public toHuman(): string {
-    const { ticker, id } = this;
+    const {
+      collection: { ticker },
+      id,
+    } = this;
 
     return JSON.stringify({
       ticker,

--- a/src/api/entities/Asset/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/NonFungible/Nft.ts
@@ -14,10 +14,15 @@ export type NftUniqueIdentifiers = {
   id: BigNumber;
 };
 
+export interface HumanReadable {
+  id: string;
+  collection: string;
+}
+
 /**
  * Class used to manage Nft functionality
  */
-export class Nft extends Entity<NftUniqueIdentifiers, string> {
+export class Nft extends Entity<NftUniqueIdentifiers, HumanReadable> {
   public id: BigNumber;
 
   public collection: NftCollection;
@@ -103,15 +108,15 @@ export class Nft extends Entity<NftUniqueIdentifiers, string> {
   /**
    * @hidden
    */
-  public toHuman(): string {
+  public toHuman(): HumanReadable {
     const {
       collection: { ticker },
       id,
     } = this;
 
-    return JSON.stringify({
-      ticker,
-      id,
-    });
+    return {
+      collection: ticker,
+      id: id.toString(),
+    };
   }
 }

--- a/src/api/entities/Asset/__tests__/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/Nft.ts
@@ -138,7 +138,7 @@ describe('Nft class', () => {
       const ticker = 'TICKER';
       const nft = new Nft({ ticker, id: new BigNumber(1) }, context);
 
-      expect(nft.toHuman()).toBe('{"ticker":"TICKER","id":"1"}');
+      expect(nft.toHuman()).toEqual({ collection: 'TICKER', id: '1' });
     });
   });
 });

--- a/src/api/entities/Asset/__tests__/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/Nft.ts
@@ -42,7 +42,7 @@ describe('Nft class', () => {
       const id = new BigNumber(1);
       const nft = new Nft({ ticker, id }, context);
 
-      expect(nft.ticker).toBe(ticker);
+      expect(nft.collection.ticker).toBe(ticker);
       expect(nft.id).toEqual(id);
       expect(nft.collection.ticker).toEqual(ticker);
     });

--- a/src/api/entities/Asset/__tests__/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/NftCollection.ts
@@ -35,6 +35,7 @@ describe('NftCollection class', () => {
   afterAll(() => {
     dsMockUtils.cleanup();
     procedureMockUtils.cleanup();
+    jest.clearAllMocks();
   });
 
   it('should extend Entity', () => {

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -286,7 +286,7 @@ describe('Portfolio class', () => {
     });
   });
 
-  describe('method: getNftsHeld', () => {
+  describe('method: getCollections', () => {
     let did: string;
     let id: BigNumber;
     let secondId: BigNumber;
@@ -351,12 +351,12 @@ describe('Portfolio class', () => {
     it("should return all of the portfolio's NFTs when no args are given", async () => {
       const portfolio = new NonAbstract({ did, id }, context);
 
-      const result = await portfolio.getNftsHeld();
+      const result = await portfolio.getCollections();
 
       expect(result).toEqual(
         expect.arrayContaining([
           {
-            asset: expect.objectContaining({ ticker }),
+            collection: expect.objectContaining({ ticker }),
             free: expect.arrayContaining([
               expect.objectContaining({ id }),
               expect.objectContaining({ id: secondId }),
@@ -365,7 +365,7 @@ describe('Portfolio class', () => {
             total: new BigNumber(2),
           },
           {
-            asset: expect.objectContaining({ ticker: lockedTicker }),
+            collection: expect.objectContaining({ ticker: lockedTicker }),
             free: [],
             locked: [expect.objectContaining({ id: lockedId })],
             total: new BigNumber(1),
@@ -377,12 +377,12 @@ describe('Portfolio class', () => {
     it('should filter assets if any are specified', async () => {
       const portfolio = new NonAbstract({ did, id }, context);
 
-      const result = await portfolio.getNftsHeld({ assets: [ticker] });
+      const result = await portfolio.getCollections({ collections: [ticker] });
 
       expect(result).toEqual(
         expect.arrayContaining([
           {
-            asset: expect.objectContaining({ ticker }),
+            collection: expect.objectContaining({ ticker }),
             free: expect.arrayContaining([
               expect.objectContaining({ id }),
               expect.objectContaining({ id: secondId }),
@@ -398,7 +398,7 @@ describe('Portfolio class', () => {
       const portfolio = new NonAbstract({ did, id }, context);
       exists = false;
 
-      return expect(portfolio.getNftsHeld()).rejects.toThrow(
+      return expect(portfolio.getCollections()).rejects.toThrow(
         "The Portfolio doesn't exist or was removed by its owner"
       );
     });

--- a/src/api/entities/Portfolio/types.ts
+++ b/src/api/entities/Portfolio/types.ts
@@ -1,16 +1,28 @@
 import BigNumber from 'bignumber.js';
 
-import { Account, FungibleAsset } from '~/internal';
+import { Account, FungibleAsset, Nft } from '~/internal';
 import { SettlementResultEnum as SettlementResult } from '~/middleware/enums';
 import { SettlementDirectionEnum as SettlementDirection } from '~/middleware/typesV1';
-import { Balance, Leg, NftCollection, NftHolding } from '~/types';
+import { Balance, Leg, NftCollection } from '~/types';
 
 export interface PortfolioBalance extends Balance {
   asset: FungibleAsset;
 }
 
-export interface PortfolioNftHolding extends NftHolding {
-  asset: NftCollection;
+export interface PortfolioCollection {
+  collection: NftCollection;
+  /**
+   * NFTs available for transferring
+   */
+  free: Nft[];
+  /**
+   * NFTs that are locked, such as being involved in a pending instruction
+   */
+  locked: Nft[];
+  /**
+   * Total number of NFTs held for a collection
+   */
+  total: BigNumber;
 }
 
 export interface SettlementLeg extends Leg {

--- a/src/api/entities/Portfolio/types.ts
+++ b/src/api/entities/Portfolio/types.ts
@@ -3,10 +3,14 @@ import BigNumber from 'bignumber.js';
 import { Account, FungibleAsset } from '~/internal';
 import { SettlementResultEnum as SettlementResult } from '~/middleware/enums';
 import { SettlementDirectionEnum as SettlementDirection } from '~/middleware/typesV1';
-import { Balance, Leg } from '~/types';
+import { Balance, Leg, NftCollection, NftHolding } from '~/types';
 
 export interface PortfolioBalance extends Balance {
   asset: FungibleAsset;
+}
+
+export interface PortfolioNftHolding extends NftHolding {
+  asset: NftCollection;
 }
 
 export interface SettlementLeg extends Leg {

--- a/src/api/procedures/__tests__/issueNft.ts
+++ b/src/api/procedures/__tests__/issueNft.ts
@@ -24,6 +24,10 @@ jest.mock(
   '~/api/entities/Asset/NonFungible',
   require('~/testUtils/mocks/entities').mockNftCollectionModule('~/api/entities/Asset/NonFungible')
 );
+jest.mock(
+  '~/api/entities/Asset/NonFungible',
+  require('~/testUtils/mocks/entities').mockNftModule('~/api/entities/Asset/NonFungible')
+);
 
 describe('issueNft procedure', () => {
   let mockContext: Mocked<Context>;
@@ -318,7 +322,7 @@ describe('issueNft procedure', () => {
       const context = dsMockUtils.getContextInstance();
       const result = issueNftResolver(context)({} as ISubmittableResult);
 
-      expect(result).toEqual(expect.objectContaining({ ticker }));
+      expect(result.collection).toEqual(expect.objectContaining({ ticker }));
     });
   });
 });

--- a/src/api/procedures/__tests__/moveFunds.ts
+++ b/src/api/procedures/__tests__/moveFunds.ts
@@ -19,11 +19,11 @@ import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mo
 import { Mocked } from '~/testUtils/types';
 import {
   ErrorCode,
+  FungiblePortfolioMovement,
+  NonFungiblePortfolioMovement,
   PortfolioBalance,
   PortfolioId,
   PortfolioMovement,
-  PortfolioMovementFungible,
-  PortfolioMovementNonFungible,
   RoleType,
   TxTags,
 } from '~/types';
@@ -61,11 +61,11 @@ describe('moveFunds procedure', () => {
   >;
   let fungiblePortfolioMovementToMovePortfolioFundSpy: jest.SpyInstance<
     PolymeshPrimitivesPortfolioFund,
-    [PortfolioMovementFungible, Context]
+    [FungiblePortfolioMovement, Context]
   >;
   let nftMovementToMovePortfolioFundSpy: jest.SpyInstance<
     PolymeshPrimitivesPortfolioFund,
-    [PortfolioMovementNonFungible, Context]
+    [NonFungiblePortfolioMovement, Context]
   >;
   let portfolioLikeToPortfolioIdSpy: jest.SpyInstance;
   let assertPortfolioExistsSpy: jest.SpyInstance;
@@ -252,12 +252,12 @@ describe('moveFunds procedure', () => {
       numberedPortfolioOptions: {
         did,
         getAssetBalances: [],
-        getNftsHeld: [],
+        getCollections: [],
       },
       defaultPortfolioOptions: {
         did,
         getAssetBalances: [],
-        getNftsHeld: [],
+        getCollections: [],
       },
     });
 
@@ -332,7 +332,7 @@ describe('moveFunds procedure', () => {
       nftCollectionOptions: { exists: false },
     });
 
-    const items: PortfolioMovementFungible[] = [
+    const items: FungiblePortfolioMovement[] = [
       {
         asset: asset.ticker,
         amount: new BigNumber(100),
@@ -343,12 +343,12 @@ describe('moveFunds procedure', () => {
       numberedPortfolioOptions: {
         did,
         getAssetBalances: [{ asset, total: new BigNumber(150) }] as unknown as PortfolioBalance[],
-        getNftsHeld: [],
+        getCollections: [],
       },
       defaultPortfolioOptions: {
         did,
         getAssetBalances: [{ asset, total: new BigNumber(150) }] as unknown as PortfolioBalance[],
-        getNftsHeld: [],
+        getCollections: [],
       },
     });
 
@@ -489,7 +489,7 @@ describe('moveFunds procedure', () => {
     const nftOne = new Nft({ ticker, id: new BigNumber(1) }, context);
     const nftTwo = new Nft({ ticker: assetTwo.ticker, id: new BigNumber(2) }, context);
 
-    const items: PortfolioMovementNonFungible[] = [
+    const items: NonFungiblePortfolioMovement[] = [
       {
         asset: asset.ticker,
         nfts: [nftOne.id],
@@ -504,15 +504,15 @@ describe('moveFunds procedure', () => {
       numberedPortfolioOptions: {
         did,
         getAssetBalances: [],
-        getNftsHeld: [
-          { asset, free: [nftOne], locked: [], total: new BigNumber(1) },
-          { asset: assetTwo, free: [nftTwo], locked: [], total: new BigNumber(1) },
+        getCollections: [
+          { collection: asset, free: [nftOne], locked: [], total: new BigNumber(1) },
+          { collection: assetTwo, free: [nftTwo], locked: [], total: new BigNumber(1) },
         ],
       },
       defaultPortfolioOptions: {
         did,
         getAssetBalances: [],
-        getNftsHeld: [],
+        getCollections: [],
       },
     });
 

--- a/src/api/procedures/__tests__/redeemTokens.ts
+++ b/src/api/procedures/__tests__/redeemTokens.ts
@@ -21,6 +21,10 @@ jest.mock(
   require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
 );
 jest.mock(
+  '~/api/entities/Asset/NonFungible',
+  require('~/testUtils/mocks/entities').mockNftCollectionModule('~/api/entities/Asset/NonFungible')
+);
+jest.mock(
   '~/api/entities/DefaultPortfolio',
   require('~/testUtils/mocks/entities').mockDefaultPortfolioModule(
     '~/api/entities/DefaultPortfolio'

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -77,7 +77,7 @@ import {
   PermissionGroups,
   PermissionGroupType,
   PortfolioBalance,
-  PortfolioNftHolding,
+  PortfolioCollection,
   ProposalStatus,
   ResultSet,
   ScheduleDetails,
@@ -260,7 +260,7 @@ interface NumberedPortfolioOptions extends EntityOptions {
   id?: BigNumber;
   isOwnedBy?: EntityGetter<boolean>;
   getAssetBalances?: EntityGetter<PortfolioBalance[]>;
-  getNftsHeld?: EntityGetter<PortfolioNftHolding[]>;
+  getCollections?: EntityGetter<PortfolioCollection[]>;
   getCustodian?: EntityGetter<Identity>;
   isCustodiedBy?: EntityGetter<boolean>;
 }
@@ -269,7 +269,7 @@ interface DefaultPortfolioOptions extends EntityOptions {
   did?: string;
   isOwnedBy?: EntityGetter<boolean>;
   getAssetBalances?: EntityGetter<PortfolioBalance[]>;
-  getNftsHeld?: EntityGetter<PortfolioNftHolding[]>;
+  getCollections?: EntityGetter<PortfolioCollection[]>;
   getCustodian?: EntityGetter<Identity>;
   isCustodiedBy?: EntityGetter<boolean>;
 }
@@ -1478,7 +1478,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
     owner!: Identity;
     isOwnedBy!: jest.Mock;
     getAssetBalances!: jest.Mock;
-    getNftsHeld!: jest.Mock;
+    getCollections!: jest.Mock;
     getCustodian!: jest.Mock;
     isCustodiedBy!: jest.Mock;
 
@@ -1498,7 +1498,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
       this.owner = getIdentityInstance({ did: opts.did });
       this.isOwnedBy = createEntityGetterMock(opts.isOwnedBy);
       this.getAssetBalances = createEntityGetterMock(opts.getAssetBalances);
-      this.getNftsHeld = createEntityGetterMock(opts.getNftsHeld);
+      this.getCollections = createEntityGetterMock(opts.getCollections);
       this.getCustodian = createEntityGetterMock(opts.getCustodian);
       this.isCustodiedBy = createEntityGetterMock(opts.isCustodiedBy);
     }
@@ -1514,7 +1514,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
         free: new BigNumber(1),
       },
     ],
-    getNftsHeld: [],
+    getCollections: [],
     did: 'someDid',
     getCustodian: getIdentityInstance(),
     isCustodiedBy: true,
@@ -1532,7 +1532,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
     owner!: Identity;
     isOwnedBy!: jest.Mock;
     getAssetBalances!: jest.Mock;
-    getNftsHeld!: jest.Mock;
+    getCollections!: jest.Mock;
     getCustodian!: jest.Mock;
     isCustodiedBy!: jest.Mock;
 
@@ -1551,7 +1551,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
       this.owner = getIdentityInstance({ did: opts.did });
       this.isOwnedBy = createEntityGetterMock(opts.isOwnedBy);
       this.getAssetBalances = createEntityGetterMock(opts.getAssetBalances);
-      this.getNftsHeld = createEntityGetterMock(opts.getNftsHeld);
+      this.getCollections = createEntityGetterMock(opts.getCollections);
       this.getCustodian = createEntityGetterMock(opts.getCustodian);
       this.isCustodiedBy = createEntityGetterMock(opts.isCustodiedBy);
     }
@@ -1566,7 +1566,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
         free: new BigNumber(1),
       },
     ],
-    getNftsHeld: [],
+    getCollections: [],
     did: 'someDid',
     getCustodian: getIdentityInstance(),
     isCustodiedBy: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -743,21 +743,6 @@ export interface Balance {
   total: BigNumber;
 }
 
-export interface NftHolding {
-  /**
-   * NFTs available for transferring
-   */
-  free: Nft[];
-  /**
-   * NFTs that are locked, such as being involved in a pending instruction
-   */
-  locked: Nft[];
-  /**
-   * Total number of NFTs held for a collection
-   */
-  total: BigNumber;
-}
-
 export type AccountBalance = Balance;
 
 export interface PaginationOptions {
@@ -1286,7 +1271,7 @@ export type PermissionsLike = {
     }
 );
 
-export interface PortfolioMovementFungible {
+export interface FungiblePortfolioMovement {
   asset: string | FungibleAsset;
   amount: BigNumber;
   /**
@@ -1295,7 +1280,7 @@ export interface PortfolioMovementFungible {
   memo?: string;
 }
 
-export type PortfolioMovementNonFungible = {
+export type NonFungiblePortfolioMovement = {
   asset: NftCollection | string;
   nfts: (Nft | BigNumber)[];
   /**
@@ -1304,7 +1289,7 @@ export type PortfolioMovementNonFungible = {
   memo?: string;
 };
 
-export type PortfolioMovement = PortfolioMovementFungible | PortfolioMovementNonFungible;
+export type PortfolioMovement = FungiblePortfolioMovement | NonFungiblePortfolioMovement;
 export interface ProcedureAuthorizationStatus {
   /**
    * whether the Identity complies with all required Agent permissions

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,8 @@ import {
   Identity,
   Instruction,
   KnownPermissionGroup,
+  Nft,
+  NftCollection,
   NumberedPortfolio,
   Offering,
   PolymeshTransaction,
@@ -741,6 +743,21 @@ export interface Balance {
   total: BigNumber;
 }
 
+export interface NftHolding {
+  /**
+   * NFTs available for transferring
+   */
+  free: Nft[];
+  /**
+   * NFTs that are locked, such as being involved in a pending instruction
+   */
+  locked: Nft[];
+  /**
+   * Total number of NFTs held for a collection
+   */
+  total: BigNumber;
+}
+
 export type AccountBalance = Balance;
 
 export interface PaginationOptions {
@@ -1269,7 +1286,7 @@ export type PermissionsLike = {
     }
 );
 
-export interface PortfolioMovement {
+export interface PortfolioMovementFungible {
   asset: string | FungibleAsset;
   amount: BigNumber;
   /**
@@ -1278,6 +1295,16 @@ export interface PortfolioMovement {
   memo?: string;
 }
 
+export type PortfolioMovementNonFungible = {
+  asset: NftCollection | string;
+  nfts: (Nft | BigNumber)[];
+  /**
+   * identifier string to help differentiate transfers
+   */
+  memo?: string;
+};
+
+export type PortfolioMovement = PortfolioMovementFungible | PortfolioMovementNonFungible;
 export interface ProcedureAuthorizationStatus {
   /**
    * whether the Identity complies with all required Agent permissions

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -40,6 +40,7 @@ import {
   PolymeshPrimitivesMemo,
   PolymeshPrimitivesMultisigProposalStatus,
   PolymeshPrimitivesNftNftMetadataAttribute,
+  PolymeshPrimitivesNftNfTs,
   PolymeshPrimitivesPortfolioFund,
   PolymeshPrimitivesSecondaryKeySignatory,
   PolymeshPrimitivesSettlementLeg,
@@ -130,6 +131,7 @@ import {
   PermissionsLike,
   PermissionType,
   PortfolioMovement,
+  PortfolioMovementNonFungible,
   ProposalStatus,
   Scope,
   ScopeType,
@@ -204,6 +206,7 @@ import {
   fundingRoundToAssetFundingRound,
   fundraiserTierToTier,
   fundraiserToOfferingDetails,
+  fungibleMovementToPortfolioFund,
   granularCanTransferResultToTransferBreakdown,
   hashToString,
   identitiesToBtreeSet,
@@ -252,6 +255,8 @@ import {
   momentToDate,
   nameToAssetName,
   nftInputToNftMetadataVec,
+  nftMovementToPortfolioFund,
+  nftToMeshNft,
   offeringTierToPriceTier,
   percentageToPermill,
   permillToBigNumber,
@@ -261,7 +266,6 @@ import {
   portfolioIdToMeshPortfolioId,
   portfolioLikeToPortfolio,
   portfolioLikeToPortfolioId,
-  portfolioMovementToPortfolioFund,
   portfolioToPortfolioKind,
   posRatioToBigNumber,
   requirementToComplianceRequirement,
@@ -456,7 +460,7 @@ describe('stringToBytes and bytesToString', () => {
   });
 });
 
-describe('portfolioMovementToPortfolioFund', () => {
+describe('fungibleMovementToPortfolioFund', () => {
   beforeAll(() => {
     dsMockUtils.initMocks();
     entityMockUtils.initMocks();
@@ -508,7 +512,7 @@ describe('portfolioMovementToPortfolioFund', () => {
       })
       .mockReturnValue(fakeResult);
 
-    let result = portfolioMovementToPortfolioFund(portfolioMovement, context);
+    let result = fungibleMovementToPortfolioFund(portfolioMovement, context);
 
     expect(result).toBe(fakeResult);
 
@@ -517,7 +521,7 @@ describe('portfolioMovementToPortfolioFund', () => {
       amount,
     };
 
-    result = portfolioMovementToPortfolioFund(portfolioMovement, context);
+    result = fungibleMovementToPortfolioFund(portfolioMovement, context);
 
     expect(result).toBe(fakeResult);
 
@@ -543,7 +547,98 @@ describe('portfolioMovementToPortfolioFund', () => {
       memo,
     };
 
-    result = portfolioMovementToPortfolioFund(portfolioMovement, context);
+    result = fungibleMovementToPortfolioFund(portfolioMovement, context);
+
+    expect(result).toBe(fakeResult);
+  });
+});
+
+describe('nftMovementToPortfolioFund', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should convert a portfolio item into a polkadot move portfolio item', () => {
+    const context = dsMockUtils.getContextInstance();
+    const ticker = 'COLLECTION';
+    const id = new BigNumber(1);
+    const memo = 'someMessage';
+    const asset = entityMockUtils.getNftCollectionInstance({ ticker });
+    const rawTicker = dsMockUtils.createMockTicker(ticker);
+    const rawId = dsMockUtils.createMockU64(id);
+    const rawMemo = 'memo' as unknown as PolymeshPrimitivesMemo;
+    const fakeResult =
+      'PolymeshPrimitivesPortfolioFund' as unknown as PolymeshPrimitivesPortfolioFund;
+
+    let portfolioMovement: PortfolioMovementNonFungible = {
+      asset: ticker,
+      nfts: [id],
+    };
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesTicker', padString(ticker, 12))
+      .mockReturnValue(rawTicker);
+
+    when(context.createType).calledWith('u64', id.toString()).mockReturnValue(rawId);
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesPortfolioFund', {
+        description: {
+          NonFungible: {
+            ticker: rawTicker,
+            ids: [rawId],
+          },
+        },
+        memo: null,
+      })
+      .mockReturnValue(fakeResult);
+
+    let result = nftMovementToPortfolioFund(portfolioMovement, context);
+
+    expect(result).toBe(fakeResult);
+
+    portfolioMovement = {
+      asset,
+      nfts: [id],
+    };
+
+    result = nftMovementToPortfolioFund(portfolioMovement, context);
+
+    expect(result).toBe(fakeResult);
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesMemo', padString(memo, 32))
+      .mockReturnValue(rawMemo);
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesPortfolioFund', {
+        description: {
+          NonFungible: {
+            ticker: rawTicker,
+            ids: [rawId],
+          },
+        },
+        memo: rawMemo,
+      })
+      .mockReturnValue(fakeResult);
+
+    portfolioMovement = {
+      asset,
+      nfts: [id],
+      memo,
+    };
+
+    result = nftMovementToPortfolioFund(portfolioMovement, context);
 
     expect(result).toBe(fakeResult);
   });
@@ -9420,6 +9515,45 @@ describe('nftInputToNftMetadataAttribute', () => {
     const input = [{ type: MetadataType.Local, id, value }];
 
     const result = nftInputToNftMetadataVec(input, context);
+
+    expect(result).toEqual(mockResult);
+  });
+});
+
+describe('nftToMeshNft', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should converts Nft input', () => {
+    const ticker = 'TICKER';
+    const rawTicker = dsMockUtils.createMockTicker(ticker);
+    const id = new BigNumber(1);
+    const rawId = dsMockUtils.createMockU64(id);
+    const context = dsMockUtils.getContextInstance();
+
+    const mockResult = 'mockResult' as unknown as PolymeshPrimitivesNftNfTs;
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesTicker', padString(ticker, MAX_TICKER_LENGTH))
+      .mockReturnValue(rawTicker);
+    when(context.createType).calledWith('u64', id.toString()).mockReturnValue(rawId);
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesNftNfTs', {
+        ticker: rawTicker,
+        ids: [rawId],
+      })
+      .mockReturnValue(mockResult);
+
+    const result = nftToMeshNft(ticker, [id], context);
 
     expect(result).toEqual(mockResult);
   });

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -122,6 +122,7 @@ import {
   MetadataLockStatus,
   MetadataType,
   ModuleName,
+  NonFungiblePortfolioMovement,
   OfferingBalanceStatus,
   OfferingSaleStatus,
   OfferingTier,
@@ -131,7 +132,6 @@ import {
   PermissionsLike,
   PermissionType,
   PortfolioMovement,
-  PortfolioMovementNonFungible,
   ProposalStatus,
   Scope,
   ScopeType,
@@ -580,7 +580,7 @@ describe('nftMovementToPortfolioFund', () => {
     const fakeResult =
       'PolymeshPrimitivesPortfolioFund' as unknown as PolymeshPrimitivesPortfolioFund;
 
-    let portfolioMovement: PortfolioMovementNonFungible = {
+    let portfolioMovement: NonFungiblePortfolioMovement = {
       asset: ticker,
       nfts: [id],
     };

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -11,7 +11,15 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
-import { Account, Context, FungibleAsset, Identity, PolymeshError, Procedure } from '~/internal';
+import {
+  Account,
+  Context,
+  FungibleAsset,
+  Identity,
+  Nft,
+  PolymeshError,
+  Procedure,
+} from '~/internal';
 import { latestSqVersionQuery } from '~/middleware/queries';
 import { ClaimScopeTypeEnum } from '~/middleware/typesV1';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
@@ -53,6 +61,7 @@ import {
   asAccount,
   asChildIdentity,
   asFungibleAsset,
+  asNftId,
   assertAddressValid,
   assertExpectedChainVersion,
   assertExpectedSqVersion,
@@ -2178,5 +2187,26 @@ describe('asFungibleAsset', () => {
     const result = asFungibleAsset(baseAsset, mockContext);
 
     expect(result).toEqual(expect.objectContaining({ ticker }));
+  });
+});
+
+describe('asNftId', () => {
+  it('should return a BigNumber when given an NFT', () => {
+    const context = dsMockUtils.getContextInstance();
+    const id = new BigNumber(1);
+    const ticker = 'TICKER';
+    const nft = new Nft({ id, ticker }, context);
+
+    const result = asNftId(nft);
+
+    expect(result).toEqual(id);
+  });
+
+  it('should return a BigNumber when given a BigNumber', () => {
+    const id = new BigNumber(1);
+
+    const result = asNftId(id);
+
+    expect(result).toEqual(id);
   });
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -150,6 +150,7 @@ import {
   ErrorCode,
   EventIdentifier,
   ExternalAgentCondition,
+  FungiblePortfolioMovement,
   HistoricInstruction,
   IdentityCondition,
   IdentityWithClaims,
@@ -172,6 +173,7 @@ import {
   ModuleName,
   MultiClaimCondition,
   NftMetadataInput,
+  NonFungiblePortfolioMovement,
   OfferingBalanceStatus,
   OfferingDetails,
   OfferingSaleStatus,
@@ -184,8 +186,6 @@ import {
   PermissionType,
   PortfolioId,
   PortfolioLike,
-  PortfolioMovementFungible,
-  PortfolioMovementNonFungible,
   ProposalStatus,
   Requirement,
   RequirementCompliance,
@@ -2971,7 +2971,7 @@ export function nftToMeshNft(
  * @hidden
  */
 export function fungibleMovementToPortfolioFund(
-  portfolioItem: PortfolioMovementFungible,
+  portfolioItem: FungiblePortfolioMovement,
   context: Context
 ): PolymeshPrimitivesPortfolioFund {
   const { asset, amount, memo } = portfolioItem;
@@ -2991,7 +2991,7 @@ export function fungibleMovementToPortfolioFund(
  * @hidden
  */
 export function nftMovementToPortfolioFund(
-  portfolioItem: PortfolioMovementNonFungible,
+  portfolioItem: NonFungiblePortfolioMovement,
   context: Context
 ): PolymeshPrimitivesPortfolioFund {
   const { asset, nfts, memo } = portfolioItem;

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -184,7 +184,8 @@ import {
   PermissionType,
   PortfolioId,
   PortfolioLike,
-  PortfolioMovement,
+  PortfolioMovementFungible,
+  PortfolioMovementNonFungible,
   ProposalStatus,
   Requirement,
   RequirementCompliance,
@@ -239,6 +240,7 @@ import {
 } from '~/utils/constants';
 import {
   asDid,
+  asNftId,
   assertAddressValid,
   assertIsInteger,
   assertIsPositive,
@@ -2954,8 +2956,22 @@ export function toIdentityWithClaimsArray(
 /**
  * @hidden
  */
-export function portfolioMovementToPortfolioFund(
-  portfolioItem: PortfolioMovement,
+export function nftToMeshNft(
+  ticker: string,
+  ids: BigNumber[],
+  context: Context
+): PolymeshPrimitivesNftNfTs {
+  return context.createType('PolymeshPrimitivesNftNfTs', {
+    ticker: stringToTicker(ticker, context),
+    ids: ids.map(id => bigNumberToU64(id, context)),
+  });
+}
+
+/**
+ * @hidden
+ */
+export function fungibleMovementToPortfolioFund(
+  portfolioItem: PortfolioMovementFungible,
   context: Context
 ): PolymeshPrimitivesPortfolioFund {
   const { asset, amount, memo } = portfolioItem;
@@ -2965,6 +2981,26 @@ export function portfolioMovementToPortfolioFund(
       Fungible: {
         ticker: stringToTicker(asTicker(asset), context),
         amount: bigNumberToBalance(amount, context),
+      },
+    },
+    memo: optionize(stringToMemo)(memo, context),
+  });
+}
+
+/**
+ * @hidden
+ */
+export function nftMovementToPortfolioFund(
+  portfolioItem: PortfolioMovementNonFungible,
+  context: Context
+): PolymeshPrimitivesPortfolioFund {
+  const { asset, nfts, memo } = portfolioItem;
+
+  return context.createType('PolymeshPrimitivesPortfolioFund', {
+    description: {
+      NonFungible: {
+        ticker: stringToTicker(asTicker(asset), context),
+        ids: nfts.map(nftId => bigNumberToU64(asNftId(nftId), context)),
       },
     },
     memo: optionize(stringToMemo)(memo, context),

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -37,6 +37,7 @@ import {
   Context,
   FungibleAsset,
   Identity,
+  Nft,
   NftCollection,
   PolymeshError,
 } from '~/internal';
@@ -1791,4 +1792,15 @@ export function assembleAssetQuery(
       return new FungibleAsset({ ticker }, context);
     }
   });
+}
+
+/**
+ * @hidden
+ */
+export function asNftId(nft: Nft | BigNumber): BigNumber {
+  if (nft instanceof BigNumber) {
+    return nft;
+  } else {
+    return nft.id;
+  }
 }

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -16,6 +16,7 @@ import {
   Identity,
   Instruction,
   KnownPermissionGroup,
+  NftCollection,
   NumberedPortfolio,
   Offering,
   PolymeshError,
@@ -42,7 +43,6 @@ import {
   JurisdictionClaim,
   KycClaim,
   MultiClaimCondition,
-  NftCollection,
   PortfolioCustodianRole,
   ProposalStatus,
   Role,
@@ -361,5 +361,5 @@ export function isFungibleAsset(asset: BaseAsset): asset is FungibleAsset {
  * Return whether an asset is a NftCollection
  */
 export function isNftCollection(asset: BaseAsset): asset is NftCollection {
-  return asset instanceof FungibleAsset;
+  return asset instanceof NftCollection;
 }


### PR DESCRIPTION
### Description

Add `.getCollections` to portfolios to retrieve held NFTs. `portfolio.moveFunds` has been extended to support NFT movements.

### Breaking Changes

None

### JIRA Link

[DA-879](https://polymesh.atlassian.net/browse/DA-879)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-879]: https://polymesh.atlassian.net/browse/DA-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ