### PR TITLE
feat: 🎸 expand collection metadata spec and name

### DIFF
--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -12,6 +12,7 @@ import { EventIdEnum } from '~/middleware/enums';
 import {
   Compliance,
   EventIdentifier,
+  MetadataDetails,
   MetadataType,
   TransferError,
   TransferRestriction,
@@ -86,6 +87,9 @@ export interface HistoricAssetTransaction extends EventIdentifier {
   extrinsicIndex: BigNumber;
 }
 
+/**
+ * The data needed to uniquely identify a metadata specification
+ */
 export type MetadataKeyId =
   | {
       type: MetadataType.Global;
@@ -98,9 +102,22 @@ export type MetadataKeyId =
     };
 
 export interface NftMetadata {
+  /**
+   * The metadata key this value is intended for
+   */
   key: MetadataKeyId;
+  /**
+   * The value the particular NFT has for the metadata
+   */
   value: string;
 }
+
+/**
+ * A metadata entry for which each NFT in the collection must have an entry for
+ *
+ * @note each NFT **must** have an entry for each metadata value, the entry **should** comply with the relevant spec
+ */
+export type CollectionMetadata = MetadataKeyId & MetadataDetails;
 
 export * from './Fungible/Checkpoints/types';
 export * from './Fungible/CorporateActions/types';

--- a/src/api/procedures/__tests__/issueNft.ts
+++ b/src/api/procedures/__tests__/issueNft.ts
@@ -243,7 +243,9 @@ describe('issueNft procedure', () => {
 
       const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance({
-          collectionMetadataKeys: [{ type: MetadataType.Global, id: new BigNumber(1) }],
+          collectionMetadata: [
+            { type: MetadataType.Global, id: new BigNumber(1), specs: {}, name: 'Example Global' },
+          ],
         }),
       });
 
@@ -270,9 +272,15 @@ describe('issueNft procedure', () => {
 
       const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance({
-          collectionMetadataKeys: [
-            { type: MetadataType.Local, id: new BigNumber(1), ticker },
-            { type: MetadataType.Global, id: new BigNumber(2) },
+          collectionMetadata: [
+            {
+              type: MetadataType.Local,
+              id: new BigNumber(1),
+              ticker,
+              name: 'Example Local',
+              specs: {},
+            },
+            { type: MetadataType.Global, id: new BigNumber(2), specs: {}, name: 'Example Global' },
           ],
         }),
       });

--- a/src/api/procedures/issueNft.ts
+++ b/src/api/procedures/issueNft.ts
@@ -53,7 +53,7 @@ export async function prepareIssueNft(
   const { ticker, portfolioId, metadata } = args;
   const rawMetadataValues = nftInputToNftMetadataVec(metadata, context);
 
-  const neededMetadata = await collection.collectionMetadataKeys();
+  const neededMetadata = await collection.collectionMetadata();
 
   // for each input, find and remove a value from needed
   args.metadata.forEach(value => {

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -45,6 +45,7 @@ import {
   AuthorizationType,
   CheckPermissionsResult,
   CheckRolesResult,
+  CollectionMetadata,
   ComplianceRequirements,
   CorporateActionDefaultConfig,
   CorporateActionKind,
@@ -62,7 +63,6 @@ import {
   KnownNftType,
   Leg,
   MetadataDetails,
-  MetadataKeyId,
   MetadataLockStatus,
   MetadataType,
   MetadataValue,
@@ -202,7 +202,7 @@ interface NftCollectionOptions extends BaseAssetOptions {
   complianceRequirementsGet?: EntityGetter<ComplianceRequirements>;
   investorCount?: EntityGetter<BigNumber>;
   getNextLocalId?: EntityGetter<BigNumber>;
-  collectionMetadataKeys?: EntityGetter<MetadataKeyId[]>;
+  collectionMetadata?: EntityGetter<CollectionMetadata[]>;
   getCollectionId?: EntityGetter<BigNumber>;
 }
 
@@ -1117,7 +1117,7 @@ const MockNftCollectionClass = createMockEntityClass<NftCollectionOptions>(
 
     metadata = {} as { getNextLocalId: jest.Mock };
 
-    collectionMetadataKeys!: jest.Mock;
+    collectionMetadata!: jest.Mock;
     getCollectionId!: jest.Mock;
 
     investorCount!: jest.Mock;
@@ -1143,7 +1143,7 @@ const MockNftCollectionClass = createMockEntityClass<NftCollectionOptions>(
       this.permissions.getAgents = createEntityGetterMock(opts.permissionsGetAgents);
       this.investorCount = createEntityGetterMock(opts.investorCount);
       this.metadata.getNextLocalId = createEntityGetterMock(opts.getNextLocalId);
-      this.collectionMetadataKeys = createEntityGetterMock(opts.collectionMetadataKeys);
+      this.collectionMetadata = createEntityGetterMock(opts.collectionMetadata);
       this.getCollectionId = createEntityGetterMock(opts.getCollectionId);
     }
   },
@@ -1174,7 +1174,7 @@ const MockNftCollectionClass = createMockEntityClass<NftCollectionOptions>(
     getNextLocalId: new BigNumber(0),
     toHuman: 'SOME_TICKER',
     investorCount: new BigNumber(0),
-    collectionMetadataKeys: [],
+    collectionMetadata: [],
     getCollectionId: new BigNumber(0),
   }),
   ['NftCollection']


### PR DESCRIPTION
### Description

Return more information for collection metadata so its easier to see what each key should be

### Breaking Changes

`collection.collectionMetadataKeys()` is renamed to `collection.collectionMetadata()` (method was `alpha` branch only)

### JIRA Link

Originally implemented: [DA-876](https://polymesh.atlassian.net/browse/DA-876)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-876]: https://polymesh.atlassian.net/browse/DA-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ