### PR TITLE
fix: 🐛 crash due to unhandled promise rejection

### DIFF
--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -22,6 +22,7 @@ import {
   ProcedureAuthorization,
 } from '~/types/internal';
 import { signerToString } from '~/utils/conversion';
+import { defusePromise } from '~/utils/internal';
 
 /**
  * @hidden
@@ -283,7 +284,7 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
       const ctx = await this.setup(procArgs, context, opts);
 
       // parallelize the async calls
-      const prepareTransactionsPromise = this.prepareTransactions(procArgs);
+      const prepareTransactionsPromise = defusePromise(this.prepareTransactions(procArgs));
       const { roles, signerPermissions, agentPermissions, accountFrozen, noIdentity } =
         await this._checkAuthorization(procArgs, ctx);
 


### PR DESCRIPTION
### Description

use `defusePromise` to prevent process crashes from unhandled promise rejections. Previously node would exit before user code had a chance to handle it.

### Breaking Changes

None

### JIRA Link

✅ Closes:[ #1116](https://github.com/PolymeshAssociation/polymesh-sdk/issues/1116)

### Checklist

- [ ] Updated the Readme.md (if required) ?
