### PR TITLE
fix: 🐛 Return MultiSig address from `account.getMultiSig` func

### DIFF
--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -841,7 +841,7 @@ describe('Account class', () => {
 
       const result = await account.getMultiSig();
 
-      expect(result?.address).toEqual('someAddress');
+      expect(result?.address).toEqual('multiAddress');
     });
   });
 

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -33,6 +33,7 @@ import {
 } from '~/types';
 import { Ensured } from '~/types/utils';
 import {
+  accountIdToString,
   addressToKey,
   extrinsicIdentifierToTxTag,
   keyToAddress,
@@ -434,7 +435,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       return null;
     }
 
-    return new MultiSig({ address }, context);
+    return new MultiSig({ address: accountIdToString(rawKeyRecord.asMultiSigSignerKey) }, context);
   }
 
   /**


### PR DESCRIPTION
### Description

`getMultiSig()` was returning address of the account from which the method was invoked. This correctly now returns the multisig it is part of

### Breaking Changes

NA

### JIRA Link

DA-897

### Checklist

- [ ] Updated the Readme.md (if required) ?
