### PR TITLE
fix: 🐛 allow exec manual to be batched with affirm instruction

### DIFF
--- a/src/api/procedures/executeManualInstruction.ts
+++ b/src/api/procedures/executeManualInstruction.ts
@@ -104,7 +104,7 @@ export async function prepareExecuteManualInstruction(
       fungibleTokens,
       nonFungibleTokens,
       offChainAssets,
-      consumedWeight,
+      skipAffirmationCheck ? null : consumedWeight,
     ],
   };
 }


### PR DESCRIPTION
### Description

update handling of instruction weights to allow affirm instruction to be batched with execute manually. The RPC underestimates the weight if the instruction has not yet been affirmed

### Breaking Changes

None

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
