### PR TITLE
feat: 🎸 add `getInvolvedConfidentialTransactions` to Identity

### DIFF
--- a/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
@@ -339,6 +339,32 @@ describe('ConfidentialTransaction class', () => {
     });
   });
 
+  describe('method: getPendingAffirmCount', () => {
+    const mockCount = new BigNumber(3);
+    const rawMockCount = dsMockUtils.createMockU32(mockCount);
+    it('should return the number of pending affirmations', async () => {
+      dsMockUtils.createQueryMock('confidentialAsset', 'pendingAffirms', {
+        returnValue: dsMockUtils.createMockOption(rawMockCount),
+      });
+
+      const result = await transaction.getPendingAffirmsCount();
+      expect(result).toEqual(mockCount);
+    });
+
+    it('should throw an error if the count is not found', async () => {
+      dsMockUtils.createQueryMock('confidentialAsset', 'pendingAffirms', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'Affirm count not available. The transaction has likely been completed and pruned',
+      });
+
+      return expect(transaction.getPendingAffirmsCount()).rejects.toThrow(expectedError);
+    });
+  });
+
   describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       expect(transaction.toHuman()).toBe('1');

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -58,6 +58,7 @@ import {
   PalletConfidentialAssetConfidentialAccount,
   PalletConfidentialAssetConfidentialAssetDetails,
   PalletConfidentialAssetConfidentialAuditors,
+  PalletConfidentialAssetLegParty,
   PalletConfidentialAssetTransaction,
   PalletConfidentialAssetTransactionId,
   PalletConfidentialAssetTransactionLeg,
@@ -4713,4 +4714,17 @@ export const createMockConfidentialAssetTransactionId = (
   return createMockNumberCodec<u64>(
     txId
   ) as unknown as MockCodec<PalletConfidentialAssetTransactionId>;
+};
+
+/**
+ *  NOTE: `isEmpty` will be set to true if no value is passed
+ */
+export const createMockConfidentialLegParty = (
+  role?: 'Sender' | 'Receiver' | 'Mediator' | PalletConfidentialAssetLegParty
+): MockCodec<PalletConfidentialAssetLegParty> => {
+  if (isCodec<PalletConfidentialAssetLegParty>(role)) {
+    return role as MockCodec<PalletConfidentialAssetLegParty>;
+  }
+
+  return createMockEnum<PalletConfidentialAssetLegParty>(role);
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ import {
   BaseAsset,
   Checkpoint,
   CheckpointSchedule,
+  ConfidentialTransaction,
   CustomPermissionGroup,
   DefaultPortfolio,
   DefaultTrustedClaimIssuer,
@@ -1791,3 +1792,23 @@ export interface ConfidentialTransactionDetails {
   status: ConfidentialTransactionStatus;
   memo?: string;
 }
+
+export enum ConfidentialAffirmParty {
+  Sender = 'Sender',
+  Receiver = 'Receiver',
+  Mediator = 'Mediator',
+}
+
+export enum ConfidentialLegParty {
+  Sender = 'Sender',
+  Receiver = 'Receiver',
+  Mediator = 'Mediator',
+  Auditor = 'Auditor',
+}
+
+export type ConfidentialAffirmation = {
+  transaction: ConfidentialTransaction;
+  legId: BigNumber;
+  role: ConfidentialLegParty;
+  affirmed: boolean;
+};

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -12,8 +12,10 @@ import {
 import {
   PalletConfidentialAssetAuditorAccount,
   PalletConfidentialAssetConfidentialAuditors,
+  PalletConfidentialAssetLegParty,
   PalletConfidentialAssetTransaction,
   PalletConfidentialAssetTransactionLeg,
+  PalletConfidentialAssetTransactionLegId,
   PalletConfidentialAssetTransactionStatus,
   PalletCorporateActionsCaId,
   PalletCorporateActionsCaKind,
@@ -123,6 +125,7 @@ import {
   ConditionCompliance,
   ConditionTarget,
   ConditionType,
+  ConfidentialLegParty,
   ConfidentialTransactionStatus,
   CorporateActionKind,
   CorporateActionParams,
@@ -210,7 +213,9 @@ import {
   complianceRequirementToRequirement,
   confidentialAssetsToBtreeSet,
   confidentialLegIdToId,
+  confidentialLegPartyToRole,
   confidentialLegToMeshLeg,
+  confidentialTransactionLegIdToBigNumber,
   corporateActionIdentifierToCaId,
   corporateActionKindToCaKind,
   corporateActionParamsToMeshCorporateActionArgs,
@@ -10140,5 +10145,69 @@ describe('meshConfidentialAssetTransactionIdToId', () => {
     const result = meshConfidentialAssetTransactionIdToId(mockAssetId);
 
     expect(result).toEqual(new BigNumber(1));
+  });
+
+  describe('confidentialTransactionLegIdToBigNumber', () => {
+    let id: BigNumber;
+    let rawId: PalletConfidentialAssetTransactionLegId;
+
+    beforeAll(() => {
+      dsMockUtils.initMocks();
+    });
+
+    beforeEach(() => {
+      id = new BigNumber(1);
+      rawId = dsMockUtils.createMockConfidentialTransactionLegId(id);
+    });
+
+    afterEach(() => {
+      dsMockUtils.reset();
+    });
+
+    afterAll(() => {
+      dsMockUtils.cleanup();
+    });
+
+    it('should convert PalletConfidentialAssetTransactionLegId to BigNumber ', () => {
+      const result = confidentialTransactionLegIdToBigNumber(rawId);
+
+      expect(result).toEqual(id);
+    });
+  });
+
+  describe('confidentialTransactionLegIdToBigNumber', () => {
+    beforeAll(() => {
+      dsMockUtils.initMocks();
+    });
+    afterEach(() => {
+      dsMockUtils.reset();
+    });
+
+    afterAll(() => {
+      dsMockUtils.cleanup();
+    });
+
+    it('should convert PalletConfidentialAssetTransactionLegId to BigNumber ', () => {
+      let input = dsMockUtils.createMockConfidentialLegParty('Sender');
+      let expected = ConfidentialLegParty.Sender;
+      let result = confidentialLegPartyToRole(input);
+      expect(result).toEqual(expected);
+
+      input = dsMockUtils.createMockConfidentialLegParty('Receiver');
+      expected = ConfidentialLegParty.Receiver;
+      result = confidentialLegPartyToRole(input);
+      expect(result).toEqual(expected);
+
+      input = dsMockUtils.createMockConfidentialLegParty('Mediator');
+      expected = ConfidentialLegParty.Mediator;
+      result = confidentialLegPartyToRole(input);
+      expect(result).toEqual(expected);
+    });
+
+    it('should throw if an unexpected role is received', () => {
+      const input = 'notSomeRole' as unknown as PalletConfidentialAssetLegParty;
+
+      expect(() => confidentialLegPartyToRole(input)).toThrow(UnreachableCaseError);
+    });
   });
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -19,6 +19,7 @@ import {
   PalletConfidentialAssetAuditorAccount,
   PalletConfidentialAssetConfidentialAccount,
   PalletConfidentialAssetConfidentialAuditors,
+  PalletConfidentialAssetLegParty,
   PalletConfidentialAssetTransaction,
   PalletConfidentialAssetTransactionId,
   PalletConfidentialAssetTransactionLeg,
@@ -175,6 +176,7 @@ import {
   ConditionTarget,
   ConditionType,
   ConfidentialLeg,
+  ConfidentialLegParty,
   ConfidentialTransactionDetails,
   ConfidentialTransactionStatus,
   CorporateActionKind,
@@ -5011,6 +5013,12 @@ export function meshConfidentialAssetTransactionIdToId(
   return new BigNumber(id.toNumber());
 }
 
+export function confidentialTransactionLegIdToBigNumber(
+  id: PalletConfidentialAssetTransactionLegId
+): BigNumber {
+  return new BigNumber(id.toString());
+}
+
 /**
  * @hidden
  */
@@ -5042,4 +5050,22 @@ export function meshConfidentialLegDetailsToDetails(
     assetAuditors,
     mediators,
   };
+}
+
+/**
+ * @hidden
+ */
+export function confidentialLegPartyToRole(
+  role: PalletConfidentialAssetLegParty
+): ConfidentialLegParty {
+  switch (role.type) {
+    case 'Sender':
+      return ConfidentialLegParty.Sender;
+    case 'Receiver':
+      return ConfidentialLegParty.Receiver;
+    case 'Mediator':
+      return ConfidentialLegParty.Mediator;
+    default:
+      throw new UnreachableCaseError(role.type);
+  }
 }


### PR DESCRIPTION

### Description

add method for users to get confidential transactions involving their affirmation
add method to get number of pending affirmations on a confidential transaction

### Breaking Changes

None

### JIRA Link

✅ Closes: [DA-993](https://polymesh.atlassian.net/browse/DA-993)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-993]: https://polymesh.atlassian.net/browse/DA-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ