### PR TITLE
fix: 🐛 allow mediators to affirm when not involved in trade

### DIFF
--- a/src/api/procedures/__tests__/addInstruction.ts
+++ b/src/api/procedures/__tests__/addInstruction.ts
@@ -326,7 +326,7 @@ describe('addInstruction procedure', () => {
       venueId,
       instructions: [
         {
-          mediators: [mediatorDid],
+          mediators: [entityMockUtils.getIdentityInstance({ did: mediatorDid })],
           legs: [
             {
               from,

--- a/src/api/procedures/addAssetMediators.ts
+++ b/src/api/procedures/addAssetMediators.ts
@@ -3,7 +3,7 @@ import { AssetMediatorParams, ErrorCode, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import { MAX_ASSET_MEDIATORS } from '~/utils/constants';
 import { identitiesToBtreeSet, stringToTicker } from '~/utils/conversion';
-import { asIdentity } from '~/utils/internal';
+import { asIdentity, assertIdentityExists } from '~/utils/internal';
 /**
  * @hidden
  */
@@ -33,6 +33,9 @@ export async function prepareAddAssetMediators(
 
   const newMediators = mediatorInput.map(mediator => asIdentity(mediator, context));
 
+  const mediatorsExistAsserts = newMediators.map(mediator => assertIdentityExists(mediator));
+  await Promise.all(mediatorsExistAsserts);
+
   newMediators.forEach(({ did: newDid }) => {
     const alreadySetDid = currentMediators.find(({ did: currentDid }) => currentDid === newDid);
 
@@ -40,7 +43,7 @@ export async function prepareAddAssetMediators(
       throw new PolymeshError({
         code: ErrorCode.ValidationError,
         message: 'One of the specified mediators is already set',
-        data: { ticker, alreadySetDid },
+        data: { ticker, did: alreadySetDid.did },
       });
     }
   });

--- a/src/api/procedures/addInstruction.ts
+++ b/src/api/procedures/addInstruction.ts
@@ -55,6 +55,7 @@ import {
 import {
   asIdentity,
   assembleBatchTransactions,
+  assertIdentityExists,
   asTicker,
   filterEventRecords,
   optionize,
@@ -400,9 +401,14 @@ export async function prepareAddInstruction(
   } = this;
   const { instructions, venueId } = args;
 
+  const allMediators = instructions.flatMap(
+    ({ mediators }) => mediators?.map(mediator => asIdentity(mediator, context)) ?? []
+  );
+
   const [latestBlock] = await Promise.all([
     context.getLatestBlock(),
     assertVenueExists(venueId, context),
+    ...allMediators.map(mediator => assertIdentityExists(mediator)),
   ]);
 
   if (!instructions.length) {

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -72,6 +72,7 @@ import {
   assertAddressValid,
   assertExpectedChainVersion,
   assertExpectedSqVersion,
+  assertIdentityExists,
   assertIsInteger,
   assertIsPositive,
   assertNoPendingAuthorizationExists,
@@ -2486,5 +2487,24 @@ describe('assertNoPendingAuthorizationExists', () => {
         target,
       })
     ).toThrow(expectedError);
+  });
+});
+
+describe('assertIdentityExists', () => {
+  it('should resolve if the identity exists', () => {
+    const identity = entityMockUtils.getIdentityInstance({ exists: true });
+
+    return expect(assertIdentityExists(identity)).resolves.not.toThrow();
+  });
+
+  it('should throw an error if an identity does not exist', () => {
+    const identity = entityMockUtils.getIdentityInstance({ exists: false });
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.DataUnavailable,
+      message: 'The identity does not exists',
+    });
+
+    return expect(assertIdentityExists(identity)).rejects.toThrow(expectedError);
   });
 });

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -1973,3 +1973,18 @@ export function assertNoPendingAuthorizationExists(params: {
     });
   }
 }
+
+/**
+ * @hidden
+ */
+export async function assertIdentityExists(identity: Identity): Promise<void> {
+  const exists = await identity.exists();
+
+  if (!exists) {
+    throw new PolymeshError({
+      code: ErrorCode.DataUnavailable,
+      message: 'The identity does not exists',
+      data: { did: identity.did },
+    });
+  }
+}


### PR DESCRIPTION
### Description

fixes a bug where mediators would not be allowed to affirm due to non mediator validation. also adds validation to ensure mediators exist

### Breaking Changes

None

### JIRA Link

Bug introduced from: [DA-1022](https://polymesh.atlassian.net/browse/DA-1022)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1022]: https://polymesh.atlassian.net/browse/DA-1022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ