### PR TITLE
feat: 🎸 add `Identity.getHeldNfts` method

### DIFF
--- a/src/api/entities/Identity/AssetPermissions.ts
+++ b/src/api/entities/Identity/AssetPermissions.ts
@@ -21,6 +21,7 @@ import {
   ErrorCode,
   EventIdentifier,
   ModuleName,
+  NftCollection,
   PermissionType,
   ProcedureMethod,
   ResultSet,
@@ -317,7 +318,7 @@ export class AssetPermissions extends Namespace<Identity> {
   public async enabledAt({
     asset,
   }: {
-    asset: string | FungibleAsset;
+    asset: string | FungibleAsset | NftCollection;
   }): Promise<EventIdentifier | null> {
     const { context } = this;
     const ticker = asTicker(asset);

--- a/src/middleware/__tests__/queries.ts
+++ b/src/middleware/__tests__/queries.ts
@@ -19,6 +19,7 @@ import {
   latestBlockQuery,
   latestSqVersionQuery,
   metadataQuery,
+  nftHoldersQuery,
   polyxTransactionsQuery,
   portfolioMovementsQuery,
   portfolioQuery,
@@ -382,6 +383,28 @@ describe('assetHoldersQuery', () => {
     };
 
     let result = assetHoldersQuery(variables);
+
+    expect(result.query).toBeDefined();
+    expect(result.variables).toEqual(variables);
+
+    result = assetHoldersQuery(variables, new BigNumber(1), new BigNumber(0));
+
+    expect(result.query).toBeDefined();
+    expect(result.variables).toEqual({
+      ...variables,
+      size: 1,
+      start: 0,
+    });
+  });
+});
+
+describe('nftHoldersQuery', () => {
+  it('should pass the variables to the grapqhl query', () => {
+    const variables = {
+      identityId: 'someDid',
+    };
+
+    let result = nftHoldersQuery(variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);

--- a/src/middleware/queries.ts
+++ b/src/middleware/queries.ts
@@ -26,6 +26,8 @@ import {
   InvestmentsOrderBy,
   Leg,
   LegsOrderBy,
+  NftHolder,
+  NftHoldersOrderBy,
   PolyxTransactionsOrderBy,
   Portfolio,
   PortfolioMovement,
@@ -928,6 +930,40 @@ export function assetHoldersQuery(
         totalCount
         nodes {
           assetId
+        }
+      }
+    }
+  `;
+
+  return {
+    query,
+    variables: { ...filters, size: size?.toNumber(), start: start?.toNumber() },
+  };
+}
+
+/**
+ * @hidden
+ *
+ * Get NFTs held by a DID
+ */
+export function nftHoldersQuery(
+  filters: QueryArgs<NftHolder, 'identityId'>,
+  size?: BigNumber,
+  start?: BigNumber,
+  orderBy = NftHoldersOrderBy.AssetIdAsc
+): QueryOptions<PaginatedQueryArgs<QueryArgs<NftHolder, 'identityId'>>> {
+  const query = gql`
+    query NftHolderQuery($identityId: String!, $size: Int, $start: Int) {
+      nftHolders(
+        filter: { identityId: { equalTo: $identityId } }
+        first: $size
+        offset: $start
+        orderBy: [${orderBy}]
+      ) {
+        totalCount
+        nodes {
+          assetId
+          nftIds
         }
       }
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1728,3 +1728,11 @@ export type AnyJson =
   | {
       [index: string]: AnyJson;
     };
+
+/**
+ * An nft collection, along with a subset of its NFTs
+ */
+export interface HeldNfts {
+  collection: NftCollection;
+  nfts: Nft[];
+}


### PR DESCRIPTION
### Description

add method to get historically held NFTs. `AssetPermissions.enabledAt` input now accepts `NftCollection`

### Breaking Changes

None

### JIRA Link

[DA-905](https://polymesh.atlassian.net/browse/DA-905)

### Checklist

- [ ] Updated the Readme.md (if required) ?
