### PR TITLE
fix: 🐛 execute manual instruction type

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -909,7 +909,7 @@ describe('Instruction class', () => {
         )
         .mockResolvedValue(expectedTransaction);
 
-      const tx = await instruction.executeManually({ id, skipAffirmationCheck: false });
+      const tx = await instruction.executeManually({ skipAffirmationCheck: false });
 
       expect(tx).toBe(expectedTransaction);
     });

--- a/src/api/procedures/__tests__/executeManualInstruction.ts
+++ b/src/api/procedures/__tests__/executeManualInstruction.ts
@@ -5,6 +5,7 @@ import { when } from 'jest-when';
 
 import {
   getAuthorization,
+  Params,
   prepareExecuteManualInstruction,
   prepareStorage,
   Storage,
@@ -14,7 +15,6 @@ import { Context, DefaultPortfolio, Instruction, Venue } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import {
-  ExecuteManualInstructionParams,
   InstructionAffirmationOperation,
   InstructionDetails,
   InstructionStatus,
@@ -134,11 +134,7 @@ describe('executeManualInstruction procedure', () => {
   });
 
   it('should throw an error if the signing identity is not the custodian of any of the involved portfolios', () => {
-    const proc = procedureMockUtils.getInstance<
-      ExecuteManualInstructionParams,
-      Instruction,
-      Storage
-    >(mockContext, {
+    const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
       portfolios: [],
       instructionDetails,
       signerDid: 'someOtherDid',
@@ -157,11 +153,7 @@ describe('executeManualInstruction procedure', () => {
       returnValue: dsMockUtils.createMockU64(new BigNumber(1)),
     });
 
-    const proc = procedureMockUtils.getInstance<
-      ExecuteManualInstructionParams,
-      Instruction,
-      Storage
-    >(mockContext, {
+    const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
       portfolios: [portfolio, portfolio],
       instructionDetails,
       signerDid: did,
@@ -180,11 +172,7 @@ describe('executeManualInstruction procedure', () => {
       returnValue: dsMockUtils.createMockU64(new BigNumber(1)),
     });
 
-    const proc = procedureMockUtils.getInstance<
-      ExecuteManualInstructionParams,
-      Instruction,
-      Storage
-    >(mockContext, {
+    const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
       portfolios: [portfolio, portfolio],
       instructionDetails,
       signerDid: did,
@@ -205,14 +193,11 @@ describe('executeManualInstruction procedure', () => {
       returnValue: dsMockUtils.createMockU64(new BigNumber(0)),
     });
 
-    let proc = procedureMockUtils.getInstance<ExecuteManualInstructionParams, Instruction, Storage>(
-      mockContext,
-      {
-        portfolios: [portfolio, portfolio],
-        instructionDetails,
-        signerDid: did,
-      }
-    );
+    let proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
+      portfolios: [portfolio, portfolio],
+      instructionDetails,
+      signerDid: did,
+    });
 
     let result = await prepareExecuteManualInstruction.call(proc, {
       id,
@@ -233,14 +218,11 @@ describe('executeManualInstruction procedure', () => {
       resolver: expect.objectContaining({ id }),
     });
 
-    proc = procedureMockUtils.getInstance<ExecuteManualInstructionParams, Instruction, Storage>(
-      mockContext,
-      {
-        portfolios: [],
-        instructionDetails,
-        signerDid: did,
-      }
-    );
+    proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
+      portfolios: [],
+      instructionDetails,
+      signerDid: did,
+    });
 
     result = await prepareExecuteManualInstruction.call(proc, {
       id,
@@ -267,11 +249,7 @@ describe('executeManualInstruction procedure', () => {
       const from = entityMockUtils.getNumberedPortfolioInstance();
       const to = entityMockUtils.getDefaultPortfolioInstance();
 
-      const proc = procedureMockUtils.getInstance<
-        ExecuteManualInstructionParams,
-        Instruction,
-        Storage
-      >(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
         portfolios: [from, to],
         instructionDetails,
         signerDid: did,
@@ -300,11 +278,7 @@ describe('executeManualInstruction procedure', () => {
     const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
 
     it('should return the custodied portfolios associated in the instruction legs for the signing identity', async () => {
-      const proc = procedureMockUtils.getInstance<
-        ExecuteManualInstructionParams,
-        Instruction,
-        Storage
-      >(mockContext);
+      const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext);
 
       const boundFunc = prepareStorage.bind(proc);
       entityMockUtils.configureMocks({
@@ -329,11 +303,7 @@ describe('executeManualInstruction procedure', () => {
     });
 
     it('should return no portfolios when signing identity is not part of any legs', async () => {
-      const proc = procedureMockUtils.getInstance<
-        ExecuteManualInstructionParams,
-        Instruction,
-        Storage
-      >(mockContext);
+      const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext);
 
       const boundFunc = prepareStorage.bind(proc);
       from = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });

--- a/src/api/procedures/executeManualInstruction.ts
+++ b/src/api/procedures/executeManualInstruction.ts
@@ -1,4 +1,5 @@
 import { PolymeshPrimitivesIdentityIdPortfolioId } from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
 import P from 'bluebird';
 
 import { assertInstructionValidForManualExecution } from '~/api/procedures/utils';
@@ -29,9 +30,16 @@ export interface Storage {
 /**
  * @hidden
  */
+export type Params = ExecuteManualInstructionParams & {
+  id: BigNumber;
+};
+
+/**
+ * @hidden
+ */
 export async function prepareExecuteManualInstruction(
-  this: Procedure<ExecuteManualInstructionParams, Instruction, Storage>,
-  args: ExecuteManualInstructionParams
+  this: Procedure<Params, Instruction, Storage>,
+  args: Params
 ): Promise<
   TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'executeManualInstruction'>>
 > {
@@ -105,7 +113,7 @@ export async function prepareExecuteManualInstruction(
  * @hidden
  */
 export async function getAuthorization(
-  this: Procedure<ExecuteManualInstructionParams, Instruction, Storage>
+  this: Procedure<Params, Instruction, Storage>
 ): Promise<ProcedureAuthorization> {
   const {
     storage: { portfolios },
@@ -124,8 +132,8 @@ export async function getAuthorization(
  * @hidden
  */
 export async function prepareStorage(
-  this: Procedure<ExecuteManualInstructionParams, Instruction, Storage>,
-  { id }: ExecuteManualInstructionParams
+  this: Procedure<Params, Instruction, Storage>,
+  { id }: Params
 ): Promise<Storage> {
   const { context } = this;
 
@@ -170,8 +178,5 @@ export async function prepareStorage(
 /**
  * @hidden
  */
-export const executeManualInstruction = (): Procedure<
-  ExecuteManualInstructionParams,
-  Instruction,
-  Storage
-> => new Procedure(prepareExecuteManualInstruction, getAuthorization, prepareStorage);
+export const executeManualInstruction = (): Procedure<Params, Instruction, Storage> =>
+  new Procedure(prepareExecuteManualInstruction, getAuthorization, prepareStorage);

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -614,12 +614,12 @@ export type ModifyInstructionAffirmationParams = InstructionIdParams &
       }
   );
 
-export type ExecuteManualInstructionParams = InstructionIdParams & {
+export interface ExecuteManualInstructionParams {
   /**
    * (optional) Set to `true` to skip affirmation check, useful for batch transactions
    */
   skipAffirmationCheck?: boolean;
-};
+}
 
 export interface CreateVenueParams {
   description: string;


### PR DESCRIPTION
### Description

users had to specify instruction id to execute manually, now it is inferred from the instruction entity

### Breaking Changes

ID can no longer be passed into execute manually (it wasn't supposed to be allowed)

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
