### PR TITLE
feat: 🎸 Add method to check if an identity is a child identity

### DIFF
--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -77,6 +77,12 @@ jest.mock(
   )
 );
 jest.mock(
+  '~/api/entities/Identity/ChildIdentity',
+  require('~/testUtils/mocks/entities').mockChildIdentityModule(
+    '~/api/entities/Identity/ChildIdentity'
+  )
+);
+jest.mock(
   '~/api/entities/Instruction',
   require('~/testUtils/mocks/entities').mockInstructionModule('~/api/entities/Instruction')
 );
@@ -1231,6 +1237,30 @@ describe('Identity class', () => {
       const transaction = await identity.unlinkChild(args);
 
       expect(transaction).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: isChild', () => {
+    it('should return whether the Identity is a child Identity', async () => {
+      entityMockUtils.configureMocks({
+        childIdentityOptions: {
+          exists: true,
+        },
+      });
+      const identity = new Identity({ did: 'someDid' }, context);
+      let result = await identity.isChild();
+
+      expect(result).toBeTruthy();
+
+      entityMockUtils.configureMocks({
+        childIdentityOptions: {
+          exists: false,
+        },
+      });
+
+      result = await identity.isChild();
+
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -850,4 +850,15 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    *  - the transaction signer is not the primary key of the parent identity
    */
   public unlinkChild: ProcedureMethod<UnlinkChildParams, void>;
+
+  /**
+   * Check whether this Identity is a child Identity
+   */
+  public async isChild(): Promise<boolean> {
+    const { did, context } = this;
+
+    const childIdentity = new ChildIdentity({ did }, context);
+
+    return childIdentity.exists();
+  }
 }


### PR DESCRIPTION

### Description

Add method to check if an identity is a child identity. This add `isChild` method to the `Identity` entity

### Breaking Changes

NA

### JIRA Link

DA-892

### Checklist

- [ ] Updated the Readme.md (if required) ?
