### PR TITLE
feat: 🎸 Add `getAsset` method to Assets namespace

### DIFF
--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -12,6 +12,7 @@ import {
   TickerReservation,
 } from '~/internal';
 import {
+  Asset,
   CreateAssetWithTickerParams,
   CreateNftCollectionParams,
   ErrorCode,
@@ -32,6 +33,7 @@ import {
   u64ToBigNumber,
 } from '~/utils/conversion';
 import {
+  asAsset,
   assembleAssetQuery,
   createProcedureMethod,
   getDid,
@@ -174,15 +176,25 @@ export class Assets {
   }
 
   /**
+   * Retrieve a FungibleAsset or NftCollection
+   *
+   * @note `getFungibleAsset` and `getNftCollection` are similar to this method, but return a more specific type
+   */
+  public async getAsset(args: { ticker: string }): Promise<Asset> {
+    const { context } = this;
+    const { ticker } = args;
+
+    return asAsset(ticker, context);
+  }
+
+  /**
    * Retrieve all of the Assets owned by an Identity
    *
    * @param args.owner - Identity representation or Identity ID as stored in the blockchain
    *
    * @note Assets with unreadable characters in their tickers will be left out
    */
-  public async getAssets(args?: {
-    owner: string | Identity;
-  }): Promise<(FungibleAsset | NftCollection)[]> {
+  public async getAssets(args?: { owner: string | Identity }): Promise<Asset[]> {
     const {
       context: {
         polymeshApi: { query },

--- a/src/api/client/__tests__/Assets.ts
+++ b/src/api/client/__tests__/Assets.ts
@@ -292,6 +292,32 @@ describe('Assets Class', () => {
     });
   });
 
+  describe('method: getAsset', () => {
+    it('should return a specific Asset', async () => {
+      const ticker = 'TEST';
+
+      entityMockUtils.configureMocks({
+        fungibleAssetOptions: { exists: false },
+        nftCollectionOptions: { exists: true },
+      });
+
+      const asset = await assets.getAsset({ ticker });
+      expect(asset).toBeInstanceOf(NftCollection);
+    });
+
+    it('should throw if the Asset does not exist', async () => {
+      const ticker = 'TEST';
+      entityMockUtils.configureMocks({
+        fungibleAssetOptions: { exists: false },
+        nftCollectionOptions: { exists: false },
+      });
+
+      return expect(assets.getAsset({ ticker })).rejects.toThrow(
+        `No asset exists with ticker: "${ticker}"`
+      );
+    });
+  });
+
   describe('method: getFungibleAsset', () => {
     it('should return a specific Asset', async () => {
       const ticker = 'TEST';

--- a/src/api/entities/Asset/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/NonFungible/NftCollection.ts
@@ -10,10 +10,11 @@ import { assetQuery } from '~/middleware/queries';
 import { Query } from '~/middleware/types';
 import {
   AssetDetails,
-  CollectionMetadata,
+  CollectionKey,
   ErrorCode,
   EventIdentifier,
   IssueNftParams,
+  MetadataType,
   ProcedureMethod,
   SubCallback,
   UniqueIdentifiers,
@@ -49,7 +50,7 @@ export class NftCollection extends BaseAsset {
   /**
    * Issues a new NFT for the collection
    *
-   * @note Each NFT requires metadata for each value returned by `collectionMetadata`. The SDK and chain only validate the presence of these fields. Additional validation may be needed to ensure each value complies with the specification.
+   * @note Each NFT requires metadata for each value returned by `collectionKeys`. The SDK and chain only validate the presence of these fields. Additional validation may be needed to ensure each value complies with the specification.
    */
   public issue: ProcedureMethod<IssueNftParams, Nft>;
 
@@ -136,7 +137,7 @@ export class NftCollection extends BaseAsset {
    * @note Each NFT **must** have an entry for each value, it **should** comply with the spec.
    * In other words, the SDK only validates the presence of metadata keys, additional validation should be used when issuing
    */
-  public async collectionMetadata(): Promise<CollectionMetadata[]> {
+  public async collectionKeys(): Promise<CollectionKey[]> {
     const {
       context,
       ticker,
@@ -164,7 +165,12 @@ export class NftCollection extends BaseAsset {
         }
 
         const details = await neededMetadata.details();
-        return { ...details, id, type, ticker };
+
+        if (type === MetadataType.Local) {
+          return { ...details, id, type, ticker };
+        } else {
+          return { ...details, id, type };
+        }
       })
     );
   }

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -14,9 +14,16 @@ import {
   EventIdentifier,
   MetadataDetails,
   MetadataType,
+  NftCollection,
   TransferError,
   TransferRestriction,
 } from '~/types';
+
+/**
+ * Represents a generic asset on chain. Common functionality (e.g. documents) can be interacted with directly. For type specific functionality (e.g. issue) the type can
+ * be narrowed via `instanceof` operator, or by using a more specific getter
+ */
+export type Asset = FungibleAsset | NftCollection;
 
 /**
  * Properties that uniquely identify an Asset
@@ -117,7 +124,7 @@ export interface NftMetadata {
  *
  * @note each NFT **must** have an entry for each metadata value, the entry **should** comply with the relevant spec
  */
-export type CollectionMetadata = MetadataKeyId & MetadataDetails;
+export type CollectionKey = MetadataKeyId & MetadataDetails;
 
 export * from './Fungible/Checkpoints/types';
 export * from './Fungible/CorporateActions/types';

--- a/src/api/procedures/__tests__/issueNft.ts
+++ b/src/api/procedures/__tests__/issueNft.ts
@@ -243,7 +243,7 @@ describe('issueNft procedure', () => {
 
       const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance({
-          collectionMetadata: [
+          collectionKeys: [
             { type: MetadataType.Global, id: new BigNumber(1), specs: {}, name: 'Example Global' },
           ],
         }),
@@ -272,7 +272,7 @@ describe('issueNft procedure', () => {
 
       const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance({
-          collectionMetadata: [
+          collectionKeys: [
             {
               type: MetadataType.Local,
               id: new BigNumber(1),

--- a/src/api/procedures/createNftCollection.ts
+++ b/src/api/procedures/createNftCollection.ts
@@ -4,6 +4,7 @@ import { values } from 'lodash';
 
 import { addManualFees } from '~/api/procedures/utils';
 import {
+  BaseAsset,
   FungibleAsset,
   Identity,
   NftCollection,
@@ -269,7 +270,7 @@ export async function getAuthorization(
     return {
       permissions: {
         ...permissions,
-        assets: [new FungibleAsset({ ticker }, context)],
+        assets: [new BaseAsset({ ticker }, context)],
       },
     };
   }

--- a/src/api/procedures/issueNft.ts
+++ b/src/api/procedures/issueNft.ts
@@ -53,7 +53,7 @@ export async function prepareIssueNft(
   const { ticker, portfolioId, metadata } = args;
   const rawMetadataValues = nftInputToNftMetadataVec(metadata, context);
 
-  const neededMetadata = await collection.collectionMetadata();
+  const neededMetadata = await collection.collectionKeys();
 
   // for each input, find and remove a value from needed
   args.metadata.forEach(value => {

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -45,7 +45,7 @@ import {
   AuthorizationType,
   CheckPermissionsResult,
   CheckRolesResult,
-  CollectionMetadata,
+  CollectionKey,
   ComplianceRequirements,
   CorporateActionDefaultConfig,
   CorporateActionKind,
@@ -202,7 +202,7 @@ interface NftCollectionOptions extends BaseAssetOptions {
   complianceRequirementsGet?: EntityGetter<ComplianceRequirements>;
   investorCount?: EntityGetter<BigNumber>;
   getNextLocalId?: EntityGetter<BigNumber>;
-  collectionMetadata?: EntityGetter<CollectionMetadata[]>;
+  collectionKeys?: EntityGetter<CollectionKey[]>;
   getCollectionId?: EntityGetter<BigNumber>;
   getBaseImageUrl?: EntityGetter<string | null>;
 }
@@ -1118,7 +1118,7 @@ const MockNftCollectionClass = createMockEntityClass<NftCollectionOptions>(
 
     metadata = {} as { getNextLocalId: jest.Mock };
 
-    collectionMetadata!: jest.Mock;
+    collectionKeys!: jest.Mock;
     getCollectionId!: jest.Mock;
 
     investorCount!: jest.Mock;
@@ -1145,7 +1145,7 @@ const MockNftCollectionClass = createMockEntityClass<NftCollectionOptions>(
       this.permissions.getAgents = createEntityGetterMock(opts.permissionsGetAgents);
       this.investorCount = createEntityGetterMock(opts.investorCount);
       this.metadata.getNextLocalId = createEntityGetterMock(opts.getNextLocalId);
-      this.collectionMetadata = createEntityGetterMock(opts.collectionMetadata);
+      this.collectionKeys = createEntityGetterMock(opts.collectionKeys);
       this.getCollectionId = createEntityGetterMock(opts.getCollectionId);
       this.getBaseImageUrl = createEntityGetterMock(opts.getBaseImageUrl);
     }
@@ -1177,7 +1177,7 @@ const MockNftCollectionClass = createMockEntityClass<NftCollectionOptions>(
     getNextLocalId: new BigNumber(0),
     toHuman: 'SOME_TICKER',
     investorCount: new BigNumber(0),
-    collectionMetadata: [],
+    collectionKeys: [],
     getCollectionId: new BigNumber(0),
     getBaseImageUrl: null,
   }),


### PR DESCRIPTION
### Description

Add type `Asset` as union of FungibleAsset and NftCollection. `getAsset` method added for use cases where the type doesn't matter, e.g. adding documents. 

### Breaking Changes

`NftCollection.collectionMetadata` renamed to `collectionKeys` for consistency with storage (alpha only method)

### JIRA Link

[DA-878](https://polymesh.atlassian.net/browse/DA-878)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-878]: https://polymesh.atlassian.net/browse/DA-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ