### PR TITLE
 fix: 🐛 export type for docs

### DIFF
--- a/src/api/client/Claims.ts
+++ b/src/api/client/Claims.ts
@@ -17,6 +17,7 @@ import {
   ClaimScope,
   ClaimType,
   CustomClaimType,
+  CustomClaimTypeWithDid,
   ErrorCode,
   IdentityWithClaims,
   ModifyClaimsParams,
@@ -27,7 +28,6 @@ import {
   ScopedClaim,
   ScopeType,
 } from '~/types';
-import { CustomClaimTypeWithDid } from '~/types/internal';
 import { Ensured } from '~/types/utils';
 import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 import {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1724,6 +1724,9 @@ export interface SpWeightV2 {
   proofSize: BigNumber;
 }
 
+/**
+ * CustomClaimType
+ */
 export type CustomClaimType = {
   name: string;
   id: BigNumber;
@@ -1750,3 +1753,8 @@ export interface HeldNfts {
   collection: NftCollection;
   nfts: Nft[];
 }
+
+/**
+ * CustomClaimType with DID that registered the CustomClaimType
+ */
+export type CustomClaimTypeWithDid = CustomClaimType & { did?: string };

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -22,7 +22,6 @@ import { Identity, Procedure } from '~/internal';
 import { CallIdEnum, ModuleIdEnum } from '~/middleware/types';
 import {
   ClaimType,
-  CustomClaimType,
   InputStatClaim,
   KnownAssetType,
   KnownNftType,
@@ -336,5 +335,3 @@ export interface StatClaimIssuer {
   issuer: Identity;
   claimType: StatClaimType;
 }
-
-export type CustomClaimTypeWithDid = CustomClaimType & { did?: string };

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -151,6 +151,7 @@ import {
   CorporateActionTargets,
   CountryCode,
   CountTransferRestrictionInput,
+  CustomClaimTypeWithDid,
   DividendDistributionParams,
   ErrorCode,
   EventIdentifier,
@@ -221,7 +222,6 @@ import {
 } from '~/types';
 import {
   CorporateActionIdentifier,
-  CustomClaimTypeWithDid,
   ExemptKey,
   ExtrinsicIdentifier,
   InstructionStatus,


### PR DESCRIPTION
### Description

Reverts https://github.com/PolymeshAssociation/polymesh-sdk/pull/1093
Updates so that CustomClaimTypeWithDid is exported for docs 

### Breaking Changes


### JIRA Link

https://polymesh.atlassian.net/browse/DA-937

### Checklist

- [x] Updated the Readme.md (if required) ?
