### PR TITLE
feat: 🎸 Add entities to manage confidential venue & transaction

### DIFF
--- a/src/api/client/ConfidentialSettlements.ts
+++ b/src/api/client/ConfidentialSettlements.ts
@@ -1,0 +1,60 @@
+import BigNumber from 'bignumber.js';
+
+import { ConfidentialTransaction, ConfidentialVenue, Context, PolymeshError } from '~/internal';
+import { ErrorCode } from '~/types';
+
+/**
+ * Handles all functionalities for venues and transactions of confidential Assets
+ */
+export class ConfidentialSettlements {
+  private context: Context;
+
+  /**
+   * @hidden
+   */
+  constructor(context: Context) {
+    this.context = context;
+  }
+
+  /**
+   * Retrieve a confidential Venue by its ID
+   *
+   * @param args.id - identifier number of the confidential Venue
+   */
+  public async getVenue(args: { id: BigNumber }): Promise<ConfidentialVenue> {
+    const { context } = this;
+
+    const venue = new ConfidentialVenue(args, context);
+
+    const venueExists = await venue.exists();
+    if (!venueExists) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'The confidential Venue does not exists',
+      });
+    }
+
+    return venue;
+  }
+
+  /**
+   * Retrieve a settlement Transaction by its ID
+   *
+   * @param args.id - identifier number of the ConfidentialTransaction
+   */
+  public async getTransaction(args: { id: BigNumber }): Promise<ConfidentialTransaction> {
+    const { context } = this;
+
+    const transaction = new ConfidentialTransaction(args, context);
+
+    const exists = await transaction.exists();
+    if (!exists) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'The Transaction does not exists',
+      });
+    }
+
+    return transaction;
+  }
+}

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -9,6 +9,7 @@ import { SigningManager } from '@polymeshassociation/signing-manager-types';
 import fetch from 'cross-fetch';
 import schema from 'polymesh-types/schema';
 
+import { ConfidentialSettlements } from '~/api/client/ConfidentialSettlements';
 import { Account, Context, createTransactionBatch, Identity, PolymeshError } from '~/internal';
 import {
   CreateTransactionBatchProcedureMethod,
@@ -116,6 +117,11 @@ export class Polymesh {
   public confidentialAssets: ConfidentialAssets;
 
   /**
+   * A set of methods for exchanging confidential Assets
+   */
+  public confidentialSettlements: ConfidentialSettlements;
+
+  /**
    * @hidden
    */
   private constructor(context: Context) {
@@ -128,6 +134,7 @@ export class Polymesh {
     this.identities = new Identities(context);
     this.assets = new Assets(context);
     this.confidentialAssets = new ConfidentialAssets(context);
+    this.confidentialSettlements = new ConfidentialSettlements(context);
 
     this.createTransactionBatch = createProcedureMethod(
       {

--- a/src/api/client/__tests__/ConfidentialSettlements.ts
+++ b/src/api/client/__tests__/ConfidentialSettlements.ts
@@ -1,0 +1,99 @@
+import BigNumber from 'bignumber.js';
+
+import { ConfidentialSettlements } from '~/api/client/ConfidentialSettlements';
+import { Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+
+jest.mock(
+  '~/api/entities/confidential/ConfidentialVenue',
+  require('~/testUtils/mocks/entities').mockConfidentialVenueModule(
+    '~/api/entities/confidential/ConfidentialVenue'
+  )
+);
+
+jest.mock(
+  '~/api/entities/confidential/ConfidentialTransaction',
+  require('~/testUtils/mocks/entities').mockConfidentialTransactionModule(
+    '~/api/entities/confidential/ConfidentialTransaction'
+  )
+);
+
+describe('ConfidentialSettlements Class', () => {
+  let context: Mocked<Context>;
+  let settlements: ConfidentialSettlements;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+    settlements = new ConfidentialSettlements(context);
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    procedureMockUtils.cleanup();
+  });
+
+  describe('method: getVenue', () => {
+    it('should return a confidential Venue by its id', async () => {
+      const venueId = new BigNumber(1);
+
+      entityMockUtils.configureMocks({
+        confidentialVenueOptions: { exists: true },
+      });
+
+      const result = await settlements.getVenue({ id: venueId });
+
+      expect(result.id).toEqual(venueId);
+    });
+
+    it('should throw if the confidential Venue does not exist', async () => {
+      const venueId = new BigNumber(1);
+
+      entityMockUtils.configureMocks({
+        confidentialVenueOptions: { exists: false },
+      });
+
+      return expect(settlements.getVenue({ id: venueId })).rejects.toThrow(
+        'The confidential Venue does not exists'
+      );
+    });
+  });
+
+  describe('method: getInstruction', () => {
+    it('should return an Instruction by its id', async () => {
+      const transactionId = new BigNumber(1);
+
+      entityMockUtils.configureMocks({
+        confidentialTransactionOptions: { exists: true },
+      });
+
+      const result = await settlements.getTransaction({ id: transactionId });
+
+      expect(result.id).toEqual(transactionId);
+    });
+
+    it('should throw if the Instruction does not exist', async () => {
+      const transactionId = new BigNumber(1);
+
+      entityMockUtils.configureMocks({
+        confidentialTransactionOptions: { exists: false },
+      });
+
+      return expect(settlements.getTransaction({ id: transactionId })).rejects.toThrow(
+        'The Transaction does not exists'
+      );
+    });
+  });
+});

--- a/src/api/entities/confidential/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/ConfidentialTransaction/index.ts
@@ -1,0 +1,68 @@
+import BigNumber from 'bignumber.js';
+
+import { Context, Entity } from '~/internal';
+import { u64ToBigNumber } from '~/utils/conversion';
+
+export interface UniqueIdentifiers {
+  id: BigNumber;
+}
+
+/**
+ * Represents a confidential Asset Transaction to be executed on a certain Venue
+ */
+export class ConfidentialTransaction extends Entity<UniqueIdentifiers, string> {
+  /**
+   * @hidden
+   * Check if a value is of type {@link UniqueIdentifiers}
+   */
+  public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
+    const { id } = identifier as UniqueIdentifiers;
+
+    return id instanceof BigNumber;
+  }
+
+  /**
+   * Unique identifier number of the settlement transaction
+   */
+  public id: BigNumber;
+
+  /**
+   * @hidden
+   */
+  public constructor(identifiers: UniqueIdentifiers, context: Context) {
+    super(identifiers, context);
+
+    const { id } = identifiers;
+
+    this.id = id;
+  }
+
+  /**
+   * Determine whether this settlement Transaction exists on chain (or existed and was pruned)
+   */
+  public async exists(): Promise<boolean> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { confidentialAsset },
+        },
+      },
+      id,
+    } = this;
+
+    if (id.lte(new BigNumber(0))) {
+      return false;
+    }
+
+    const transactionCounter = await confidentialAsset.transactionCounter();
+
+    return id.lte(u64ToBigNumber(transactionCounter.unwrap()));
+  }
+
+  /**
+   * Return the settlement Transaction's ID
+   */
+  public toHuman(): string {
+    return this.id.toString();
+  }
+}

--- a/src/api/entities/confidential/ConfidentialVenue/index.ts
+++ b/src/api/entities/confidential/ConfidentialVenue/index.ts
@@ -1,0 +1,98 @@
+import BigNumber from 'bignumber.js';
+
+import { Context, Entity, Identity, PolymeshError } from '~/internal';
+import { ErrorCode } from '~/types';
+import { bigNumberToU64, identityIdToString, u64ToBigNumber } from '~/utils/conversion';
+
+export interface UniqueIdentifiers {
+  id: BigNumber;
+}
+
+/**
+ * Represents a Venue through which confidential transactions are handled
+ */
+export class ConfidentialVenue extends Entity<UniqueIdentifiers, string> {
+  /**
+   * @hidden
+   * Check if a value is of type {@link UniqueIdentifiers}
+   */
+  public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
+    const { id } = identifier as UniqueIdentifiers;
+
+    return id instanceof BigNumber;
+  }
+
+  /**
+   * identifier number of the confidential Venue
+   */
+  public id: BigNumber;
+
+  /**
+   * @hidden
+   */
+  public constructor(identifiers: UniqueIdentifiers, context: Context) {
+    super(identifiers, context);
+
+    const { id } = identifiers;
+
+    this.id = id;
+  }
+
+  /**
+   * Determine whether this confidential Venue exists on chain
+   */
+  public async exists(): Promise<boolean> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { confidentialAsset },
+        },
+      },
+      id,
+    } = this;
+
+    if (id.lte(new BigNumber(0))) {
+      return false;
+    }
+
+    const rawCounter = await confidentialAsset.venueCounter();
+
+    const nextVenue = u64ToBigNumber(rawCounter);
+
+    return id.lt(nextVenue);
+  }
+
+  /**
+   * Retrieve the creator of this confidential Venue
+   */
+  public async creator(): Promise<Identity> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { confidentialAsset },
+        },
+      },
+      id,
+      context,
+    } = this;
+
+    const rawId = bigNumberToU64(id, context);
+    const creator = await confidentialAsset.venueCreator(rawId);
+
+    if (creator.isNone) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'The Venue does not exists',
+      });
+    }
+
+    return new Identity({ did: identityIdToString(creator.unwrap()) }, context);
+  }
+
+  /**
+   * Return the confidential Venue's ID
+   */
+  public toHuman(): string {
+    return this.id.toString();
+  }
+}

--- a/src/api/entities/confidential/ConfidentialVenue/index.ts
+++ b/src/api/entities/confidential/ConfidentialVenue/index.ts
@@ -13,6 +13,11 @@ export interface UniqueIdentifiers {
  */
 export class ConfidentialVenue extends Entity<UniqueIdentifiers, string> {
   /**
+   * identifier number of the confidential Venue
+   */
+  public id: BigNumber;
+
+  /**
    * @hidden
    * Check if a value is of type {@link UniqueIdentifiers}
    */
@@ -23,11 +28,6 @@ export class ConfidentialVenue extends Entity<UniqueIdentifiers, string> {
   }
 
   /**
-   * identifier number of the confidential Venue
-   */
-  public id: BigNumber;
-
-  /**
    * @hidden
    */
   public constructor(identifiers: UniqueIdentifiers, context: Context) {
@@ -36,30 +36,6 @@ export class ConfidentialVenue extends Entity<UniqueIdentifiers, string> {
     const { id } = identifiers;
 
     this.id = id;
-  }
-
-  /**
-   * Determine whether this confidential Venue exists on chain
-   */
-  public async exists(): Promise<boolean> {
-    const {
-      context: {
-        polymeshApi: {
-          query: { confidentialAsset },
-        },
-      },
-      id,
-    } = this;
-
-    if (id.lte(new BigNumber(0))) {
-      return false;
-    }
-
-    const rawCounter = await confidentialAsset.venueCounter();
-
-    const nextVenue = u64ToBigNumber(rawCounter);
-
-    return id.lt(nextVenue);
   }
 
   /**
@@ -87,6 +63,30 @@ export class ConfidentialVenue extends Entity<UniqueIdentifiers, string> {
     }
 
     return new Identity({ did: identityIdToString(creator.unwrap()) }, context);
+  }
+
+  /**
+   * Determine whether this confidential Venue exists on chain
+   */
+  public async exists(): Promise<boolean> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { confidentialAsset },
+        },
+      },
+      id,
+    } = this;
+
+    if (id.lte(new BigNumber(0))) {
+      return false;
+    }
+
+    const rawCounter = await confidentialAsset.venueCounter();
+
+    const nextVenue = u64ToBigNumber(rawCounter);
+
+    return id.lt(nextVenue);
   }
 
   /**

--- a/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
@@ -1,0 +1,79 @@
+import BigNumber from 'bignumber.js';
+
+import { ConfidentialTransaction, Context, Entity } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+
+describe('ConfidentialTransaction class', () => {
+  let context: Mocked<Context>;
+  let transaction: ConfidentialTransaction;
+  let id: BigNumber;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+
+    id = new BigNumber(1);
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+    transaction = new ConfidentialTransaction({ id }, context);
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    procedureMockUtils.cleanup();
+  });
+
+  it('should extend Entity', () => {
+    expect(ConfidentialTransaction.prototype instanceof Entity).toBe(true);
+  });
+
+  describe('method: isUniqueIdentifiers', () => {
+    it('should return true if the object conforms to the interface', () => {
+      expect(ConfidentialTransaction.isUniqueIdentifiers({ id: new BigNumber(1) })).toBe(true);
+      expect(ConfidentialTransaction.isUniqueIdentifiers({})).toBe(false);
+      expect(ConfidentialTransaction.isUniqueIdentifiers({ id: 3 })).toBe(false);
+    });
+  });
+
+  describe('method: exists', () => {
+    it('should return whether the instruction exists', async () => {
+      dsMockUtils
+        .createQueryMock('confidentialAsset', 'transactionCounter')
+        .mockResolvedValue(
+          dsMockUtils.createMockCompact(dsMockUtils.createMockU64(new BigNumber(10)))
+        );
+
+      let result = await transaction.exists();
+
+      expect(result).toBe(true);
+
+      let fakeTransaction = new ConfidentialTransaction({ id: new BigNumber(0) }, context);
+
+      result = await fakeTransaction.exists();
+
+      expect(result).toBe(false);
+
+      fakeTransaction = new ConfidentialTransaction({ id: new BigNumber(20) }, context);
+
+      result = await fakeTransaction.exists();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('method: toHuman', () => {
+    it('should return a human readable version of the entity', () => {
+      expect(transaction.toHuman()).toBe('1');
+    });
+  });
+});

--- a/src/api/entities/confidential/__tests__/ConfidentialVenue/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialVenue/index.ts
@@ -1,0 +1,123 @@
+import { u64 } from '@polkadot/types';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import { ConfidentialVenue, Context, Entity, PolymeshError } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { ErrorCode } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+describe('ConfidentialVenue class', () => {
+  let context: Mocked<Context>;
+  let venue: ConfidentialVenue;
+
+  let id: BigNumber;
+
+  let rawId: u64;
+  let bigNumberToU64Spy: jest.SpyInstance;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+
+    id = new BigNumber(5);
+    rawId = dsMockUtils.createMockU64(id);
+
+    bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+    venue = new ConfidentialVenue({ id }, context);
+
+    when(bigNumberToU64Spy).calledWith(id, context).mockReturnValue(rawId);
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    procedureMockUtils.cleanup();
+  });
+
+  it('should extend Entity', () => {
+    expect(ConfidentialVenue.prototype instanceof Entity).toBe(true);
+  });
+
+  describe('method: isUniqueIdentifiers', () => {
+    it('should return true if the object conforms to the interface', () => {
+      expect(ConfidentialVenue.isUniqueIdentifiers({ id: new BigNumber(1) })).toBe(true);
+      expect(ConfidentialVenue.isUniqueIdentifiers({})).toBe(false);
+      expect(ConfidentialVenue.isUniqueIdentifiers({ id: 3 })).toBe(false);
+    });
+  });
+
+  describe('method: exists', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return whether if the venue exists or not', async () => {
+      const venueCounterMock = dsMockUtils.createQueryMock('confidentialAsset', 'venueCounter');
+      venueCounterMock.mockResolvedValueOnce(dsMockUtils.createMockU64(new BigNumber(6)));
+
+      let result = await venue.exists();
+
+      expect(result).toEqual(true);
+
+      venueCounterMock.mockResolvedValueOnce(dsMockUtils.createMockU64(new BigNumber(3)));
+
+      result = await venue.exists();
+
+      expect(result).toEqual(false);
+
+      const fakeVenue = new ConfidentialVenue({ id: new BigNumber(0) }, context);
+
+      result = await fakeVenue.exists();
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('method: creator', () => {
+    let venueCreatorMock: jest.Mock;
+
+    beforeEach(() => {
+      venueCreatorMock = dsMockUtils.createQueryMock('confidentialAsset', 'venueCreator');
+      venueCreatorMock.mockResolvedValue(
+        dsMockUtils.createMockOption(dsMockUtils.createMockIdentityId('someDid'))
+      );
+    });
+
+    it('should return the creator of ConfidentialVenue', async () => {
+      const result = await venue.creator();
+
+      expect(result).toEqual(expect.objectContaining({ did: 'someDid' }));
+    });
+
+    it('should throw an error if no creator exists', async () => {
+      const expectedError = new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'The Venue does not exists',
+      });
+
+      venueCreatorMock.mockResolvedValue(dsMockUtils.createMockOption());
+
+      await expect(venue.creator()).rejects.toThrow(expectedError);
+    });
+  });
+
+  describe('method: toHuman', () => {
+    it('should return a human readable version of the entity', () => {
+      const venueEntity = new ConfidentialVenue({ id: new BigNumber(1) }, context);
+
+      expect(venueEntity.toHuman()).toBe('1');
+    });
+  });
+});

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -5,6 +5,8 @@ import {
   CheckpointSchedule as CheckpointScheduleClass,
   ChildIdentity as ChildIdentityClass,
   ConfidentialAsset as ConfidentialAssetClass,
+  ConfidentialTransaction as ConfidentialTransactionClass,
+  ConfidentialVenue as ConfidentialVenueClass,
   CorporateAction as CorporateActionClass,
   CustomPermissionGroup as CustomPermissionGroupClass,
   DefaultPortfolio as DefaultPortfolioClass,
@@ -41,6 +43,8 @@ export type Instruction = InstructionClass;
 export type KnownPermissionGroup = KnownPermissionGroupClass;
 export type NumberedPortfolio = NumberedPortfolioClass;
 export type ConfidentialAsset = ConfidentialAssetClass;
+export type ConfidentialVenue = ConfidentialVenueClass;
+export type ConfidentialTransaction = ConfidentialTransactionClass;
 export type FungibleAsset = FungibleAssetClass;
 export type Nft = NftClass;
 export type NftCollection = NftCollectionClass;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -101,6 +101,8 @@ export { MultiSigProposal } from '~/api/entities/MultiSigProposal';
 export { TickerReservation } from '~/api/entities/TickerReservation';
 export { BaseAsset, FungibleAsset, NftCollection, Nft } from '~/api/entities/Asset';
 export { ConfidentialAsset } from '~/api/entities/confidential/ConfidentialAsset';
+export { ConfidentialVenue } from '~/api/entities/confidential/ConfidentialVenue';
+export { ConfidentialTransaction } from '~/api/entities/confidential/ConfidentialTransaction';
 export { MetadataEntry } from '~/api/entities/MetadataEntry';
 export { registerMetadata } from '~/api/procedures/registerMetadata';
 export { setMetadata } from '~/api/procedures/setMetadata';

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -14,6 +14,8 @@ import {
   CheckpointSchedule,
   ChildIdentity,
   ConfidentialAsset,
+  ConfidentialTransaction,
+  ConfidentialVenue,
   CorporateAction,
   CustomPermissionGroup,
   DefaultPortfolio,
@@ -368,6 +370,15 @@ interface ConfidentialAssetOptions extends EntityOptions {
   details?: EntityGetter<ConfidentialAssetDetails | null>;
 }
 
+interface ConfidentialVenueOptions extends EntityOptions {
+  id?: BigNumber;
+  creator?: EntityGetter<Identity>;
+}
+
+interface ConfidentialTransactionOptions extends EntityOptions {
+  id?: BigNumber;
+}
+
 type MockOptions = {
   identityOptions?: IdentityOptions;
   childIdentityOptions?: ChildIdentityOptions;
@@ -394,6 +405,8 @@ type MockOptions = {
   multiSigOptions?: MultiSigOptions;
   multiSigProposalOptions?: MultiSigProposalOptions;
   confidentialAssetOptions?: ConfidentialAssetOptions;
+  confidentialVenueOptions?: ConfidentialVenueOptions;
+  confidentialTransactionOptions?: ConfidentialTransactionOptions;
 };
 
 type Class<T = any> = new (...args: any[]) => T;
@@ -2125,6 +2138,61 @@ const MockConfidentialAssetClass = createMockEntityClass<ConfidentialAssetOption
   ['ConfidentialAsset']
 );
 
+const MockConfidentialVenueClass = createMockEntityClass<ConfidentialVenueOptions>(
+  class {
+    uuid!: string;
+    id!: BigNumber;
+    creator!: jest.Mock;
+
+    /**
+     * @hidden
+     */
+    public argsToOpts(...args: ConstructorParameters<typeof ConfidentialVenue>) {
+      return extractFromArgs(args, ['id']);
+    }
+
+    /**
+     * @hidden
+     */
+    public configure(opts: Required<ConfidentialVenueOptions>) {
+      this.uuid = 'confidentialVenue';
+      this.id = opts.id;
+      this.creator = createEntityGetterMock(opts.creator);
+    }
+  },
+  () => ({
+    id: new BigNumber(1),
+    creator: getIdentityInstance(),
+  }),
+  ['ConfidentialVenue']
+);
+
+const MockConfidentialTransactionClass = createMockEntityClass<ConfidentialTransactionOptions>(
+  class {
+    uuid!: string;
+    id!: BigNumber;
+
+    /**
+     * @hidden
+     */
+    public argsToOpts(...args: ConstructorParameters<typeof ConfidentialTransaction>) {
+      return extractFromArgs(args, ['id']);
+    }
+
+    /**
+     * @hidden
+     */
+    public configure(opts: Required<ConfidentialTransactionOptions>) {
+      this.uuid = 'confidentialTransaction';
+      this.id = opts.id;
+    }
+  },
+  () => ({
+    id: new BigNumber(1),
+  }),
+  ['ConfidentialTransaction']
+);
+
 export const mockIdentityModule = (path: string) => (): Record<string, unknown> => ({
   ...jest.requireActual(path),
   Identity: MockIdentityClass,
@@ -2250,6 +2318,16 @@ export const mockConfidentialAssetModule = (path: string) => (): Record<string, 
   ConfidentialAsset: MockConfidentialAssetClass,
 });
 
+export const mockConfidentialVenueModule = (path: string) => (): Record<string, unknown> => ({
+  ...jest.requireActual(path),
+  ConfidentialVenue: MockConfidentialVenueClass,
+});
+
+export const mockConfidentialTransactionModule = (path: string) => (): Record<string, unknown> => ({
+  ...jest.requireActual(path),
+  ConfidentialTransaction: MockConfidentialTransactionClass,
+});
+
 /**
  * @hidden
  *
@@ -2280,6 +2358,8 @@ export const initMocks = function (opts?: MockOptions): void {
   MockMultiSigClass.init(opts?.multiSigOptions);
   MockMultiSigProposalClass.init(opts?.multiSigProposalOptions);
   MockConfidentialAssetClass.init(opts?.confidentialAssetOptions);
+  MockConfidentialVenueClass.init(opts?.confidentialVenueOptions);
+  MockConfidentialTransactionClass.init(opts?.confidentialTransactionOptions);
 };
 
 /**
@@ -2313,6 +2393,8 @@ export const configureMocks = function (opts?: MockOptions): void {
   MockMultiSigClass.setOptions(opts?.multiSigOptions);
   MockMultiSigProposalClass.setOptions(opts?.multiSigProposalOptions);
   MockConfidentialAssetClass.setOptions(opts?.confidentialAssetOptions);
+  MockConfidentialVenueClass.setOptions(opts?.confidentialVenueOptions);
+  MockConfidentialTransactionClass.setOptions(opts?.confidentialTransactionOptions);
 };
 
 /**
@@ -2343,6 +2425,8 @@ export const reset = function (): void {
   MockMultiSigClass.resetOptions();
   MockMultiSigProposalClass.resetOptions();
   MockConfidentialAssetClass.resetOptions();
+  MockConfidentialVenueClass.resetOptions();
+  MockConfidentialTransactionClass.resetOptions();
 };
 
 /**


### PR DESCRIPTION
### Description

* Adds `ConfidentialVenue` and `ConfidentialTransaction` entity with basic `exists` and `toHuman` method
* `ConfidentialVenue` also has `creator` method to fetch the creator of the venue
* Adds `ConfidentialSettlements` namespace that will handle all venue and transaction related functions. For now `getVenue` and `getTransaction` has been added

### Breaking Changes

NA

### JIRA Link

DA-988, DA-989, DA-990

### Checklist

- [ ] Updated the Readme.md (if required) ?
