### PR TITLE
feat: 🎸 Add new attributes to HistoricAssetTransaction

### DIFF
--- a/src/api/entities/Asset/Fungible/index.ts
+++ b/src/api/entities/Asset/Fungible/index.ts
@@ -264,7 +264,7 @@ export class FungibleAsset extends BaseAsset {
       )
     );
 
-    const data = nodes.map(
+    const data: HistoricAssetTransaction[] = nodes.map(
       ({
         assetId,
         amount,
@@ -274,12 +274,18 @@ export class FungibleAsset extends BaseAsset {
         eventId,
         eventIdx,
         extrinsicIdx,
+        fundingRound,
+        instructionId,
+        instructionMemo,
       }) => ({
         asset: new FungibleAsset({ ticker: assetId }, context),
         amount: new BigNumber(amount).shiftedBy(-6),
         event: eventId,
         from: optionize(middlewarePortfolioToPortfolio)(fromPortfolio, context),
         to: optionize(middlewarePortfolioToPortfolio)(toPortfolio, context),
+        fundingRound,
+        instructionId: instructionId ? new BigNumber(instructionId) : undefined,
+        instructionMemo,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         extrinsicIndex: new BigNumber(extrinsicIdx!),
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/api/entities/Asset/__tests__/Fungible/index.ts
+++ b/src/api/entities/Asset/__tests__/Fungible/index.ts
@@ -781,6 +781,8 @@ describe('Asset class', () => {
               identityId: 'SOME_OTHER_DID',
               number: 1,
             },
+            instructionId: '2',
+            instructionMemo: 'Some memo',
             eventIdx: 1,
             extrinsicIdx: 1,
             createdBlock: {
@@ -821,6 +823,8 @@ describe('Asset class', () => {
       expect(result.data[2].event).toEqual(transactionResponse.nodes[2].eventId);
       expect(result.data[2].from).toBeInstanceOf(DefaultPortfolio);
       expect(result.data[2].to).toBeInstanceOf(NumberedPortfolio);
+      expect(result.data[2].instructionId).toEqual(new BigNumber(2));
+      expect(result.data[2].instructionMemo).toEqual('Some memo');
 
       expect(result.count).toEqual(transactionResponse.totalCount);
       expect(result.next).toEqual(new BigNumber(3));

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -87,11 +87,42 @@ export interface AgentWithGroup {
 
 export interface HistoricAssetTransaction extends EventIdentifier {
   asset: FungibleAsset;
-  amount: BigNumber;
+  /**
+   * Origin portfolio involved in the transaction. This value will be null when the `event` value is `Issued`
+   */
   from: DefaultPortfolio | NumberedPortfolio | null;
+  /**
+   * Destination portfolio involved in the transaction . This value will be null when the `event` value is `Redeemed`
+   */
   to: DefaultPortfolio | NumberedPortfolio | null;
+
+  /**
+   * Event identifying the type of transaction
+   */
   event: EventIdEnum;
+
+  /**
+   * Amount of the fungible tokens involved in the transaction
+   */
+  amount: BigNumber;
+
+  /**
+   * Index value of the extrinsic which led to the Asset transaction within the `blockNumber` block
+   */
   extrinsicIndex: BigNumber;
+
+  /**
+   * Name of the funding round (if provided while issuing the Asset). This value is present only when the value of `event` is `Issued`
+   */
+  fundingRound?: string;
+  /**
+   * ID of the instruction being executed. This value is present only when the value of `event` is `Transfer`
+   */
+  instructionId?: BigNumber;
+  /**
+   * Memo provided against the executed instruction. This value is present only when the value of `event` is `Transfer`
+   */
+  instructionMemo?: string;
 }
 
 /**

--- a/src/middleware/queries.ts
+++ b/src/middleware/queries.ts
@@ -1254,6 +1254,8 @@ export function assetTransactionQuery(
           eventIdx
           extrinsicIdx
           fundingRound
+          instructionId
+          instructionMemo
           datetime
           createdBlock {
             blockId

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -1158,7 +1158,7 @@ describe('assertExpectedSqVersion', () => {
       subqueryVersions: {
         nodes: [
           {
-            version: '10.1.0',
+            version: '12.2.0-alpha.2',
           },
         ],
       },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -145,7 +145,7 @@ export const DEFAULT_CDD_ID = '0x00000000000000000000000000000000000000000000000
 /**
  * Minimum version of Middleware V2 GraphQL Service (SubQuery) that is compatible with this version of the SDK
  */
-export const MINIMUM_SQ_VERSION = '10.1.0';
+export const MINIMUM_SQ_VERSION = '12.2.0-alpha.2';
 
 /**
  * Global metadata key used to conventionally register an NFT image


### PR DESCRIPTION
### Description

PR updates the middleware types to fetch in the new attributes from SQ and adds optional `instructionId`, `instructionMemo` and `fundingRound` attributes to `HistoricAssetTransaction`.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
