### PR TITLE
feat: 🎸 adds ability to pre-approve receiving assets

### DIFF
--- a/src/api/procedures/__tests__/toggleTickerPreApproval.ts
+++ b/src/api/procedures/__tests__/toggleTickerPreApproval.ts
@@ -1,0 +1,140 @@
+import { PolymeshPrimitivesTicker } from '@polkadot/types/lookup';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareToggleTickerPreApproval,
+} from '~/api/procedures/toggleTickerPreApproval';
+import { Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { Identity, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Asset/Fungible',
+  require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+
+describe('toggleTickerPreApproval procedure', () => {
+  let mockContext: Mocked<Context>;
+  let mockSigningIdentity: Mocked<Identity>;
+  let stringToTickerSpy: jest.SpyInstance<PolymeshPrimitivesTicker, [string, Context]>;
+  let ticker: string;
+  let rawTicker: PolymeshPrimitivesTicker;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    stringToTickerSpy = jest.spyOn(utilsConversionModule, 'stringToTicker');
+    ticker = 'TEST';
+    rawTicker = dsMockUtils.createMockTicker(ticker);
+  });
+
+  beforeEach(() => {
+    mockSigningIdentity = entityMockUtils.getIdentityInstance({
+      isAssetPreApproved: false,
+    });
+    mockContext = dsMockUtils.getContextInstance();
+    mockContext.getSigningIdentity.mockResolvedValue(mockSigningIdentity);
+    when(stringToTickerSpy).calledWith(ticker, mockContext).mockReturnValue(rawTicker);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if pre approving an already approved asset', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+    mockSigningIdentity.isAssetPreApproved.mockResolvedValue(true);
+
+    return expect(
+      prepareToggleTickerPreApproval.call(proc, {
+        ticker,
+        preApprove: true,
+      })
+    ).rejects.toThrow('The signing identity has already pre-approved the ticker');
+  });
+
+  it('should throw an error if removing pre approval for an asset that is not pre-approved', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    return expect(
+      prepareToggleTickerPreApproval.call(proc, {
+        ticker,
+        preApprove: false,
+      })
+    ).rejects.toThrow('The signing identity has not pre-approved the asset');
+  });
+
+  it('should return a pre approve transaction spec', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const transaction = dsMockUtils.createTxMock('asset', 'preApproveTicker');
+
+    const result = await prepareToggleTickerPreApproval.call(proc, {
+      ticker,
+      preApprove: true,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawTicker],
+    });
+  });
+
+  it('should return a remove pre approval transaction spec', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+    mockSigningIdentity.isAssetPreApproved.mockResolvedValue(true);
+
+    const transaction = dsMockUtils.createTxMock('asset', 'removeTickerPreApproval');
+
+    const result = await prepareToggleTickerPreApproval.call(proc, {
+      ticker,
+      preApprove: false,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawTicker],
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+      const args: Params = {
+        ticker,
+        preApprove: true,
+      };
+
+      expect(boundFunc(args)).toEqual({
+        permissions: {
+          transactions: [TxTags.asset.PreApproveTicker],
+          assets: [expect.objectContaining({ ticker })],
+          portfolios: [],
+        },
+      });
+
+      args.preApprove = false;
+
+      expect(boundFunc(args)).toEqual({
+        permissions: {
+          transactions: [TxTags.asset.RemoveTickerPreApproval],
+          assets: [expect.objectContaining({ ticker })],
+          portfolios: [],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/toggleTickerPreApproval.ts
+++ b/src/api/procedures/toggleTickerPreApproval.ts
@@ -1,0 +1,77 @@
+import { BaseAsset, PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { stringToTicker } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export interface Params {
+  ticker: string;
+  preApprove: boolean;
+}
+
+/**
+ * @hidden
+ */
+export async function prepareToggleTickerPreApproval(
+  this: Procedure<Params, void>,
+  args: Params
+): Promise<TransactionSpec<void, ExtrinsicParams<'assets', 'preApprove'>>> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    context,
+  } = this;
+  const { ticker, preApprove } = args;
+
+  const identity = await context.getSigningIdentity();
+  const isPreApproved = await identity.isAssetPreApproved(ticker);
+
+  if (isPreApproved === preApprove) {
+    const message = isPreApproved
+      ? 'The signing identity has already pre-approved the ticker'
+      : 'The signing identity has not pre-approved the asset';
+    throw new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message,
+      data: { identity: identity.did, ticker },
+    });
+  }
+
+  const rawTicker = stringToTicker(ticker, context);
+
+  const transaction = preApprove ? tx.asset.preApproveTicker : tx.asset.removeTickerPreApproval;
+
+  return {
+    transaction,
+    args: [rawTicker],
+    resolver: undefined,
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void>,
+  { ticker, preApprove }: Params
+): ProcedureAuthorization {
+  const { context } = this;
+  return {
+    permissions: {
+      transactions: [
+        preApprove ? TxTags.asset.PreApproveTicker : TxTags.asset.RemoveTickerPreApproval,
+      ],
+      assets: [new BaseAsset({ ticker }, context)],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const toggleTickerPreApproval = (): Procedure<Params, void> =>
+  new Procedure(prepareToggleTickerPreApproval, getAuthorization);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -161,3 +161,4 @@ export { addAssetStat } from '~/api/procedures/addAssetStat';
 export { removeAssetStat } from '~/api/procedures/removeAssetStat';
 export { setVenueFiltering } from '~/api/procedures/setVenueFiltering';
 export { registerCustomClaimType } from '~/api/procedures/registerCustomClaimType';
+export { toggleTickerPreApproval } from '~/api/procedures/toggleTickerPreApproval';

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -796,6 +796,7 @@ function configureContext(opts: ContextOptions): void {
       checkPermissions: jest.fn().mockResolvedValue(opts.checkAssetPermissions),
     },
     areSecondaryAccountsFrozen: jest.fn().mockResolvedValue(opts.areSecondaryAccountsFrozen),
+    isTickerPreApproved: jest.fn(),
     isEqual: jest.fn().mockReturnValue(opts.signingIdentityIsEqual),
   };
   opts.withSigningManager

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -149,6 +149,8 @@ interface IdentityOptions extends EntityOptions {
   areSecondaryAccountsFrozen?: EntityGetter<boolean>;
   assetPermissionsGetGroup?: EntityGetter<CustomPermissionGroup | KnownPermissionGroup>;
   assetPermissionsGet?: EntityGetter<AssetWithGroup[]>;
+  isAssetPreApproved?: EntityGetter<boolean>;
+  preApprovedAssets?: EntityGetter<ResultSet<(FungibleAsset | NftCollection)[]>>;
 }
 
 interface ChildIdentityOptions extends IdentityOptions {
@@ -589,6 +591,8 @@ const MockIdentityClass = createMockEntityClass<IdentityOptions>(
     getSecondaryAccounts!: jest.Mock;
     areSecondaryAccountsFrozen!: jest.Mock;
     isCddProvider!: jest.Mock;
+    preApprovedAssets!: jest.Mock;
+    isAssetPreApproved!: jest.Mock;
 
     /**
      * @hidden
@@ -626,6 +630,8 @@ const MockIdentityClass = createMockEntityClass<IdentityOptions>(
       this.getSecondaryAccounts = createEntityGetterMock(opts.getSecondaryAccounts);
       this.areSecondaryAccountsFrozen = createEntityGetterMock(opts.areSecondaryAccountsFrozen);
       this.isCddProvider = createEntityGetterMock(opts.isCddProvider);
+      this.preApprovedAssets = createEntityGetterMock(opts.preApprovedAssets);
+      this.isAssetPreApproved = createEntityGetterMock(opts.isAssetPreApproved);
     }
   },
   () => ({
@@ -661,6 +667,8 @@ const MockIdentityClass = createMockEntityClass<IdentityOptions>(
     checkRoles: {
       result: true,
     },
+    preApprovedAssets: { data: [], next: null, count: new BigNumber(0) },
+    isAssetPreApproved: false,
     toHuman: 'someDid',
   }),
   ['Identity']
@@ -704,6 +712,8 @@ const MockChildIdentityClass = createMockEntityClass<ChildIdentityOptions>(
 
     getParentDid!: jest.Mock;
     getChildIdentities!: Promise<ChildIdentity[]>;
+    preApproveAssets!: jest.Mock;
+    isAssetPreApproved!: jest.Mock;
 
     /**
      * @hidden
@@ -747,6 +757,8 @@ const MockChildIdentityClass = createMockEntityClass<ChildIdentityOptions>(
 
       this.getParentDid = createEntityGetterMock(opts.getParentDid);
       this.getChildIdentities = Promise.resolve([]);
+      this.preApproveAssets = createEntityGetterMock(opts.preApprovedAssets);
+      this.isAssetPreApproved = createEntityGetterMock(opts.isAssetPreApproved);
     }
   },
   () => ({
@@ -786,6 +798,8 @@ const MockChildIdentityClass = createMockEntityClass<ChildIdentityOptions>(
 
     toHuman: 'someChildDid',
     getParentDid: getIdentityInstance(),
+    preApprovedAssets: { data: [], next: null, count: new BigNumber(0) },
+    isAssetPreApproved: false,
   }),
   ['ChildIdentity', 'Identity']
 );


### PR DESCRIPTION



### Description

Adds `asset.settlements.preApprove` and
`asset.settlements.removePreApproval` methods to allow identities to automatically affirm receiving certain assets. Adds getter methods `identity.preApprovedAssets` and `identity.isAssetPreApproved` to allow checking pre-approvals.


### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

✅ Closes: [DA-1080](https://polymesh.atlassian.net/browse/DA-1080)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1080]: https://polymesh.atlassian.net/browse/DA-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ