### PR TITLE
feat: 🎸 Add `ConfidentialAccount` entity and method to get confidential Asset auditors

### DIFF
--- a/src/api/entities/confidential/ConfidentialAccount/index.ts
+++ b/src/api/entities/confidential/ConfidentialAccount/index.ts
@@ -1,0 +1,79 @@
+import { Context, Entity, Identity } from '~/internal';
+import { identityIdToString, stringToU8aFixed } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export interface UniqueIdentifiers {
+  publicKey: string;
+}
+
+/**
+ * Represents an confidential Account in the Polymesh blockchain
+ */
+export class ConfidentialAccount extends Entity<UniqueIdentifiers, string> {
+  /**
+   * @hidden
+   * Check if a value is of type {@link UniqueIdentifiers}
+   */
+  public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
+    const { publicKey } = identifier as UniqueIdentifiers;
+
+    return typeof publicKey === 'string';
+  }
+
+  /**
+   * Public key of the confidential Account. Serves as an identifier
+   */
+  public publicKey: string;
+
+  /**
+   * @hidden
+   */
+  public constructor(identifiers: UniqueIdentifiers, context: Context) {
+    super(identifiers, context);
+
+    const { publicKey } = identifiers;
+
+    this.publicKey = publicKey;
+  }
+
+  /**
+   * Retrieve the Identity associated to this Account (null if there is none)
+   */
+  public async getIdentity(): Promise<Identity | null> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { confidentialAsset },
+        },
+      },
+      context,
+      publicKey,
+    } = this;
+
+    const optIdentityId = await confidentialAsset.accountDid(stringToU8aFixed(publicKey, context));
+
+    if (optIdentityId.isNone) {
+      return null;
+    }
+
+    const did = identityIdToString(optIdentityId.unwrap());
+
+    return new Identity({ did }, context);
+  }
+
+  /**
+   * Determine whether this Account exists on chain
+   */
+  public async exists(): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Return the Account's address
+   */
+  public toHuman(): string {
+    return this.publicKey;
+  }
+}

--- a/src/api/entities/confidential/ConfidentialAsset/index.ts
+++ b/src/api/entities/confidential/ConfidentialAsset/index.ts
@@ -78,13 +78,14 @@ export class ConfidentialAsset extends Entity<UniqueIdentifiers, string> {
    * Retrieve the confidential Asset's details
    */
   public async details(): Promise<ConfidentialAssetDetails | null> {
-    const { context } = this;
+    const { context, id } = this;
     const assetDetails = await this.getDetailsFromChain();
 
     if (assetDetails.isNone) {
       throw new PolymeshError({
         code: ErrorCode.DataUnavailable,
         message: 'The Confidential Asset does not exists',
+        data: { id },
       });
     }
 
@@ -120,6 +121,7 @@ export class ConfidentialAsset extends Entity<UniqueIdentifiers, string> {
       throw new PolymeshError({
         code: ErrorCode.DataUnavailable,
         message: 'The Confidential Asset does not exists',
+        data: { id },
       });
     }
 

--- a/src/api/entities/confidential/ConfidentialAsset/types.ts
+++ b/src/api/entities/confidential/ConfidentialAsset/types.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 
-import { Identity } from '~/internal';
+import { ConfidentialAccount, Identity } from '~/types';
 
 export interface ConfidentialAssetDetails {
   owner: Identity;
@@ -10,4 +10,9 @@ export interface ConfidentialAssetDetails {
    * optional ticker value if provided while creating the confidential Asset
    */
   ticker?: string;
+}
+
+export interface GroupedAuditors {
+  auditors: ConfidentialAccount[];
+  mediators: Identity[];
 }

--- a/src/api/entities/confidential/__tests__/ConfidentialAccount/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialAccount/index.ts
@@ -1,0 +1,88 @@
+import { ConfidentialAccount, Context, Entity } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+describe('ConfidentialAccount class', () => {
+  let context: Mocked<Context>;
+
+  let publicKey: string;
+  let account: ConfidentialAccount;
+
+  beforeAll(() => {
+    entityMockUtils.initMocks();
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    jest.spyOn(utilsConversionModule, 'addressToKey').mockImplementation();
+
+    publicKey = '0xb8bb6107ef0dacb727199b329e2d09141ea6f36774818797e843df800c746d19';
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+    account = new ConfidentialAccount({ publicKey }, context);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    dsMockUtils.reset();
+    procedureMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    procedureMockUtils.cleanup();
+    jest.restoreAllMocks();
+  });
+
+  it('should extend Entity', () => {
+    expect(ConfidentialAccount.prototype).toBeInstanceOf(Entity);
+  });
+
+  describe('method: isUniqueIdentifiers', () => {
+    it('should return true if the object conforms to the interface', () => {
+      expect(ConfidentialAccount.isUniqueIdentifiers({ publicKey })).toBe(true);
+      expect(ConfidentialAccount.isUniqueIdentifiers({})).toBe(false);
+      expect(ConfidentialAccount.isUniqueIdentifiers({ publicKey: 3 })).toBe(false);
+    });
+  });
+
+  describe('method: getIdentity', () => {
+    let accountDidMock: jest.Mock;
+
+    beforeEach(() => {
+      accountDidMock = dsMockUtils.createQueryMock('confidentialAsset', 'accountDid');
+      jest.spyOn(utilsConversionModule, 'stringToU8aFixed');
+    });
+
+    it('should return the Identity associated to the ConfidentialAccount', async () => {
+      const did = 'someDid';
+      accountDidMock.mockReturnValueOnce(
+        dsMockUtils.createMockOption(dsMockUtils.createMockIdentityId(did))
+      );
+
+      const result = await account.getIdentity();
+      expect(result?.did).toBe(did);
+    });
+
+    it('should return null if there is no Identity associated to the ConfidentialAccount', async () => {
+      accountDidMock.mockReturnValue(dsMockUtils.createMockOption());
+
+      const result = await account.getIdentity();
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('method: toHuman', () => {
+    it('should return a human readable version of the entity', () => {
+      expect(account.toHuman()).toBe(account.publicKey);
+    });
+  });
+
+  describe('method: exists', () => {
+    it('should return true', () => {
+      return expect(account.exists()).resolves.toBe(true);
+    });
+  });
+});

--- a/src/api/entities/confidential/__tests__/ConfidentialAsset/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialAsset/index.ts
@@ -139,6 +139,7 @@ describe('ConfidentialAsset class', () => {
       const expectedError = new PolymeshError({
         code: ErrorCode.DataUnavailable,
         message: 'The Confidential Asset does not exists',
+        data: { id },
       });
       detailsQueryMock.mockResolvedValue(dsMockUtils.createMockOption());
       await expect(confidentialAsset.details()).rejects.toThrow(expectedError);
@@ -154,6 +155,7 @@ describe('ConfidentialAsset class', () => {
       const expectedError = new PolymeshError({
         code: ErrorCode.DataUnavailable,
         message: 'The Confidential Asset does not exists',
+        data: { id },
       });
 
       return expect(confidentialAsset.getAuditors()).rejects.toThrow(expectedError);

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -4,6 +4,7 @@ import {
   Checkpoint as CheckpointClass,
   CheckpointSchedule as CheckpointScheduleClass,
   ChildIdentity as ChildIdentityClass,
+  ConfidentialAccount as ConfidentialAccountClass,
   ConfidentialAsset as ConfidentialAssetClass,
   ConfidentialTransaction as ConfidentialTransactionClass,
   ConfidentialVenue as ConfidentialVenueClass,
@@ -42,6 +43,7 @@ export type ChildIdentity = ChildIdentityClass;
 export type Instruction = InstructionClass;
 export type KnownPermissionGroup = KnownPermissionGroupClass;
 export type NumberedPortfolio = NumberedPortfolioClass;
+export type ConfidentialAccount = ConfidentialAccountClass;
 export type ConfidentialAsset = ConfidentialAssetClass;
 export type ConfidentialVenue = ConfidentialVenueClass;
 export type ConfidentialTransaction = ConfidentialTransactionClass;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -100,6 +100,7 @@ export { MultiSig } from '~/api/entities/Account/MultiSig';
 export { MultiSigProposal } from '~/api/entities/MultiSigProposal';
 export { TickerReservation } from '~/api/entities/TickerReservation';
 export { BaseAsset, FungibleAsset, NftCollection, Nft } from '~/api/entities/Asset';
+export { ConfidentialAccount } from '~/api/entities/confidential/ConfidentialAccount';
 export { ConfidentialAsset } from '~/api/entities/confidential/ConfidentialAsset';
 export { ConfidentialVenue } from '~/api/entities/confidential/ConfidentialVenue';
 export { ConfidentialTransaction } from '~/api/entities/confidential/ConfidentialTransaction';

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -52,7 +52,9 @@ import {
   PalletAssetSecurityToken,
   PalletAssetTickerRegistration,
   PalletAssetTickerRegistrationConfig,
+  PalletConfidentialAssetAuditorAccount,
   PalletConfidentialAssetConfidentialAssetDetails,
+  PalletConfidentialAssetConfidentialAuditors,
   PalletContractsStorageContractInfo,
   PalletCorporateActionsCaCheckpoint,
   PalletCorporateActionsCaId,
@@ -4445,4 +4447,32 @@ export const createMockConfidentialAssetDetails = (
   };
 
   return createMockCodec({ totalSupply, ownerDid, data, ticker }, !details);
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
+export const createMockConfidentialAuditors = (
+  assetAuditors?:
+    | PalletConfidentialAssetConfidentialAuditors
+    | {
+        auditors:
+          | BTreeSet<PalletConfidentialAssetAuditorAccount>
+          | Parameters<typeof createMockBTreeSet>[0];
+        mediators:
+          | BTreeSet<PolymeshPrimitivesIdentityId>
+          | Parameters<typeof createMockBTreeSet>[0];
+      }
+): MockCodec<PalletConfidentialAssetConfidentialAuditors> => {
+  if (isCodec<PalletConfidentialAssetConfidentialAuditors>(assetAuditors)) {
+    return assetAuditors as MockCodec<PalletConfidentialAssetConfidentialAuditors>;
+  }
+
+  const { auditors, mediators } = assetAuditors ?? {
+    auditors: createMockBTreeSet(),
+    mediators: createMockBTreeSet(),
+  };
+
+  return createMockCodec({ auditors, mediators }, !assetAuditors);
 };

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -13,6 +13,7 @@ import {
   Checkpoint,
   CheckpointSchedule,
   ChildIdentity,
+  ConfidentialAccount,
   ConfidentialAsset,
   ConfidentialTransaction,
   ConfidentialVenue,
@@ -379,6 +380,11 @@ interface ConfidentialTransactionOptions extends EntityOptions {
   id?: BigNumber;
 }
 
+interface ConfidentialAccountOptions extends EntityOptions {
+  publicKey?: string;
+  getIdentity?: EntityGetter<Identity | null>;
+}
+
 type MockOptions = {
   identityOptions?: IdentityOptions;
   childIdentityOptions?: ChildIdentityOptions;
@@ -407,6 +413,7 @@ type MockOptions = {
   confidentialAssetOptions?: ConfidentialAssetOptions;
   confidentialVenueOptions?: ConfidentialVenueOptions;
   confidentialTransactionOptions?: ConfidentialTransactionOptions;
+  confidentialAccountOptions?: ConfidentialAccountOptions;
 };
 
 type Class<T = any> = new (...args: any[]) => T;
@@ -2104,6 +2111,35 @@ const MockKnownPermissionGroupClass = createMockEntityClass<KnownPermissionGroup
   ['PermissionGroup', 'KnownPermissionGroup']
 );
 
+const MockConfidentialAccountClass = createMockEntityClass<ConfidentialAccountOptions>(
+  class {
+    uuid!: string;
+    publicKey!: string;
+    getIdentity!: jest.Mock;
+
+    /**
+     * @hidden
+     */
+    public argsToOpts(...args: ConstructorParameters<typeof ConfidentialAccount>) {
+      return extractFromArgs(args, ['publicKey']);
+    }
+
+    /**
+     * @hidden
+     */
+    public configure(opts: Required<ConfidentialAccountOptions>) {
+      this.uuid = 'confidentialAccount';
+      this.publicKey = opts.publicKey;
+      this.getIdentity = createEntityGetterMock(opts.getIdentity);
+    }
+  },
+  () => ({
+    publicKey: 'somePublicKey',
+    getIdentity: getIdentityInstance(),
+  }),
+  ['ConfidentialAccount']
+);
+
 const MockConfidentialAssetClass = createMockEntityClass<ConfidentialAssetOptions>(
   class {
     uuid!: string;
@@ -2313,6 +2349,11 @@ export const mockKnownPermissionGroupModule = (path: string) => (): Record<strin
   KnownPermissionGroup: MockKnownPermissionGroupClass,
 });
 
+export const mockConfidentialAccountModule = (path: string) => (): Record<string, unknown> => ({
+  ...jest.requireActual(path),
+  ConfidentialAccount: MockConfidentialAccountClass,
+});
+
 export const mockConfidentialAssetModule = (path: string) => (): Record<string, unknown> => ({
   ...jest.requireActual(path),
   ConfidentialAsset: MockConfidentialAssetClass,
@@ -2357,6 +2398,7 @@ export const initMocks = function (opts?: MockOptions): void {
   MockDividendDistributionClass.init(opts?.dividendDistributionOptions);
   MockMultiSigClass.init(opts?.multiSigOptions);
   MockMultiSigProposalClass.init(opts?.multiSigProposalOptions);
+  MockConfidentialAccountClass.init(opts?.confidentialAccountOptions);
   MockConfidentialAssetClass.init(opts?.confidentialAssetOptions);
   MockConfidentialVenueClass.init(opts?.confidentialVenueOptions);
   MockConfidentialTransactionClass.init(opts?.confidentialTransactionOptions);
@@ -2392,6 +2434,7 @@ export const configureMocks = function (opts?: MockOptions): void {
   MockDividendDistributionClass.setOptions(opts?.dividendDistributionOptions);
   MockMultiSigClass.setOptions(opts?.multiSigOptions);
   MockMultiSigProposalClass.setOptions(opts?.multiSigProposalOptions);
+  MockConfidentialAccountClass.setOptions(opts?.confidentialAccountOptions);
   MockConfidentialAssetClass.setOptions(opts?.confidentialAssetOptions);
   MockConfidentialVenueClass.setOptions(opts?.confidentialVenueOptions);
   MockConfidentialTransactionClass.setOptions(opts?.confidentialTransactionOptions);
@@ -2424,6 +2467,7 @@ export const reset = function (): void {
   MockDividendDistributionClass.resetOptions();
   MockMultiSigClass.resetOptions();
   MockMultiSigProposalClass.resetOptions();
+  MockConfidentialAccountClass.resetOptions();
   MockConfidentialAssetClass.resetOptions();
   MockConfidentialVenueClass.resetOptions();
   MockConfidentialTransactionClass.resetOptions();


### PR DESCRIPTION
### Description

* Adds in `ConfidentialAccount` entity. This also has `getIdentity` method to get DID mapped with the CA
* Adds in `getAuditors` to `ConfidentialAsset` to get auditors (mapped by type) for a CA

### Breaking Changes

NA

### JIRA Link

DA-987
DA-1014

### Checklist

- [ ] Updated the Readme.md (if required) ?
