### PR TITLE
feat: 🎸 add {affirm,reject,withdraw}_as_mediator to Instruction

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -815,6 +815,81 @@ describe('Instruction class', () => {
     });
   });
 
+  describe('method: rejectAsMediator', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Instruction>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          {
+            args: { id, operation: InstructionAffirmationOperation.RejectAsMediator },
+            transformer: undefined,
+          },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await instruction.rejectAsMediator();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: affirmAsMediator', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Instruction>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          {
+            args: { id, operation: InstructionAffirmationOperation.AffirmAsMediator },
+            transformer: undefined,
+          },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await instruction.affirmAsMediator();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: withdrawAsMediator', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Instruction>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          {
+            args: { id, operation: InstructionAffirmationOperation.WithdrawAsMediator },
+            transformer: undefined,
+          },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await instruction.withdrawAsMediator();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
   describe('method: executeManually', () => {
     afterAll(() => {
       jest.restoreAllMocks();

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -20,12 +20,14 @@ import {
 import { instructionsQuery } from '~/middleware/queries';
 import { InstructionStatusEnum, Query } from '~/middleware/types';
 import {
+  AffirmAsMediatorParams,
   AffirmOrWithdrawInstructionParams,
   DefaultPortfolio,
   ErrorCode,
   EventIdentifier,
   ExecuteManualInstructionParams,
   InstructionAffirmationOperation,
+  NoArgsProcedureMethod,
   NumberedPortfolio,
   OptionalArgsProcedureMethod,
   PaginationOptions,
@@ -128,6 +130,39 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
           { id, operation: InstructionAffirmationOperation.Withdraw, ...args },
         ],
         optionalArgs: true,
+      },
+      context
+    );
+
+    this.rejectAsMediator = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [
+          modifyInstructionAffirmation,
+          { id, operation: InstructionAffirmationOperation.RejectAsMediator },
+        ],
+        voidArgs: true,
+      },
+      context
+    );
+
+    this.affirmAsMediator = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [
+          modifyInstructionAffirmation,
+          { id, operation: InstructionAffirmationOperation.AffirmAsMediator, ...args },
+        ],
+        optionalArgs: true,
+      },
+      context
+    );
+
+    this.withdrawAsMediator = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [
+          modifyInstructionAffirmation,
+          { id, operation: InstructionAffirmationOperation.WithdrawAsMediator },
+        ],
+        voidArgs: true,
       },
       context
     );
@@ -464,7 +499,6 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
    * @note reject on `SettleOnBlock` behaves just like unauthorize
    * @note reject on `SettleManual` behaves just like unauthorize
    */
-
   public reject: OptionalArgsProcedureMethod<RejectInstructionParams, Instruction>;
 
   /**
@@ -476,6 +510,25 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
    * Withdraw affirmation from this instruction (unauthorize)
    */
   public withdraw: OptionalArgsProcedureMethod<AffirmOrWithdrawInstructionParams, Instruction>;
+
+  /**
+   * Reject this instruction as a mediator
+   *
+   *  @note reject on `SettleOnAffirmation` will execute the settlement and it will fail immediately.
+   * @note reject on `SettleOnBlock` behaves just like unauthorize
+   * @note reject on `SettleManual` behaves just like unauthorize
+   */
+  public rejectAsMediator: NoArgsProcedureMethod<Instruction>;
+
+  /**
+   * Affirm this instruction as a mediator (authorize)
+   */
+  public affirmAsMediator: OptionalArgsProcedureMethod<AffirmAsMediatorParams, Instruction>;
+
+  /**
+   * Withdraw affirmation from this instruction as a mediator (unauthorize)
+   */
+  public withdrawAsMediator: NoArgsProcedureMethod<Instruction>;
 
   /**
    * Executes an Instruction either of type `SettleManual` or a `Failed` instruction

--- a/src/api/procedures/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/modifyInstructionAffirmation.ts
@@ -1,14 +1,16 @@
-import { u64 } from '@polkadot/types';
+import { Option, u64 } from '@polkadot/types';
 import { PolymeshPrimitivesIdentityIdPortfolioId } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 import P from 'bluebird';
 
 import { assertInstructionValid } from '~/api/procedures/utils';
 import { Instruction, PolymeshError, Procedure } from '~/internal';
+import { Moment } from '~/polkadot';
 import {
   AffirmationStatus,
   DefaultPortfolio,
   ErrorCode,
+  Identity,
   InstructionAffirmationOperation,
   Leg,
   ModifyInstructionAffirmationParams,
@@ -27,16 +29,21 @@ import {
 import { tuple } from '~/types/utils';
 import {
   bigNumberToU64,
+  dateToMoment,
+  mediatorAffirmationStatusToStatus,
   meshAffirmationStatusToAffirmationStatus,
   portfolioIdToMeshPortfolioId,
   portfolioLikeToPortfolioId,
+  stringToIdentityId,
 } from '~/utils/conversion';
+import { optionize } from '~/utils/internal';
 
 export interface Storage {
   portfolios: (DefaultPortfolio | NumberedPortfolio)[];
   portfolioParams: PortfolioLike[];
   senderLegAmount: BigNumber;
   totalLegAmount: BigNumber;
+  signer: Identity;
 }
 
 /**
@@ -49,6 +56,9 @@ export async function prepareModifyInstructionAffirmation(
   | TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'affirmInstruction'>>
   | TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'withdrawAffirmation'>>
   | TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'rejectInstruction'>>
+  | TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'affirmInstructionAsMediator'>>
+  | TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'withdrawAffirmationAsMediator'>>
+  | TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'rejectInstructionAsMediator'>>
 > {
   const {
     context: {
@@ -58,7 +68,7 @@ export async function prepareModifyInstructionAffirmation(
       },
     },
     context,
-    storage: { portfolios, portfolioParams, senderLegAmount, totalLegAmount },
+    storage: { portfolios, portfolioParams, senderLegAmount, totalLegAmount, signer },
   } = this;
 
   const { operation, id } = args;
@@ -86,11 +96,94 @@ export async function prepareModifyInstructionAffirmation(
     portfolioIdToMeshPortfolioId(portfolioLikeToPortfolioId(portfolio), context)
   );
 
+  const rawDid = stringToIdentityId(signer.did, context);
+  const multiArgs = rawPortfolioIds.map(portfolioId => tuple(portfolioId, rawInstructionId));
+
+  const [rawAffirmationStatuses, rawMediatorAffirmation] = await Promise.all([
+    settlement.userAffirmations.multi(multiArgs),
+    settlement.instructionMediatorsAffirmations(rawInstructionId, rawDid),
+  ]);
+
+  const affirmationStatuses = rawAffirmationStatuses.map(meshAffirmationStatusToAffirmationStatus);
+  const { status: mediatorStatus, expiry } =
+    mediatorAffirmationStatusToStatus(rawMediatorAffirmation);
+
   const excludeCriteria: AffirmationStatus[] = [];
   let errorMessage: string;
-  let transaction: PolymeshTx<[u64, PolymeshPrimitivesIdentityIdPortfolioId[]]> | null = null;
+  let transaction:
+    | PolymeshTx<[u64, PolymeshPrimitivesIdentityIdPortfolioId[]]>
+    | PolymeshTx<[u64, Option<Moment>]>
+    | PolymeshTx<[u64]>
+    | null = null;
 
   switch (operation) {
+    case InstructionAffirmationOperation.Reject: {
+      return {
+        transaction: settlementTx.rejectInstruction,
+        resolver: instruction,
+        feeMultiplier: totalLegAmount,
+        args: [rawInstructionId, rawPortfolioIds[0]],
+      };
+    }
+    case InstructionAffirmationOperation.AffirmAsMediator: {
+      if (mediatorStatus === AffirmationStatus.Unknown) {
+        throw new PolymeshError({
+          code: ErrorCode.ValidationError,
+          message: 'The signer is not a mediator',
+          data: { signer: signer.did, instructionId: id.toString() },
+        });
+      }
+
+      const givenExpiry = args.expiry;
+      const now = new Date();
+      if (givenExpiry && givenExpiry < now) {
+        throw new PolymeshError({
+          code: ErrorCode.ValidationError,
+          message: 'The expiry must be in the future',
+          data: { expiry, now },
+        });
+      }
+
+      const rawExpiry = optionize(dateToMoment)(givenExpiry, context);
+
+      return {
+        transaction: settlementTx.affirmInstructionAsMediator,
+        resolver: instruction,
+        args: [rawInstructionId, rawExpiry],
+      };
+    }
+
+    case InstructionAffirmationOperation.WithdrawAsMediator: {
+      if (mediatorStatus !== AffirmationStatus.Affirmed) {
+        throw new PolymeshError({
+          code: ErrorCode.ValidationError,
+          message: 'The signer is not a mediator that has already affirmed the instruction',
+          data: { signer: signer.did, instructionId: id.toString() },
+        });
+      }
+
+      return {
+        transaction: settlementTx.withdrawAffirmationAsMediator,
+        resolver: instruction,
+        args: [rawInstructionId],
+      };
+    }
+
+    case InstructionAffirmationOperation.RejectAsMediator: {
+      if (mediatorStatus === AffirmationStatus.Unknown) {
+        throw new PolymeshError({
+          code: ErrorCode.ValidationError,
+          message: 'The signer is not a mediator for the instruction',
+          data: { did: signer.did, instructionId: id.toString() },
+        });
+      }
+
+      return {
+        transaction: settlementTx.rejectInstructionAsMediator,
+        resolver: instruction,
+        args: [rawInstructionId, optionize(bigNumberToU64)(undefined, context)],
+      };
+    }
     case InstructionAffirmationOperation.Affirm: {
       excludeCriteria.push(AffirmationStatus.Affirmed);
       errorMessage = 'The Instruction is already affirmed';
@@ -107,12 +200,6 @@ export async function prepareModifyInstructionAffirmation(
     }
   }
 
-  const multiArgs = rawPortfolioIds.map(portfolioId => tuple(portfolioId, rawInstructionId));
-
-  const rawAffirmationStatuses = await settlement.userAffirmations.multi(multiArgs);
-
-  const affirmationStatuses = rawAffirmationStatuses.map(meshAffirmationStatusToAffirmationStatus);
-
   const validPortfolioIds = rawPortfolioIds.filter(
     (_, index) => !excludeCriteria.includes(affirmationStatuses[index])
   );
@@ -120,28 +207,15 @@ export async function prepareModifyInstructionAffirmation(
   if (!validPortfolioIds.length) {
     throw new PolymeshError({
       code: ErrorCode.NoDataChange,
-      // As InstructionAffirmationOperation.Reject has no excludeCriteria, if this error is thrown
-      // it means that the operation had to be either affirm or withdraw, and so the errorMessage was set
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      message: errorMessage!,
+      message: errorMessage,
     });
   }
 
-  // rejection works a bit different
-  if (transaction) {
-    return {
-      transaction,
-      resolver: instruction,
-      feeMultiplier: senderLegAmount,
-      args: [rawInstructionId, validPortfolioIds],
-    };
-  }
-
   return {
-    transaction: settlementTx.rejectInstruction,
+    transaction,
     resolver: instruction,
-    feeMultiplier: totalLegAmount,
-    args: [rawInstructionId, validPortfolioIds[0]],
+    feeMultiplier: senderLegAmount,
+    args: [rawInstructionId, validPortfolioIds],
   };
 }
 
@@ -174,6 +248,21 @@ export async function getAuthorization(
 
       break;
     }
+    case InstructionAffirmationOperation.AffirmAsMediator: {
+      transactions = [TxTags.settlement.AffirmInstructionAsMediator];
+
+      break;
+    }
+    case InstructionAffirmationOperation.WithdrawAsMediator: {
+      transactions = [TxTags.settlement.WithdrawAffirmationAsMediator];
+
+      break;
+    }
+    case InstructionAffirmationOperation.RejectAsMediator: {
+      transactions = [TxTags.settlement.RejectInstructionAsMediator];
+
+      break;
+    }
   }
 
   return {
@@ -196,7 +285,10 @@ function extractPortfolioParams(params: ModifyInstructionAffirmationParams): Por
     if (portfolio) {
       portfolioParams.push(portfolio);
     }
-  } else {
+  } else if (
+    operation === InstructionAffirmationOperation.Affirm ||
+    operation === InstructionAffirmationOperation.Withdraw
+  ) {
     const { portfolios } = params;
     if (portfolios) {
       portfolioParams = [...portfolioParams, ...portfolios];
@@ -288,7 +380,7 @@ export async function prepareStorage(
   const portfolioIdParams = portfolioParams.map(portfolioLikeToPortfolioId);
 
   const instruction = new Instruction({ id }, context);
-  const [{ data: legs }, { did: signingDid }] = await Promise.all([
+  const [{ data: legs }, signer] = await Promise.all([
     instruction.getLegs(),
     context.getSigningIdentity(),
   ]);
@@ -299,7 +391,7 @@ export async function prepareStorage(
   >(
     legs,
     async (result, { from, to }) =>
-      assemblePortfolios(result, from, to, signingDid, portfolioIdParams),
+      assemblePortfolios(result, from, to, signer.did, portfolioIdParams),
     [[], new BigNumber(0)]
   );
 
@@ -308,6 +400,7 @@ export async function prepareStorage(
     portfolioParams,
     senderLegAmount,
     totalLegAmount: new BigNumber(legs.length),
+    signer,
   };
 }
 

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -567,6 +567,9 @@ export enum InstructionAffirmationOperation {
   Affirm = 'Affirm',
   Withdraw = 'Withdraw',
   Reject = 'Reject',
+  AffirmAsMediator = 'AffirmAsMediator',
+  WithdrawAsMediator = 'WithdrawAsMediator',
+  RejectAsMediator = 'RejectAsMediator',
 }
 
 export type RejectInstructionParams = {
@@ -585,6 +588,10 @@ export type AffirmOrWithdrawInstructionParams = {
   portfolios?: PortfolioLike[];
 };
 
+export type AffirmAsMediatorParams = {
+  expiry?: Date;
+};
+
 export type ModifyInstructionAffirmationParams = InstructionIdParams &
   (
     | ({
@@ -593,8 +600,18 @@ export type ModifyInstructionAffirmationParams = InstructionIdParams &
           | InstructionAffirmationOperation.Withdraw;
       } & AffirmOrWithdrawInstructionParams)
     | ({
-        operation: InstructionAffirmationOperation.Reject;
+        operation:
+          | InstructionAffirmationOperation.Reject
+          | InstructionAffirmationOperation.RejectAsMediator;
       } & RejectInstructionParams)
+    | ({
+        operation: InstructionAffirmationOperation.AffirmAsMediator;
+      } & AffirmAsMediatorParams)
+    | {
+        operation:
+          | InstructionAffirmationOperation.WithdrawAsMediator
+          | InstructionAffirmationOperation.RejectAsMediator;
+      }
   );
 
 export type ExecuteManualInstructionParams = InstructionIdParams & {


### PR DESCRIPTION
### Description

adds a set of methods to allow instruction mediators to manage their affirmation status

### Breaking Changes

None

### JIRA Link

✅ Closes: [DA-1022](https://polymesh.atlassian.net/browse/DA-1022)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1022]: https://polymesh.atlassian.net/browse/DA-1022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ