### PR TITLE
feat: 🎸 add `onStatusChange` to confidential transaction

### DIFF
--- a/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
@@ -1,3 +1,4 @@
+import { u64 } from '@polkadot/types';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -154,8 +155,8 @@ describe('ConfidentialTransaction class', () => {
 
   describe('method: onStatusChange', () => {
     let bigNumberToU64Spy: jest.SpyInstance;
-    let instructionStatusesMock: jest.Mock;
-    const rawId = dsMockUtils.createMockU64(new BigNumber(1));
+    let transactionStatusesMock: jest.Mock;
+    let rawId: u64;
 
     afterAll(() => {
       jest.restoreAllMocks();
@@ -167,10 +168,11 @@ describe('ConfidentialTransaction class', () => {
 
     beforeEach(() => {
       const owner = 'someDid';
+      rawId = dsMockUtils.createMockU64(new BigNumber(1));
       entityMockUtils.configureMocks({ identityOptions: { did: owner } });
       when(bigNumberToU64Spy).calledWith(id, context).mockReturnValue(rawId);
 
-      instructionStatusesMock = dsMockUtils.createQueryMock(
+      transactionStatusesMock = dsMockUtils.createQueryMock(
         'confidentialAsset',
         'transactionStatuses'
       );
@@ -186,12 +188,12 @@ describe('ConfidentialTransaction class', () => {
       const mockPending = dsMockUtils.createMockOption(
         createMockConfidentialTransactionStatus(ConfidentialTransactionStatus.Pending)
       );
-      instructionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
+      transactionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
         cbFunc(mockPending);
         return unsubCallback;
       });
 
-      when(instructionStatusesMock).calledWith(rawId).mockResolvedValue(mockPendingStatus);
+      when(transactionStatusesMock).calledWith(rawId).mockResolvedValue(mockPendingStatus);
 
       let result = await transaction.onStatusChange(callback);
 
@@ -202,7 +204,7 @@ describe('ConfidentialTransaction class', () => {
         dsMockUtils.createMockInstructionStatus(ConfidentialTransactionStatus.Rejected)
       );
 
-      instructionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
+      transactionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
         cbFunc(mockRejectedStatus);
         return unsubCallback;
       });
@@ -217,7 +219,7 @@ describe('ConfidentialTransaction class', () => {
       const unsubCallback = 'unsubCallback' as unknown as Promise<UnsubCallback>;
       const callback = jest.fn();
 
-      instructionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
+      transactionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
         cbFunc(dsMockUtils.createMockOption());
         return unsubCallback;
       });

--- a/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
@@ -1,13 +1,16 @@
 import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
 
 import { ConfidentialTransaction, Context, Entity, PolymeshError } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import {
   createMockConfidentialAssetTransaction,
+  createMockConfidentialTransactionStatus,
   createMockOption,
 } from '~/testUtils/mocks/dataSources';
 import { Mocked } from '~/testUtils/types';
-import { ConfidentialTransactionStatus, ErrorCode } from '~/types';
+import { ConfidentialTransactionStatus, ErrorCode, UnsubCallback } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
 
 describe('ConfidentialTransaction class', () => {
   let context: Mocked<Context>;
@@ -146,6 +149,85 @@ describe('ConfidentialTransaction class', () => {
       });
 
       return expect(transaction.details()).rejects.toThrow(expectedError);
+    });
+  });
+
+  describe('method: onStatusChange', () => {
+    let bigNumberToU64Spy: jest.SpyInstance;
+    let instructionStatusesMock: jest.Mock;
+    const rawId = dsMockUtils.createMockU64(new BigNumber(1));
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    beforeAll(() => {
+      bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+    });
+
+    beforeEach(() => {
+      const owner = 'someDid';
+      entityMockUtils.configureMocks({ identityOptions: { did: owner } });
+      when(bigNumberToU64Spy).calledWith(id, context).mockReturnValue(rawId);
+
+      instructionStatusesMock = dsMockUtils.createQueryMock(
+        'confidentialAsset',
+        'transactionStatuses'
+      );
+    });
+
+    it('should allow subscription', async () => {
+      const unsubCallback = 'unsubCallback' as unknown as Promise<UnsubCallback>;
+      const callback = jest.fn();
+
+      const mockPendingStatus = dsMockUtils.createMockConfidentialTransactionStatus(
+        ConfidentialTransactionStatus.Pending
+      );
+      const mockPending = dsMockUtils.createMockOption(
+        createMockConfidentialTransactionStatus(ConfidentialTransactionStatus.Pending)
+      );
+      instructionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
+        cbFunc(mockPending);
+        return unsubCallback;
+      });
+
+      when(instructionStatusesMock).calledWith(rawId).mockResolvedValue(mockPendingStatus);
+
+      let result = await transaction.onStatusChange(callback);
+
+      expect(result).toEqual(unsubCallback);
+      expect(callback).toBeCalledWith(ConfidentialTransactionStatus.Pending);
+
+      const mockRejectedStatus = dsMockUtils.createMockOption(
+        dsMockUtils.createMockInstructionStatus(ConfidentialTransactionStatus.Rejected)
+      );
+
+      instructionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
+        cbFunc(mockRejectedStatus);
+        return unsubCallback;
+      });
+
+      result = await transaction.onStatusChange(callback);
+
+      expect(result).toEqual(unsubCallback);
+      expect(callback).toBeCalledWith(ConfidentialTransactionStatus.Rejected);
+    });
+
+    it('should error missing transaction status', () => {
+      const unsubCallback = 'unsubCallback' as unknown as Promise<UnsubCallback>;
+      const callback = jest.fn();
+
+      instructionStatusesMock.mockImplementationOnce(async (_, cbFunc) => {
+        cbFunc(dsMockUtils.createMockOption());
+        return unsubCallback;
+      });
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'The status of the transaction was not found',
+      });
+
+      return expect(transaction.onStatusChange(callback)).rejects.toThrow(expectedError);
     });
   });
 


### PR DESCRIPTION
### Description

allows for subscription to confidential transaction status changes

### Breaking Changes

none

### JIRA Link

✅ Closes: [DA-995](https://polymesh.atlassian.net/browse/DA-995)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-995]: https://polymesh.atlassian.net/browse/DA-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ