### PR TITLE
fix: 🐛 Correct the logic for `account.getTransactionHistory`

### DIFF
--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -43,9 +43,7 @@ describe('Account class', () => {
   let address: string;
   let account: Account;
   let assertAddressValidSpy: jest.SpyInstance;
-  let addressToKeySpy: jest.SpyInstance;
   let getSecondaryAccountPermissionsSpy: jest.SpyInstance;
-  let keyToAddressSpy: jest.SpyInstance;
   let txTagToExtrinsicIdentifierSpy: jest.SpyInstance;
 
   beforeAll(() => {
@@ -55,12 +53,11 @@ describe('Account class', () => {
     assertAddressValidSpy = jest
       .spyOn(utilsInternalModule, 'assertAddressValid')
       .mockImplementation();
-    addressToKeySpy = jest.spyOn(utilsConversionModule, 'addressToKey').mockImplementation();
+    jest.spyOn(utilsConversionModule, 'addressToKey').mockImplementation();
     getSecondaryAccountPermissionsSpy = jest.spyOn(
       utilsInternalModule,
       'getSecondaryAccountPermissions'
     );
-    keyToAddressSpy = jest.spyOn(utilsConversionModule, 'keyToAddress');
     txTagToExtrinsicIdentifierSpy = jest.spyOn(utilsConversionModule, 'txTagToExtrinsicIdentifier');
 
     address = 'someAddress';
@@ -271,11 +268,7 @@ describe('Account class', () => {
       const blockHash2 = 'otherHash';
       const blockDate1 = new Date('2022-12-25T00:00:00Z');
       const blockDate2 = new Date('2022-12-25T12:00:00Z');
-      const addressKey = 'd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
       const order = ExtrinsicsOrderBy.CreatedAtAsc;
-
-      addressToKeySpy.mockReturnValue(addressKey);
-      keyToAddressSpy.mockReturnValue(address);
 
       when(txTagToExtrinsicIdentifierSpy).calledWith(tag).mockReturnValue({
         moduleId,
@@ -325,7 +318,7 @@ describe('Account class', () => {
         extrinsicsByArgs(
           {
             blockId: blockNumber1.toString(),
-            address: addressKey,
+            address,
             moduleId,
             callId,
             success: undefined,
@@ -367,7 +360,7 @@ describe('Account class', () => {
       expect(result.data[0].blockDate).toEqual(blockDate1);
       expect(result.data[1].blockDate).toEqual(blockDate2);
       expect(result.data[0].address).toEqual(address);
-      expect(result.data[1].address).toBeNull();
+      expect(result.data[1].address).toBeUndefined();
       expect(result.data[0].nonce).toEqual(new BigNumber(1));
       expect(result.data[1].nonce).toBeNull();
       expect(result.data[0].success).toBeFalsy();
@@ -379,7 +372,7 @@ describe('Account class', () => {
         extrinsicsByArgs(
           {
             blockId: blockNumber1.toString(),
-            address: addressKey,
+            address,
             moduleId,
             callId,
             success: 0,
@@ -408,7 +401,7 @@ describe('Account class', () => {
       expect(result.data[0].blockDate).toEqual(blockDate1);
       expect(result.data[1].blockDate).toEqual(blockDate2);
       expect(result.data[0].address).toEqual(address);
-      expect(result.data[1].address).toBeNull();
+      expect(result.data[1].address).toBeUndefined();
       expect(result.data[0].success).toBeFalsy();
       expect(result.data[1].success).toBeTruthy();
       expect(result.count).toEqual(new BigNumber(20));
@@ -418,7 +411,7 @@ describe('Account class', () => {
         extrinsicsByArgs(
           {
             blockId: undefined,
-            address: addressKey,
+            address,
             moduleId: undefined,
             callId: undefined,
             success: 1,
@@ -447,7 +440,7 @@ describe('Account class', () => {
         extrinsicsByArgs(
           {
             blockId: undefined,
-            address: addressKey,
+            address,
             moduleId: undefined,
             callId: undefined,
             success: undefined,

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -1,4 +1,3 @@
-import { hexStripPrefix } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 
 import {
@@ -35,7 +34,6 @@ import {
   accountIdToString,
   addressToKey,
   extrinsicIdentifierToTxTag,
-  keyToAddress,
   stringToAccountId,
   stringToHash,
   txTagToExtrinsicIdentifier,
@@ -238,7 +236,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       extrinsicsByArgs(
         {
           blockId: blockNumber ? blockNumber.toString() : undefined,
-          address: hexStripPrefix(addressToKey(address, context)),
+          address,
           moduleId,
           callId,
           success: successFilter,
@@ -256,7 +254,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       ({
         blockId,
         extrinsicIdx,
-        address: rawAddress,
+        address: signerAddress,
         nonce,
         moduleId: extrinsicModuleId,
         callId: extrinsicCallId,
@@ -272,7 +270,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
           blockHash: hash,
           blockDate: new Date(`${datetime}Z`),
           extrinsicIdx: new BigNumber(extrinsicIdx),
-          address: rawAddress ? keyToAddress(rawAddress, context) : null,
+          address: signerAddress!,
           nonce: nonce ? new BigNumber(nonce) : null,
           txTag: extrinsicIdentifierToTxTag({
             moduleId: extrinsicModuleId as ModuleIdEnum,


### PR DESCRIPTION
### Description

With changes in SQ, the current logic was not returning the list of transactions. Removing the extra encoding part fixes the problem

### Breaking Changes

NA

### JIRA Link

DA-949

### Checklist

- [ ] Updated the Readme.md (if required) ?
