### PR TITLE
feat: 🎸 add type names to proposal args

### DIFF
--- a/src/api/entities/MultiSigProposal/__tests__/index.ts
+++ b/src/api/entities/MultiSigProposal/__tests__/index.ts
@@ -66,14 +66,14 @@ describe('MultiSigProposal class', () => {
         }),
       });
 
+      const mockProposal = dsMockUtils.createMockCall({
+        args: ['ABC'],
+        method: 'reserveTicker',
+        section: 'asset',
+      });
+      mockProposal.toJSON = jest.fn().mockReturnValue({ args: ['ABC'] });
       dsMockUtils.createQueryMock('multiSig', 'proposals', {
-        returnValue: createMockOption(
-          dsMockUtils.createMockCall({
-            args: ['ABC'],
-            method: 'reserveTicker',
-            section: 'asset',
-          })
-        ),
+        returnValue: createMockOption(mockProposal),
       });
 
       let result = await proposal.details();

--- a/src/api/entities/MultiSigProposal/index.ts
+++ b/src/api/entities/MultiSigProposal/index.ts
@@ -71,21 +71,22 @@ export class MultiSigProposal extends Entity<UniqueIdentifiers, HumanReadable> {
         expiry: rawExpiry,
         autoClose: rawAutoClose,
       },
-      proposal,
+      proposalOpt,
     ] = await Promise.all([
       multiSig.proposalDetail(rawMultiSignAddress, rawId),
       multiSig.proposals(rawMultiSignAddress, rawId),
     ]);
 
-    let args, method, section;
-    if (proposal.isNone) {
+    if (proposalOpt.isNone) {
       throw new PolymeshError({
         code: ErrorCode.DataUnavailable,
         message: `Proposal with ID: "${id}" was not found. It may have already been executed`,
       });
-    } else {
-      ({ args, method, section } = proposal.unwrap());
     }
+
+    const proposal = proposalOpt.unwrap();
+    const { method, section } = proposal;
+    const { args } = proposal.toJSON();
 
     const approvalAmount = u64ToBigNumber(rawApprovals);
     const rejectionAmount = u64ToBigNumber(rawRejections);
@@ -99,7 +100,7 @@ export class MultiSigProposal extends Entity<UniqueIdentifiers, HumanReadable> {
       status,
       expiry,
       autoClose,
-      args: args.map(a => a.toString()),
+      args,
       txTag: `${section}.${method}` as TxTag,
     };
   }

--- a/src/api/entities/MultiSigProposal/types.ts
+++ b/src/api/entities/MultiSigProposal/types.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 
-import { TxTag } from '~/types';
+import { AnyJson, TxTag } from '~/types';
 
 export enum ProposalStatus {
   Invalid = 'Invalid',
@@ -39,5 +39,5 @@ export interface MultiSigProposalDetails {
   /**
    * The arguments to be passed to the transaction for this proposal
    */
-  args: string[];
+  args: AnyJson;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1707,3 +1707,17 @@ export type CustomClaimType = {
   name: string;
   id: BigNumber;
 };
+
+/**
+ * Represents JSON serializable data. Used for cases when the value can take on many types, like args for a MultiSig proposal.
+ */
+export type AnyJson =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | AnyJson[]
+  | {
+      [index: string]: AnyJson;
+    };


### PR DESCRIPTION
### Description

previously multisig proposals.details() would return args as string[], they are now `AnyJson` to include the type name as a key

### Breaking Changes

BREAKING CHANGE: 🧨 MultiSigProposal.details() now returns JSON instead of string[]

### JIRA Link

✅ Closes: [DA-906](https://polymesh.atlassian.net/browse/DA-906)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-906]: https://polymesh.atlassian.net/browse/DA-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ