### PR TITLE
fix: 🐛 getAssets where ticker was not being padded for query

### DIFF
--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -288,7 +288,7 @@ export class Assets {
       }
     );
 
-    const details = await tokens.multi(tickers);
+    const details = await tokens.multi(tickers.map(ticker => stringToTicker(ticker, context)));
 
     const data = assembleAssetQuery(details, tickers, context);
 

--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -26,6 +26,7 @@ import {
   bytesToString,
   meshMetadataSpecToMetadataSpec,
   stringToIdentityId,
+  stringToTicker,
   tickerToString,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -197,7 +198,6 @@ export class Assets {
     const ownedTickers = entries.reduce<string[]>((result, [key, relation]) => {
       if (relation.isAssetOwned) {
         const ticker = tickerToString(key.args[1]);
-
         if (isPrintableAscii(ticker)) {
           result.push(ticker);
         }
@@ -206,7 +206,9 @@ export class Assets {
       return result;
     }, []);
 
-    const ownedDetails = await query.asset.tokens.multi(ownedTickers);
+    const ownedDetails = await query.asset.tokens.multi(
+      ownedTickers.map(ticker => stringToTicker(ticker, context))
+    );
 
     return assembleAssetQuery(ownedDetails, ownedTickers, context);
   }


### PR DESCRIPTION
### Description

fixes `getAssets` method which would fail for certain tickers

### Breaking Changes

None

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
