### PR TITLE
feat: 🎸 add affirm/reject methods for confidential transaction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, beta, alpha, confidential-asset]
+    branches: [master, beta, alpha, confidential-assets]
   pull_request:
     types: [assigned, opened, synchronize, reopened]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, beta, alpha]
+    branches: [master, beta, alpha, confidential-asset]
   pull_request:
     types: [assigned, opened, synchronize, reopened]
 

--- a/src/api/entities/CheckpointSchedule/index.ts
+++ b/src/api/entities/CheckpointSchedule/index.ts
@@ -17,6 +17,9 @@ export interface HumanReadable {
   expiryDate: string | null;
 }
 
+/**
+ * @hidden
+ */
 export interface Params {
   pendingPoints: Date[];
 }

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -943,7 +943,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    */
   public async getInvolvedConfidentialTransactions(
     paginationOpts?: PaginationOptions
-  ): Promise<ResultSet<ConfidentialAffirmation> | UnsubCallback> {
+  ): Promise<ResultSet<ConfidentialAffirmation>> {
     const {
       did,
       context,

--- a/src/api/entities/confidential/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/ConfidentialTransaction/index.ts
@@ -3,7 +3,6 @@ import { PalletConfidentialAssetTransactionStatus } from '@polkadot/types/lookup
 import BigNumber from 'bignumber.js';
 
 import {
-  AffirmConfidentialTransactionParams,
   affirmConfidentialTransactions,
   Context,
   Entity,
@@ -13,6 +12,7 @@ import {
   rejectConfidentialTransaction,
 } from '~/internal';
 import {
+  AffirmConfidentialTransactionParams,
   ConfidentialLeg,
   ConfidentialLegState,
   ConfidentialLegStateWithId,
@@ -366,7 +366,9 @@ export class ConfidentialTransaction extends Entity<UniqueIdentifiers, string> {
   public execute: NoArgsProcedureMethod<ConfidentialTransaction>;
 
   /**
-   * Affirms a leg of the transaction
+   * Affirms a leg of this transaction
+   *
+   * @note - The sender must provide their affirmation before anyone else can. (Sender affirmation is where amounts are specified)
    */
   public affirmLeg: ProcedureMethod<AffirmConfidentialTransactionParams, ConfidentialTransaction>;
 

--- a/src/api/entities/confidential/ConfidentialTransaction/types.ts
+++ b/src/api/entities/confidential/ConfidentialTransaction/types.ts
@@ -94,3 +94,17 @@ export interface ConfidentialAffirmTransaction {
   party: ConfidentialAffirmParty;
   proofs?: ConfidentialLegProof[];
 }
+
+export interface SenderAffirm {
+  party: ConfidentialAffirmParty.Sender;
+  proofs: ConfidentialLegProof[];
+}
+
+export interface ObserverAffirm {
+  party: ConfidentialAffirmParty.Mediator | ConfidentialAffirmParty.Receiver;
+}
+
+export type AffirmConfidentialTransactionParams = { legId: BigNumber } & (
+  | SenderAffirm
+  | ObserverAffirm
+);

--- a/src/api/entities/confidential/ConfidentialTransaction/types.ts
+++ b/src/api/entities/confidential/ConfidentialTransaction/types.ts
@@ -20,6 +20,24 @@ export interface ConfidentialLeg {
   mediators: Identity[];
 }
 
+export interface ConfidentialLegStateBalances {
+  senderInitBalance: string;
+  senderAmount: string;
+  receiverAmount: string;
+}
+
+/**
+ * The confidential state for the leg. When the sender provides proof of funds, this will contain the encrypted balances for the leg
+ */
+export type ConfidentialLegState =
+  | {
+      proved: true;
+      assetState: { asset: ConfidentialAsset; balances: ConfidentialLegStateBalances }[];
+    }
+  | { proved: false };
+
+export type ConfidentialLegStateWithId = { legId: BigNumber } & ConfidentialLegState;
+
 /**
  * Status of a confidential transaction
  */
@@ -63,4 +81,16 @@ export enum TransactionAffirmParty {
   Sender = 'Sender',
   Receiver = 'Receiver',
   Mediator = 'Mediator',
+}
+
+export interface ConfidentialLegProof {
+  asset: string | ConfidentialAsset;
+  proof: string;
+}
+
+export interface ConfidentialAffirmTransaction {
+  transactionId: BigNumber;
+  legId: BigNumber;
+  party: ConfidentialAffirmParty;
+  proofs?: ConfidentialLegProof[];
 }

--- a/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
@@ -1,4 +1,5 @@
-import { u64 } from '@polkadot/types';
+import { Bytes, u64 } from '@polkadot/types';
+import { PalletConfidentialAssetTransactionLegState } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -16,7 +17,13 @@ import {
   createMockOption,
 } from '~/testUtils/mocks/dataSources';
 import { Mocked } from '~/testUtils/types';
-import { ConfidentialTransactionStatus, ErrorCode, UnsubCallback } from '~/types';
+import {
+  ConfidentialAffirmParty,
+  ConfidentialLegStateBalances,
+  ConfidentialTransactionStatus,
+  ErrorCode,
+  UnsubCallback,
+} from '~/types';
 import { tuple } from '~/types/utils';
 import * as utilsConversionModule from '~/utils/conversion';
 
@@ -36,6 +43,7 @@ describe('ConfidentialTransaction class', () => {
   let context: Mocked<Context>;
   let transaction: ConfidentialTransaction;
   let id: BigNumber;
+  let legId: BigNumber;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -43,6 +51,7 @@ describe('ConfidentialTransaction class', () => {
     procedureMockUtils.initMocks();
 
     id = new BigNumber(1);
+    legId = new BigNumber(2);
   });
 
   beforeEach(() => {
@@ -294,7 +303,6 @@ describe('ConfidentialTransaction class', () => {
   });
 
   describe('method: getLegs', () => {
-    const legId = new BigNumber(2);
     const rawTransactionId = dsMockUtils.createMockConfidentialAssetTransactionId(id);
     const senderKey = '0x01';
     const receiverKey = '0x02';
@@ -395,6 +403,158 @@ describe('ConfidentialTransaction class', () => {
       const tx = await transaction.execute();
 
       expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: affirm', () => {
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const expectedTransaction =
+        'someTransaction' as unknown as PolymeshTransaction<ConfidentialTransaction>;
+
+      const args = { legId, party: ConfidentialAffirmParty.Mediator } as const;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          {
+            args: { transaction, ...args },
+            transformer: undefined,
+          },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await transaction.affirmLeg(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: reject', () => {
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const expectedTransaction =
+        'someTransaction' as unknown as PolymeshTransaction<ConfidentialTransaction>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          {
+            args: { transaction },
+            transformer: undefined,
+          },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await transaction.reject();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('leg state methods', () => {});
+  let mockLegState: dsMockUtils.MockCodec<PalletConfidentialAssetTransactionLegState>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockLegReturn: any;
+
+  beforeEach(() => {
+    mockLegState = dsMockUtils.createMockConfidentialLegState({
+      assetState: dsMockUtils.createMockBTreeMap<
+        Bytes,
+        PalletConfidentialAssetTransactionLegState
+      >(),
+    });
+    mockLegReturn = dsMockUtils.createMockOption(mockLegState);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockLegState.assetState as any).toJSON = (): Record<string, ConfidentialLegStateBalances> => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      '0x01': {
+        senderInitBalance: '0x02',
+        senderAmount: '0x03',
+        receiverAmount: '0x04',
+      },
+    });
+
+    jest.spyOn(mockLegReturn, 'unwrap').mockReturnValue(mockLegState);
+  });
+
+  describe('method: getLegStates', () => {
+    it('should return the leg states for the transaction', async () => {
+      dsMockUtils.createQueryMock('confidentialAsset', 'txLegStates', {
+        entries: [
+          tuple(
+            [
+              dsMockUtils.createMockConfidentialTransactionId(id),
+              dsMockUtils.createMockConfidentialTransactionLegId(legId),
+            ],
+            mockLegReturn
+          ),
+          tuple(
+            [
+              dsMockUtils.createMockConfidentialTransactionId(id),
+              dsMockUtils.createMockConfidentialTransactionLegId(new BigNumber(legId.plus(1))),
+            ],
+            dsMockUtils.createMockOption()
+          ),
+        ],
+      });
+
+      const result = await transaction.getLegStates();
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            proved: true,
+            assetState: expect.arrayContaining([
+              expect.objectContaining({
+                asset: expect.objectContaining({ id: '01' }),
+                balances: expect.objectContaining({
+                  senderInitBalance: '0x02',
+                  senderAmount: '0x03',
+                  receiverAmount: '0x04',
+                }),
+              }),
+            ]),
+          }),
+          expect.objectContaining({
+            proved: false,
+          }),
+        ])
+      );
+    });
+  });
+
+  describe('method: getLegState', () => {
+    it('should return the leg state for the leg when its pending proof', async () => {
+      dsMockUtils.createQueryMock('confidentialAsset', 'txLegStates', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+      const result = await transaction.getLegState(legId);
+
+      expect(result).toEqual({ proved: false });
+    });
+
+    it('should return the leg state for the leg when it has been proved', async () => {
+      dsMockUtils.createQueryMock('confidentialAsset', 'txLegStates', {
+        returnValue: mockLegReturn,
+      });
+
+      const result = await transaction.getLegState(legId);
+
+      expect(result).toEqual({
+        proved: true,
+        assetState: expect.arrayContaining([
+          expect.objectContaining({
+            asset: expect.objectContaining({ id: '01' }),
+            balances: expect.objectContaining({
+              senderInitBalance: '0x02',
+              senderAmount: '0x03',
+              receiverAmount: '0x04',
+            }),
+          }),
+        ]),
+      });
     });
   });
 

--- a/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
@@ -406,7 +406,7 @@ describe('ConfidentialTransaction class', () => {
     });
   });
 
-  describe('method: affirm', () => {
+  describe('method: affirmLeg', () => {
     it('should prepare the procedure and return the resulting transaction', async () => {
       const expectedTransaction =
         'someTransaction' as unknown as PolymeshTransaction<ConfidentialTransaction>;
@@ -464,8 +464,6 @@ describe('ConfidentialTransaction class', () => {
         PalletConfidentialAssetTransactionLegState
       >(),
     });
-    mockLegReturn = dsMockUtils.createMockOption(mockLegState);
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockLegState.assetState as any).toJSON = (): Record<string, ConfidentialLegStateBalances> => ({
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -476,7 +474,7 @@ describe('ConfidentialTransaction class', () => {
       },
     });
 
-    jest.spyOn(mockLegReturn, 'unwrap').mockReturnValue(mockLegState);
+    mockLegReturn = dsMockUtils.createMockOption(mockLegState);
   });
 
   describe('method: getLegStates', () => {

--- a/src/api/procedures/__tests__/affirmConfidentialTransactions.ts
+++ b/src/api/procedures/__tests__/affirmConfidentialTransactions.ts
@@ -1,0 +1,213 @@
+import { u32, u64 } from '@polkadot/types';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareAffirmConfidentialTransactions,
+} from '~/api/procedures/affirmConfidentialTransactions';
+import { Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import {
+  ConfidentialAffirmParty,
+  ConfidentialTransaction,
+  ConfidentialTransactionStatus,
+  TxTags,
+} from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/confidential/ConfidentialTransaction',
+  require('~/testUtils/mocks/entities').mockConfidentialTransactionModule(
+    '~/api/entities/confidential/ConfidentialTransaction'
+  )
+);
+
+describe('affirmConfidentialTransactions procedure', () => {
+  let legId: BigNumber;
+  let mockContext: Mocked<Context>;
+  let bigNumberToU64Spy: jest.SpyInstance;
+  let bigNumberToU32Spy: jest.SpyInstance;
+  let confidentialAffirmsToRawSpy: jest.SpyInstance;
+  let transactionId: BigNumber;
+  let legsCount: BigNumber;
+  let rawLegsCount: u32;
+  let rawTransactionId: u64;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+
+    bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+    bigNumberToU32Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU32');
+    confidentialAffirmsToRawSpy = jest.spyOn(utilsConversionModule, 'confidentialAffirmsToRaw');
+    legId = new BigNumber(1);
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance();
+
+    transactionId = new BigNumber(1);
+    legsCount = new BigNumber(1);
+    rawTransactionId = dsMockUtils.createMockU64(transactionId);
+    rawLegsCount = dsMockUtils.createMockU32(legsCount);
+
+    when(bigNumberToU64Spy)
+      .calledWith(transactionId, mockContext)
+      .mockReturnValue(rawTransactionId);
+    when(bigNumberToU32Spy).calledWith(legsCount, mockContext).mockReturnValue(rawLegsCount);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if the signing identity is not involved in the transaction', () => {
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
+
+    return expect(
+      prepareAffirmConfidentialTransactions.call(proc, {
+        legId,
+        party: ConfidentialAffirmParty.Mediator,
+        transaction: entityMockUtils.getConfidentialTransactionInstance({
+          getInvolvedParties: [entityMockUtils.getIdentityInstance({ did: 'randomDid' })],
+        }),
+      })
+    ).rejects.toThrow('The signing identity is not involved in this Confidential Transaction');
+  });
+
+  it('should throw an error if status is already Executed or Rejected', async () => {
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
+
+    await expect(
+      prepareAffirmConfidentialTransactions.call(proc, {
+        legId,
+        party: ConfidentialAffirmParty.Sender,
+        proofs: [],
+        transaction: entityMockUtils.getConfidentialTransactionInstance({
+          details: {
+            status: ConfidentialTransactionStatus.Executed,
+          },
+        }),
+      })
+    ).rejects.toThrow('The Confidential Transaction has already been completed');
+
+    await expect(
+      prepareAffirmConfidentialTransactions.call(proc, {
+        legId,
+        party: ConfidentialAffirmParty.Mediator,
+        transaction: entityMockUtils.getConfidentialTransactionInstance({
+          details: {
+            status: ConfidentialTransactionStatus.Rejected,
+          },
+        }),
+      })
+    ).rejects.toThrow('The Confidential Transaction has already been completed');
+  });
+
+  it('should throw an error if the sender is affirming an already proved leg', async () => {
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
+
+    return expect(
+      prepareAffirmConfidentialTransactions.call(proc, {
+        legId,
+        party: ConfidentialAffirmParty.Sender,
+        proofs: [],
+        transaction: entityMockUtils.getConfidentialTransactionInstance({
+          getLegState: {
+            proved: true,
+            assetState: [],
+          },
+        }),
+      })
+    ).rejects.toThrow('The leg has already been affirmed by the sender');
+  });
+
+  it('should throw an error if a non-sender is affirming a not proved leg', async () => {
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
+
+    return expect(
+      prepareAffirmConfidentialTransactions.call(proc, {
+        legId,
+        party: ConfidentialAffirmParty.Mediator,
+        transaction: entityMockUtils.getConfidentialTransactionInstance({
+          getLegState: {
+            proved: false,
+          },
+        }),
+      })
+    ).rejects.toThrow('The sender has not yet provided amounts and proof for this leg');
+  });
+
+  it('should return an affirm transaction spec for a sender', async () => {
+    const transaction = dsMockUtils.createTxMock('confidentialAsset', 'affirmTransactions');
+    const fakeArgs = 'fakeArgs';
+    confidentialAffirmsToRawSpy.mockReturnValue(fakeArgs);
+
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
+
+    const result = await prepareAffirmConfidentialTransactions.call(proc, {
+      legId,
+      party: ConfidentialAffirmParty.Sender,
+      transaction: entityMockUtils.getConfidentialTransactionInstance(),
+      proofs: [],
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [fakeArgs],
+      resolver: expect.objectContaining({ id: transactionId }),
+    });
+  });
+
+  it('should return an affirm transaction spec for a receiver', async () => {
+    const transaction = dsMockUtils.createTxMock('confidentialAsset', 'affirmTransactions');
+    const fakeArgs = 'fakeArgs';
+    confidentialAffirmsToRawSpy.mockReturnValue(fakeArgs);
+
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
+
+    const result = await prepareAffirmConfidentialTransactions.call(proc, {
+      legId,
+      party: ConfidentialAffirmParty.Receiver,
+      transaction: entityMockUtils.getConfidentialTransactionInstance({
+        getLegState: {
+          proved: true,
+        },
+      }),
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [fakeArgs],
+      resolver: expect.objectContaining({ id: transactionId }),
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', async () => {
+      const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+
+      const result = await boundFunc();
+
+      expect(result).toEqual({
+        permissions: {
+          transactions: [TxTags.confidentialAsset.AffirmTransactions],
+          portfolios: [],
+          assets: [],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/__tests__/rejectConfidentialTransaction.ts
+++ b/src/api/procedures/__tests__/rejectConfidentialTransaction.ts
@@ -3,24 +3,24 @@ import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
 import {
-  ExecuteConfidentialTransactionParams,
   getAuthorization,
-  prepareExecuteConfidentialTransaction,
-} from '~/api/procedures/executeConfidentialTransaction';
+  Params,
+  prepareRejectConfidentialTransaction,
+} from '~/api/procedures/rejectConfidentialTransaction';
 import { Context } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import { ConfidentialTransaction, ConfidentialTransactionStatus, TxTags } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
 
-describe('executeConfidentialTransaction procedure', () => {
+describe('rejectConfidentialTransaction procedure', () => {
   let mockContext: Mocked<Context>;
   let bigNumberToU64Spy: jest.SpyInstance;
   let bigNumberToU32Spy: jest.SpyInstance;
   let transactionId: BigNumber;
   let legsCount: BigNumber;
-  let rawTransactionId: u64;
   let rawLegsCount: u32;
+  let rawTransactionId: u64;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -57,13 +57,10 @@ describe('executeConfidentialTransaction procedure', () => {
   });
 
   it('should throw an error if the signing identity is not involved in the transaction', () => {
-    const proc = procedureMockUtils.getInstance<
-      ExecuteConfidentialTransactionParams,
-      ConfidentialTransaction
-    >(mockContext);
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
 
     return expect(
-      prepareExecuteConfidentialTransaction.call(proc, {
+      prepareRejectConfidentialTransaction.call(proc, {
         transaction: entityMockUtils.getConfidentialTransactionInstance({
           getInvolvedParties: [entityMockUtils.getIdentityInstance({ did: 'randomDid' })],
         }),
@@ -71,59 +68,36 @@ describe('executeConfidentialTransaction procedure', () => {
     ).rejects.toThrow('The signing identity is not involved in this Confidential Transaction');
   });
 
-  it('should throw an error if there are some pending affirmations', () => {
-    const proc = procedureMockUtils.getInstance<
-      ExecuteConfidentialTransactionParams,
-      ConfidentialTransaction
-    >(mockContext);
-
-    return expect(
-      prepareExecuteConfidentialTransaction.call(proc, {
-        transaction: entityMockUtils.getConfidentialTransactionInstance({
-          getPendingAffirmsCount: new BigNumber(2),
-        }),
-      })
-    ).rejects.toThrow(
-      'The Confidential Transaction needs to be affirmed by all parties before it can be executed'
-    );
-  });
-
   it('should throw an error if status is already Executed or Rejected', async () => {
-    const proc = procedureMockUtils.getInstance<
-      ExecuteConfidentialTransactionParams,
-      ConfidentialTransaction
-    >(mockContext);
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
 
     await expect(
-      prepareExecuteConfidentialTransaction.call(proc, {
+      prepareRejectConfidentialTransaction.call(proc, {
         transaction: entityMockUtils.getConfidentialTransactionInstance({
           details: {
             status: ConfidentialTransactionStatus.Executed,
           },
         }),
       })
-    ).rejects.toThrow('The Confidential Transaction has already been executed');
+    ).rejects.toThrow('The Confidential Transaction has already been completed');
 
     await expect(
-      prepareExecuteConfidentialTransaction.call(proc, {
+      prepareRejectConfidentialTransaction.call(proc, {
         transaction: entityMockUtils.getConfidentialTransactionInstance({
           details: {
             status: ConfidentialTransactionStatus.Rejected,
           },
         }),
       })
-    ).rejects.toThrow('The Confidential Transaction has already been rejected');
+    ).rejects.toThrow('The Confidential Transaction has already been completed');
   });
 
-  it('should return an execute manual instruction transaction spec', async () => {
-    const transaction = dsMockUtils.createTxMock('confidentialAsset', 'executeTransaction');
+  it('should return a reject transaction spec', async () => {
+    const transaction = dsMockUtils.createTxMock('confidentialAsset', 'rejectTransaction');
 
-    const proc = procedureMockUtils.getInstance<
-      ExecuteConfidentialTransactionParams,
-      ConfidentialTransaction
-    >(mockContext);
+    const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
 
-    const result = await prepareExecuteConfidentialTransaction.call(proc, {
+    const result = await prepareRejectConfidentialTransaction.call(proc, {
       transaction: entityMockUtils.getConfidentialTransactionInstance(),
     });
 
@@ -136,17 +110,14 @@ describe('executeConfidentialTransaction procedure', () => {
 
   describe('getAuthorization', () => {
     it('should return the appropriate roles and permissions', async () => {
-      const proc = procedureMockUtils.getInstance<
-        ExecuteConfidentialTransactionParams,
-        ConfidentialTransaction
-      >(mockContext);
+      const proc = procedureMockUtils.getInstance<Params, ConfidentialTransaction>(mockContext);
       const boundFunc = getAuthorization.bind(proc);
 
       const result = await boundFunc();
 
       expect(result).toEqual({
         permissions: {
-          transactions: [TxTags.confidentialAsset.ExecuteTransaction],
+          transactions: [TxTags.confidentialAsset.RejectTransaction],
           portfolios: [],
           assets: [],
         },

--- a/src/api/procedures/affirmConfidentialTransactions.ts
+++ b/src/api/procedures/affirmConfidentialTransactions.ts
@@ -1,9 +1,7 @@
-import BigNumber from 'bignumber.js';
-
 import { PolymeshError, Procedure } from '~/internal';
 import {
+  AffirmConfidentialTransactionParams,
   ConfidentialAffirmParty,
-  ConfidentialLegProof,
   ConfidentialTransaction,
   ConfidentialTransactionStatus,
   ErrorCode,
@@ -14,20 +12,6 @@ import {
   confidentialAffirmsToRaw,
   confidentialAffirmTransactionToMeshTransaction,
 } from '~/utils/conversion';
-
-interface SenderAffirm {
-  party: ConfidentialAffirmParty.Sender;
-  proofs: ConfidentialLegProof[];
-}
-
-interface ObserverAffirm {
-  party: ConfidentialAffirmParty.Mediator | ConfidentialAffirmParty.Receiver;
-}
-
-export type AffirmConfidentialTransactionParams = { legId: BigNumber } & (
-  | SenderAffirm
-  | ObserverAffirm
-);
 
 export type Params = {
   transaction: ConfidentialTransaction;

--- a/src/api/procedures/affirmConfidentialTransactions.ts
+++ b/src/api/procedures/affirmConfidentialTransactions.ts
@@ -1,0 +1,138 @@
+import BigNumber from 'bignumber.js';
+
+import { PolymeshError, Procedure } from '~/internal';
+import {
+  ConfidentialAffirmParty,
+  ConfidentialLegProof,
+  ConfidentialTransaction,
+  ConfidentialTransactionStatus,
+  ErrorCode,
+  TxTags,
+} from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import {
+  confidentialAffirmsToRaw,
+  confidentialAffirmTransactionToMeshTransaction,
+} from '~/utils/conversion';
+
+interface SenderAffirm {
+  party: ConfidentialAffirmParty.Sender;
+  proofs: ConfidentialLegProof[];
+}
+
+interface ObserverAffirm {
+  party: ConfidentialAffirmParty.Mediator | ConfidentialAffirmParty.Receiver;
+}
+
+export type AffirmConfidentialTransactionParams = { legId: BigNumber } & (
+  | SenderAffirm
+  | ObserverAffirm
+);
+
+export type Params = {
+  transaction: ConfidentialTransaction;
+} & AffirmConfidentialTransactionParams;
+
+/**
+ * @hidden
+ */
+export async function prepareAffirmConfidentialTransactions(
+  this: Procedure<Params, ConfidentialTransaction>,
+  args: Params
+): Promise<
+  TransactionSpec<
+    ConfidentialTransaction,
+    ExtrinsicParams<'confidentialAsset', 'affirmTransactions'>
+  >
+> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: { confidentialAsset },
+      },
+    },
+    context,
+  } = this;
+
+  const { transaction, legId, party } = args;
+
+  const [{ status }, involvedParties, signingIdentity, legState] = await Promise.all([
+    transaction.details(),
+    transaction.getInvolvedParties(),
+    context.getSigningIdentity(),
+    transaction.getLegState(legId),
+  ]);
+
+  if (status !== ConfidentialTransactionStatus.Pending) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The Confidential Transaction has already been completed',
+      data: { transactionId: transaction.id.toString(), status },
+    });
+  }
+
+  if (!involvedParties.some(involvedParty => involvedParty.did === signingIdentity.did)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The signing identity is not involved in this Confidential Transaction',
+      data: { did: signingIdentity.did, transactionId: transaction.id.toString() },
+    });
+  }
+
+  if (party === ConfidentialAffirmParty.Sender) {
+    if (legState.proved) {
+      throw new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message: 'The leg has already been affirmed by the sender',
+        data: { transactionId: transaction.id.toString(), legId: legId.toString() },
+      });
+    }
+  } else if (!legState.proved) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The sender has not yet provided amounts and proof for this leg',
+      data: { legId: legId.toString },
+    });
+  }
+
+  const proofs = party === ConfidentialAffirmParty.Sender ? args.proofs : undefined;
+
+  const rawTx = confidentialAffirmTransactionToMeshTransaction(
+    {
+      transactionId: transaction.id,
+      legId,
+      party,
+      proofs,
+    },
+    context
+  );
+
+  const rawAffirm = confidentialAffirmsToRaw([rawTx], context);
+
+  return {
+    transaction: confidentialAsset.affirmTransactions,
+    args: [rawAffirm],
+    resolver: transaction,
+  };
+}
+
+/**
+ * @hidden
+ */
+export async function getAuthorization(
+  this: Procedure<Params, ConfidentialTransaction>
+): Promise<ProcedureAuthorization> {
+  return {
+    permissions: {
+      assets: [],
+      portfolios: [],
+      transactions: [TxTags.confidentialAsset.AffirmTransactions],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const affirmConfidentialTransactions = (): Procedure<Params, ConfidentialTransaction> =>
+  new Procedure(prepareAffirmConfidentialTransactions, getAuthorization);

--- a/src/api/procedures/rejectConfidentialTransaction.ts
+++ b/src/api/procedures/rejectConfidentialTransaction.ts
@@ -1,0 +1,90 @@
+import BigNumber from 'bignumber.js';
+
+import { PolymeshError, Procedure } from '~/internal';
+import { ConfidentialTransaction, ConfidentialTransactionStatus, ErrorCode, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { bigNumberToU32, bigNumberToU64 } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export interface Params {
+  transaction: ConfidentialTransaction;
+}
+
+/**
+ * @hidden
+ */
+export async function prepareRejectConfidentialTransaction(
+  this: Procedure<Params, ConfidentialTransaction>,
+  args: Params
+): Promise<
+  TransactionSpec<
+    ConfidentialTransaction,
+    ExtrinsicParams<'confidentialAsset', 'rejectTransaction'>
+  >
+> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: { confidentialAsset },
+      },
+    },
+    context,
+  } = this;
+
+  const { transaction } = args;
+
+  const [{ status }, legs, involvedParties, signingIdentity] = await Promise.all([
+    transaction.details(),
+    transaction.getLegs(),
+    transaction.getInvolvedParties(),
+    context.getSigningIdentity(),
+  ]);
+
+  if (status !== ConfidentialTransactionStatus.Pending) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The Confidential Transaction has already been completed',
+      data: { transactionId: transaction.id.toString(), status },
+    });
+  }
+
+  if (!involvedParties.some(party => party.did === signingIdentity.did)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The signing identity is not involved in this Confidential Transaction',
+      data: { did: signingIdentity.did, transactionId: transaction.id.toString() },
+    });
+  }
+
+  const rawId = bigNumberToU64(transaction.id, context);
+  const rawCount = bigNumberToU32(new BigNumber(legs.length), context);
+
+  return {
+    transaction: confidentialAsset.rejectTransaction,
+    args: [rawId, rawCount],
+    resolver: transaction,
+  };
+}
+
+/**
+ * @hidden
+ */
+export async function getAuthorization(
+  this: Procedure<Params, ConfidentialTransaction>
+): Promise<ProcedureAuthorization> {
+  return {
+    permissions: {
+      assets: [],
+      portfolios: [],
+      transactions: [TxTags.confidentialAsset.RejectTransaction],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const rejectConfidentialTransaction = (): Procedure<Params, ConfidentialTransaction> =>
+  new Procedure(prepareRejectConfidentialTransaction, getAuthorization);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -26,6 +26,11 @@ export { addInstruction } from '~/api/procedures/addInstruction';
 export { executeManualInstruction } from '~/api/procedures/executeManualInstruction';
 export { executeConfidentialTransaction } from '~/api/procedures/executeConfidentialTransaction';
 export {
+  affirmConfidentialTransactions,
+  AffirmConfidentialTransactionParams,
+} from '~/api/procedures/affirmConfidentialTransactions';
+export { rejectConfidentialTransaction } from '~/api/procedures/rejectConfidentialTransaction';
+export {
   consumeAuthorizationRequests,
   ConsumeAuthorizationRequestsParams,
   ConsumeParams,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -25,10 +25,7 @@ export { addConfidentialTransaction } from '~/api/procedures/addConfidentialTran
 export { addInstruction } from '~/api/procedures/addInstruction';
 export { executeManualInstruction } from '~/api/procedures/executeManualInstruction';
 export { executeConfidentialTransaction } from '~/api/procedures/executeConfidentialTransaction';
-export {
-  affirmConfidentialTransactions,
-  AffirmConfidentialTransactionParams,
-} from '~/api/procedures/affirmConfidentialTransactions';
+export { affirmConfidentialTransactions } from '~/api/procedures/affirmConfidentialTransactions';
 export { rejectConfidentialTransaction } from '~/api/procedures/rejectConfidentialTransaction';
 export {
   consumeAuthorizationRequests,

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -64,6 +64,7 @@ import {
   PalletConfidentialAssetTransactionLeg,
   PalletConfidentialAssetTransactionLegDetails,
   PalletConfidentialAssetTransactionLegId,
+  PalletConfidentialAssetTransactionLegState,
   PalletConfidentialAssetTransactionStatus,
   PalletContractsStorageContractInfo,
   PalletCorporateActionsCaCheckpoint,
@@ -4727,4 +4728,26 @@ export const createMockConfidentialLegParty = (
   }
 
   return createMockEnum<PalletConfidentialAssetLegParty>(role);
+};
+
+export const createMockConfidentialLegState = (
+  state?:
+    | {
+        assetState: BTreeMap<U8aFixed, PalletConfidentialAssetTransactionLegState>;
+      }
+    | PalletConfidentialAssetTransactionLegState
+): MockCodec<PalletConfidentialAssetTransactionLegState> => {
+  if (isCodec<PalletConfidentialAssetTransactionLegState>(state)) {
+    return state as MockCodec<PalletConfidentialAssetTransactionLegState>;
+  }
+  const mockBTreeSet = dsMockUtils.createMockBTreeMap<
+    Bytes,
+    PalletConfidentialAssetTransactionLegState
+  >();
+
+  const { assetState } = state ?? {
+    assetState: mockBTreeSet,
+  };
+
+  return createMockCodec<PalletConfidentialAssetTransactionLegState>({ assetState }, !state);
 };

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -53,6 +53,8 @@ import {
   ComplianceRequirements,
   ConfidentialAssetDetails,
   ConfidentialLeg,
+  ConfidentialLegState,
+  ConfidentialLegStateWithId,
   ConfidentialTransactionDetails,
   ConfidentialTransactionStatus,
   ConfidentialVenueFilteringDetails,
@@ -395,6 +397,8 @@ interface ConfidentialTransactionOptions extends EntityOptions {
   getInvolvedParties?: EntityGetter<Identity[]>;
   getPendingAffirmsCount?: EntityGetter<BigNumber>;
   getLegs?: EntityGetter<ConfidentialLeg[]>;
+  getLegState?: EntityGetter<ConfidentialLegState>;
+  getLegStates?: EntityGetter<ConfidentialLegStateWithId[]>;
 }
 
 interface ConfidentialAccountOptions extends EntityOptions {
@@ -2231,6 +2235,8 @@ const MockConfidentialTransactionClass = createMockEntityClass<ConfidentialTrans
     getInvolvedParties!: jest.Mock;
     getLegs!: jest.Mock;
     getPendingAffirmsCount!: jest.Mock;
+    getLegState!: jest.Mock;
+    getLegStates!: jest.Mock;
 
     /**
      * @hidden
@@ -2249,6 +2255,8 @@ const MockConfidentialTransactionClass = createMockEntityClass<ConfidentialTrans
       this.getInvolvedParties = createEntityGetterMock(opts.getInvolvedParties);
       this.getLegs = createEntityGetterMock(opts.getLegs);
       this.getPendingAffirmsCount = createEntityGetterMock(opts.getPendingAffirmsCount);
+      this.getLegState = createEntityGetterMock(opts.getLegState);
+      this.getLegStates = createEntityGetterMock(opts.getLegStates);
     }
   },
   () => ({
@@ -2279,6 +2287,10 @@ const MockConfidentialTransactionClass = createMockEntityClass<ConfidentialTrans
       getIdentityInstance({ did: 'receiverDid' }),
       getIdentityInstance({ did: 'auditorDid' }),
     ],
+    getLegState: {
+      proved: false,
+    },
+    getLegStates: [{ legId: new BigNumber(0), proved: false }],
   }),
   ['ConfidentialTransaction']
 );

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -10338,8 +10338,6 @@ describe('confidentialLegStateToLegState', () => {
       >(),
     });
     mockLegReturn = dsMockUtils.createMockOption(mockLegState);
-
-    jest.spyOn(mockLegReturn, 'unwrap').mockReturnValue(mockLegState);
   });
   beforeAll(() => {
     dsMockUtils.initMocks();


### PR DESCRIPTION
### Description

also adds `getLegState` and `getLegStates` on confidential transaction to help retrieve proof info

### Breaking Changes

None

### JIRA Link

[DA-982](https://polymesh.atlassian.net/browse/DA-982)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-982]: https://polymesh.atlassian.net/browse/DA-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ