### PR TITLE
feat: 🎸 add check to ensure NFT movement has correct args

### DIFF
--- a/src/api/procedures/__tests__/addInstruction.ts
+++ b/src/api/procedures/__tests__/addInstruction.ts
@@ -654,6 +654,68 @@ describe('addInstruction procedure', () => {
     });
   });
 
+  it('should throw an error if key "amount" is not in a fungible leg', async () => {
+    dsMockUtils.configureMocks({ contextOptions: { did: fromDid } });
+    entityMockUtils.configureMocks({
+      venueOptions: {
+        exists: true,
+      },
+      fungibleAssetOptions: {
+        exists: true,
+      },
+      nftCollectionOptions: {
+        exists: false,
+      },
+    });
+    getCustodianMock.mockReturnValue({ did: fromDid });
+    const proc = procedureMockUtils.getInstance<Params, Instruction[], Storage>(mockContext, {
+      portfoliosToAffirm: [[fromPortfolio, toPortfolio]],
+    });
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The key "amount" should be present in a fungible leg',
+    });
+
+    await expect(
+      prepareAddInstruction.call(proc, {
+        venueId: args.venueId,
+        instructions: [{ legs: [{ from, to, asset, nfts: [new BigNumber(1)] }] }],
+      })
+    ).rejects.toThrow(expectedError);
+  });
+
+  it('should throw an error if key "nfts" is not in an NFT leg', async () => {
+    dsMockUtils.configureMocks({ contextOptions: { did: fromDid } });
+    entityMockUtils.configureMocks({
+      venueOptions: {
+        exists: true,
+      },
+      fungibleAssetOptions: {
+        exists: false,
+      },
+      nftCollectionOptions: {
+        exists: true,
+      },
+    });
+    getCustodianMock.mockReturnValue({ did: fromDid });
+    const proc = procedureMockUtils.getInstance<Params, Instruction[], Storage>(mockContext, {
+      portfoliosToAffirm: [[fromPortfolio, toPortfolio]],
+    });
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The key "nfts" should be present in an NFT leg',
+    });
+
+    await expect(
+      prepareAddInstruction.call(proc, {
+        venueId: args.venueId,
+        instructions: [{ legs: [{ from, to, asset, amount: new BigNumber(1) }] }],
+      })
+    ).rejects.toThrow(expectedError);
+  });
+
   it('should handle NFT legs', async () => {
     dsMockUtils.configureMocks({ contextOptions: { did: fromDid } });
     entityMockUtils.configureMocks({

--- a/src/api/procedures/addInstruction.ts
+++ b/src/api/procedures/addInstruction.ts
@@ -159,14 +159,29 @@ async function separateLegs(
   const nftLegs: InstructionNftLeg[] = [];
 
   for (const leg of legs) {
+    const ticker = asTicker(leg.asset);
     const [isFungible, isNft] = await Promise.all([
       isFungibleLegBuilder(leg, context),
       isNftLegBuilder(leg, context),
     ]);
 
     if (isFungible(leg)) {
+      if (!('amount' in leg)) {
+        throw new PolymeshError({
+          code: ErrorCode.ValidationError,
+          message: 'The key "amount" should be present in a fungible leg',
+          data: { ticker },
+        });
+      }
       fungibleLegs.push(leg);
     } else if (isNft(leg)) {
+      if (!('nfts' in leg)) {
+        throw new PolymeshError({
+          code: ErrorCode.ValidationError,
+          message: 'The key "nfts" should be present in an NFT leg',
+          data: { ticker },
+        });
+      }
       nftLegs.push(leg);
     }
   }

--- a/src/api/procedures/moveFunds.ts
+++ b/src/api/procedures/moveFunds.ts
@@ -47,12 +47,27 @@ async function segregateItems(
 
   for (const item of items) {
     const { asset } = item;
-    tickers.push(asTicker(asset));
+    const ticker = asTicker(asset);
+    tickers.push(ticker);
 
     const typedAsset = await asAsset(asset, context);
     if (isFungibleAsset(typedAsset)) {
+      if (!('amount' in item)) {
+        throw new PolymeshError({
+          code: ErrorCode.ValidationError,
+          message: 'The key "amount" should be present in a fungible portfolio movement',
+          data: { ticker },
+        });
+      }
       fungibleMovements.push(item as FungiblePortfolioMovement);
     } else if (isNftCollection(typedAsset)) {
+      if (!('nfts' in item)) {
+        throw new PolymeshError({
+          code: ErrorCode.ValidationError,
+          message: 'The key "nfts" should be present in an NFT portfolio movement',
+          data: { ticker },
+        });
+      }
       nftMovements.push(item as NonFungiblePortfolioMovement);
     }
   }


### PR DESCRIPTION
### Description

check to ensure 'amount' and 'nfts' are present in fungible and NFT movements respectively

This can happen when using the ticker instead of asset entities, otherwise TS will ensure the right field is there

### Breaking Changes

None

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
