### PR TITLE
Cherry pick commits to be added to new lts v23

### DIFF
--- a/src/api/entities/Asset/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/NonFungible/Nft.ts
@@ -116,6 +116,11 @@ export class Nft extends Entity<NftUniqueIdentifiers, HumanReadable> {
       collection,
       id,
     } = this;
+
+    if (id.lte(new BigNumber(0))) {
+      return false;
+    }
+
     const collectionId = await collection.getCollectionId();
     const rawCollectionId = bigNumberToU64(collectionId, context);
 

--- a/src/api/entities/Asset/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/NonFungible/Nft.ts
@@ -1,7 +1,14 @@
 import BigNumber from 'bignumber.js';
 
-import { Context, Entity, NftCollection, redeemNft } from '~/internal';
-import { NftMetadata, OptionalArgsProcedureMethod, RedeemNftParams } from '~/types';
+import { Context, Entity, NftCollection, PolymeshError, redeemNft } from '~/internal';
+import {
+  DefaultPortfolio,
+  ErrorCode,
+  NftMetadata,
+  NumberedPortfolio,
+  OptionalArgsProcedureMethod,
+  RedeemNftParams,
+} from '~/types';
 import {
   GLOBAL_BASE_IMAGE_URI_NAME,
   GLOBAL_BASE_TOKEN_URI_NAME,
@@ -10,8 +17,11 @@ import {
 } from '~/utils/constants';
 import {
   bigNumberToU64,
+  boolToBoolean,
   bytesToString,
   meshMetadataKeyToMetadataKey,
+  meshPortfolioIdToPortfolio,
+  portfolioToPortfolioId,
   stringToTicker,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -104,31 +114,11 @@ export class Nft extends Entity<NftUniqueIdentifiers, HumanReadable> {
 
   /**
    * Determine if the NFT exists on chain
-   *
-   * @note This method returns true, even if the token has been redeemed/burned
    */
   public async exists(): Promise<boolean> {
-    const {
-      context,
-      context: {
-        polymeshApi: { query },
-      },
-      collection,
-      id,
-    } = this;
+    const owner = await this.getOwner();
 
-    if (id.lte(new BigNumber(0))) {
-      return false;
-    }
-
-    const collectionId = await collection.getCollectionId();
-    const rawCollectionId = bigNumberToU64(collectionId, context);
-
-    // note: "nextId" is actually the last used id
-    const rawNextId = await query.nft.nextNFTId(rawCollectionId);
-    const nextId = u64ToBigNumber(rawNextId);
-
-    return id.lte(nextId);
+    return owner !== null;
   }
 
   /**
@@ -201,6 +191,71 @@ export class Nft extends Entity<NftUniqueIdentifiers, HumanReadable> {
     }
 
     return null;
+  }
+
+  /**
+   * Get owner of the NFT
+   *
+   * @note This method returns `null` if there is no existing holder for the token. This may happen even if the token has been redeemed/burned
+   */
+  public async getOwner(): Promise<DefaultPortfolio | NumberedPortfolio | null> {
+    const {
+      collection: { ticker },
+      id,
+      context: {
+        polymeshApi: {
+          query: {
+            nft: { nftOwner },
+          },
+        },
+      },
+      context,
+    } = this;
+
+    const rawTicker = stringToTicker(ticker, context);
+    const rawNftId = bigNumberToU64(id, context);
+
+    const owner = await nftOwner(rawTicker, rawNftId);
+
+    if (owner.isEmpty) {
+      return null;
+    }
+
+    return meshPortfolioIdToPortfolio(owner.unwrap(), context);
+  }
+
+  /**
+   * Check if the NFT is locked in any settlement instruction
+   *
+   * @throws if NFT has no owner (has been redeemed)
+   */
+  public async isLocked(): Promise<boolean> {
+    const {
+      collection: { ticker },
+      id,
+      context: {
+        polymeshApi: {
+          query: { portfolio },
+        },
+      },
+      context,
+    } = this;
+
+    const owner = await this.getOwner();
+
+    if (!owner) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'NFT does not exists. The token may have been redeemed',
+      });
+    }
+
+    const rawLocked = await portfolio.portfolioLockedNFT(portfolioToPortfolioId(owner), [
+      stringToTicker(ticker, context),
+      bigNumberToU64(id, context),
+    ]);
+
+    return boolToBoolean(rawLocked);
   }
 
   /**

--- a/src/api/entities/Asset/__tests__/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/Nft.ts
@@ -94,19 +94,24 @@ describe('Nft class', () => {
   });
 
   describe('method: exists', () => {
-    it('should return true when Nft Id is less than or equal to nextId for the collection', async () => {
-      const ticker = 'TICKER';
-      const context = dsMockUtils.getContextInstance();
-      const id = new BigNumber(3);
-      const nft = new Nft({ ticker, id }, context);
+    let ticker: string;
+    let id: BigNumber;
+    let context: Context;
+    let nft: Nft;
+    let nextNftIdMock: jest.Mock;
 
+    beforeEach(() => {
+      ticker = 'TICKER';
+      context = dsMockUtils.getContextInstance();
+      id = new BigNumber(3);
+      nft = new Nft({ ticker, id }, context);
       entityMockUtils.getNftCollectionInstance({
         getCollectionId: id,
       });
-
-      dsMockUtils.createQueryMock('nft', 'nextNFTId', {
-        returnValue: new BigNumber(10),
-      });
+      nextNftIdMock = dsMockUtils.createQueryMock('nft', 'nextNFTId');
+    });
+    it('should return true when Nft Id is less than or equal to nextId for the collection', async () => {
+      nextNftIdMock.mockResolvedValueOnce(new BigNumber(10));
 
       const result = await nft.exists();
 
@@ -114,18 +119,15 @@ describe('Nft class', () => {
     });
 
     it('should return false when Nft Id is greater than nextId for the collection', async () => {
-      const ticker = 'TICKER';
-      const context = dsMockUtils.getContextInstance();
-      const id = new BigNumber(3);
-      const nft = new Nft({ ticker, id }, context);
+      nextNftIdMock.mockResolvedValueOnce(new BigNumber(1));
 
-      entityMockUtils.getNftCollectionInstance({
-        getCollectionId: id,
-      });
+      const result = await nft.exists();
 
-      dsMockUtils.createQueryMock('nft', 'nextNFTId', {
-        returnValue: new BigNumber(1),
-      });
+      expect(result).toBe(false);
+    });
+
+    it('should return false when Nft ID is 0', async () => {
+      nft = new Nft({ ticker, id: new BigNumber(0) }, context);
 
       const result = await nft.exists();
 

--- a/src/api/entities/Asset/__tests__/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/Nft.ts
@@ -1,9 +1,11 @@
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
-import { Context, Entity, Nft, PolymeshTransaction } from '~/internal';
+import { Context, Entity, Nft, PolymeshError, PolymeshTransaction } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { ErrorCode } from '~/types';
 import { tuple } from '~/types/utils';
+import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(
   '~/api/entities/Asset/NonFungible',
@@ -94,42 +96,23 @@ describe('Nft class', () => {
   });
 
   describe('method: exists', () => {
-    let ticker: string;
-    let id: BigNumber;
-    let context: Context;
-    let nft: Nft;
-    let nextNftIdMock: jest.Mock;
+    it('should return whether NFT exists or not', async () => {
+      const ticker = 'TICKER';
+      const context = dsMockUtils.getContextInstance();
+      const id = new BigNumber(3);
+      const nft = new Nft({ ticker, id }, context);
 
-    beforeEach(() => {
-      ticker = 'TICKER';
-      context = dsMockUtils.getContextInstance();
-      id = new BigNumber(3);
-      nft = new Nft({ ticker, id }, context);
-      entityMockUtils.getNftCollectionInstance({
-        getCollectionId: id,
-      });
-      nextNftIdMock = dsMockUtils.createQueryMock('nft', 'nextNFTId');
-    });
-    it('should return true when Nft Id is less than or equal to nextId for the collection', async () => {
-      nextNftIdMock.mockResolvedValueOnce(new BigNumber(10));
+      const getOwnerSpy = jest.spyOn(nft, 'getOwner');
 
-      const result = await nft.exists();
+      getOwnerSpy.mockResolvedValueOnce(entityMockUtils.getDefaultPortfolioInstance());
+
+      let result = await nft.exists();
 
       expect(result).toBe(true);
-    });
 
-    it('should return false when Nft Id is greater than nextId for the collection', async () => {
-      nextNftIdMock.mockResolvedValueOnce(new BigNumber(1));
+      getOwnerSpy.mockResolvedValueOnce(null);
 
-      const result = await nft.exists();
-
-      expect(result).toBe(false);
-    });
-
-    it('should return false when Nft ID is 0', async () => {
-      nft = new Nft({ ticker, id: new BigNumber(0) }, context);
-
-      const result = await nft.exists();
+      result = await nft.exists();
 
       expect(result).toBe(false);
     });
@@ -379,6 +362,89 @@ describe('Nft class', () => {
       const tx = await nft.redeem();
 
       expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: getOwner', () => {
+    const ticker = 'TEST';
+    const id = new BigNumber(1);
+    let context: Context;
+    let nftOwnerMock: jest.Mock;
+    let nft: Nft;
+
+    beforeEach(async () => {
+      context = dsMockUtils.getContextInstance();
+      nftOwnerMock = dsMockUtils.createQueryMock('nft', 'nftOwner');
+      nft = new Nft({ ticker, id }, context);
+    });
+
+    it('should return null if no owner exists', async () => {
+      nftOwnerMock.mockResolvedValueOnce(dsMockUtils.createMockOption());
+
+      const result = await nft.getOwner();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return the owner of the NFT', async () => {
+      const meshPortfolioIdToPortfolioSpy = jest.spyOn(
+        utilsConversionModule,
+        'meshPortfolioIdToPortfolio'
+      );
+
+      const rawPortfolio = dsMockUtils.createMockPortfolioId({
+        did: 'someDid',
+        kind: dsMockUtils.createMockPortfolioKind({
+          User: dsMockUtils.createMockU64(new BigNumber(1)),
+        }),
+      });
+
+      nftOwnerMock.mockResolvedValueOnce(dsMockUtils.createMockOption(rawPortfolio));
+      const portfolio = entityMockUtils.getNumberedPortfolioInstance();
+
+      when(meshPortfolioIdToPortfolioSpy)
+        .calledWith(rawPortfolio, context)
+        .mockReturnValue(portfolio);
+
+      const result = await nft.getOwner();
+
+      expect(result).toBe(portfolio);
+    });
+  });
+
+  describe('method: isLocked', () => {
+    const ticker = 'TEST';
+    const id = new BigNumber(1);
+    let context: Context;
+    let nft: Nft;
+    let ownerSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      context = dsMockUtils.getContextInstance();
+      nft = new Nft({ ticker, id }, context);
+      ownerSpy = jest.spyOn(nft, 'getOwner');
+    });
+
+    it('should throw an error if NFT has no owner', () => {
+      ownerSpy.mockResolvedValueOnce(null);
+
+      const error = new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'NFT does not exists. The token may have been redeemed',
+      });
+      return expect(nft.isLocked()).rejects.toThrow(error);
+    });
+
+    it('should return whether NFT is locked in any settlement', async () => {
+      ownerSpy.mockResolvedValue(entityMockUtils.getDefaultPortfolioInstance());
+
+      dsMockUtils.createQueryMock('portfolio', 'portfolioLockedNFT', {
+        returnValue: dsMockUtils.createMockBool(true),
+      });
+
+      const result = await nft.isLocked();
+
+      expect(result).toBe(true);
     });
   });
 

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -834,7 +834,7 @@ describe('Instruction class', () => {
         )
         .mockResolvedValue(expectedTransaction);
 
-      const tx = await instruction.executeManually({ id, skipAffirmationCheck: false });
+      const tx = await instruction.executeManually({ skipAffirmationCheck: false });
 
       expect(tx).toBe(expectedTransaction);
     });

--- a/src/api/procedures/__tests__/executeManualInstruction.ts
+++ b/src/api/procedures/__tests__/executeManualInstruction.ts
@@ -5,6 +5,7 @@ import { when } from 'jest-when';
 
 import {
   getAuthorization,
+  Params,
   prepareExecuteManualInstruction,
   prepareStorage,
   Storage,
@@ -14,7 +15,6 @@ import { Context, DefaultPortfolio, Instruction, Venue } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import {
-  ExecuteManualInstructionParams,
   InstructionAffirmationOperation,
   InstructionDetails,
   InstructionStatus,
@@ -134,11 +134,7 @@ describe('executeManualInstruction procedure', () => {
   });
 
   it('should throw an error if the signing identity is not the custodian of any of the involved portfolios', () => {
-    const proc = procedureMockUtils.getInstance<
-      ExecuteManualInstructionParams,
-      Instruction,
-      Storage
-    >(mockContext, {
+    const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
       portfolios: [],
       instructionDetails,
       signerDid: 'someOtherDid',
@@ -157,11 +153,7 @@ describe('executeManualInstruction procedure', () => {
       returnValue: dsMockUtils.createMockU64(new BigNumber(1)),
     });
 
-    const proc = procedureMockUtils.getInstance<
-      ExecuteManualInstructionParams,
-      Instruction,
-      Storage
-    >(mockContext, {
+    const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
       portfolios: [portfolio, portfolio],
       instructionDetails,
       signerDid: did,
@@ -180,11 +172,7 @@ describe('executeManualInstruction procedure', () => {
       returnValue: dsMockUtils.createMockU64(new BigNumber(1)),
     });
 
-    const proc = procedureMockUtils.getInstance<
-      ExecuteManualInstructionParams,
-      Instruction,
-      Storage
-    >(mockContext, {
+    const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
       portfolios: [portfolio, portfolio],
       instructionDetails,
       signerDid: did,
@@ -205,14 +193,11 @@ describe('executeManualInstruction procedure', () => {
       returnValue: dsMockUtils.createMockU64(new BigNumber(0)),
     });
 
-    let proc = procedureMockUtils.getInstance<ExecuteManualInstructionParams, Instruction, Storage>(
-      mockContext,
-      {
-        portfolios: [portfolio, portfolio],
-        instructionDetails,
-        signerDid: did,
-      }
-    );
+    let proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
+      portfolios: [portfolio, portfolio],
+      instructionDetails,
+      signerDid: did,
+    });
 
     let result = await prepareExecuteManualInstruction.call(proc, {
       id,
@@ -233,14 +218,11 @@ describe('executeManualInstruction procedure', () => {
       resolver: expect.objectContaining({ id }),
     });
 
-    proc = procedureMockUtils.getInstance<ExecuteManualInstructionParams, Instruction, Storage>(
-      mockContext,
-      {
-        portfolios: [],
-        instructionDetails,
-        signerDid: did,
-      }
-    );
+    proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
+      portfolios: [],
+      instructionDetails,
+      signerDid: did,
+    });
 
     result = await prepareExecuteManualInstruction.call(proc, {
       id,
@@ -267,11 +249,7 @@ describe('executeManualInstruction procedure', () => {
       const from = entityMockUtils.getNumberedPortfolioInstance();
       const to = entityMockUtils.getDefaultPortfolioInstance();
 
-      const proc = procedureMockUtils.getInstance<
-        ExecuteManualInstructionParams,
-        Instruction,
-        Storage
-      >(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext, {
         portfolios: [from, to],
         instructionDetails,
         signerDid: did,
@@ -300,11 +278,7 @@ describe('executeManualInstruction procedure', () => {
     const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
 
     it('should return the custodied portfolios associated in the instruction legs for the signing identity', async () => {
-      const proc = procedureMockUtils.getInstance<
-        ExecuteManualInstructionParams,
-        Instruction,
-        Storage
-      >(mockContext);
+      const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext);
 
       const boundFunc = prepareStorage.bind(proc);
       entityMockUtils.configureMocks({
@@ -329,11 +303,7 @@ describe('executeManualInstruction procedure', () => {
     });
 
     it('should return no portfolios when signing identity is not part of any legs', async () => {
-      const proc = procedureMockUtils.getInstance<
-        ExecuteManualInstructionParams,
-        Instruction,
-        Storage
-      >(mockContext);
+      const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext);
 
       const boundFunc = prepareStorage.bind(proc);
       from = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });

--- a/src/api/procedures/executeManualInstruction.ts
+++ b/src/api/procedures/executeManualInstruction.ts
@@ -1,4 +1,5 @@
 import { PolymeshPrimitivesIdentityIdPortfolioId } from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
 import P from 'bluebird';
 
 import { assertInstructionValidForManualExecution } from '~/api/procedures/utils';
@@ -29,9 +30,16 @@ export interface Storage {
 /**
  * @hidden
  */
+export type Params = ExecuteManualInstructionParams & {
+  id: BigNumber;
+};
+
+/**
+ * @hidden
+ */
 export async function prepareExecuteManualInstruction(
-  this: Procedure<ExecuteManualInstructionParams, Instruction, Storage>,
-  args: ExecuteManualInstructionParams
+  this: Procedure<Params, Instruction, Storage>,
+  args: Params
 ): Promise<
   TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'executeManualInstruction'>>
 > {
@@ -105,7 +113,7 @@ export async function prepareExecuteManualInstruction(
  * @hidden
  */
 export async function getAuthorization(
-  this: Procedure<ExecuteManualInstructionParams, Instruction, Storage>
+  this: Procedure<Params, Instruction, Storage>
 ): Promise<ProcedureAuthorization> {
   const {
     storage: { portfolios },
@@ -124,8 +132,8 @@ export async function getAuthorization(
  * @hidden
  */
 export async function prepareStorage(
-  this: Procedure<ExecuteManualInstructionParams, Instruction, Storage>,
-  { id }: ExecuteManualInstructionParams
+  this: Procedure<Params, Instruction, Storage>,
+  { id }: Params
 ): Promise<Storage> {
   const { context } = this;
 
@@ -170,8 +178,5 @@ export async function prepareStorage(
 /**
  * @hidden
  */
-export const executeManualInstruction = (): Procedure<
-  ExecuteManualInstructionParams,
-  Instruction,
-  Storage
-> => new Procedure(prepareExecuteManualInstruction, getAuthorization, prepareStorage);
+export const executeManualInstruction = (): Procedure<Params, Instruction, Storage> =>
+  new Procedure(prepareExecuteManualInstruction, getAuthorization, prepareStorage);

--- a/src/api/procedures/executeManualInstruction.ts
+++ b/src/api/procedures/executeManualInstruction.ts
@@ -96,7 +96,7 @@ export async function prepareExecuteManualInstruction(
       fungibleTokens,
       nonFungibleTokens,
       offChainAssets,
-      consumedWeight,
+      skipAffirmationCheck ? null : consumedWeight,
     ],
   };
 }

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -593,12 +593,12 @@ export type ModifyInstructionAffirmationParams = InstructionIdParams &
       } & RejectInstructionParams)
   );
 
-export type ExecuteManualInstructionParams = InstructionIdParams & {
+export interface ExecuteManualInstructionParams {
   /**
    * (optional) Set to `true` to skip affirmation check, useful for batch transactions
    */
   skipAffirmationCheck?: boolean;
-};
+}
 
 export interface CreateVenueParams {
   description: string;

--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -22,6 +22,7 @@ import {
   ProcedureAuthorization,
 } from '~/types/internal';
 import { signerToString } from '~/utils/conversion';
+import { defusePromise } from '~/utils/internal';
 
 /**
  * @hidden
@@ -283,7 +284,7 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
       const ctx = await this.setup(procArgs, context, opts);
 
       // parallelize the async calls
-      const prepareTransactionsPromise = this.prepareTransactions(procArgs);
+      const prepareTransactionsPromise = defusePromise(this.prepareTransactions(procArgs));
       const { roles, signerPermissions, agentPermissions, accountFrozen, noIdentity } =
         await this._checkAuthorization(procArgs, ctx);
 


### PR DESCRIPTION
### Description

Following bugs have been cherry picked and added - 
:bug: allow exec manual to be batched with affirm instruction ([7e5b064](https://github.com/PolymeshAssociation/polymesh-sdk/commit/7e5b06462cd9cdc64ea176640e3a857fa3676507))
:bug: crash due to unhandled promise rejection ([2926ff0](https://github.com/PolymeshAssociation/polymesh-sdk/commit/2926ff017edede69d1c75052a30a0c0fb05f7d79)), closes [#1116](https://github.com/PolymeshAssociation/polymesh-sdk/issues/1116)
:bug: execute manual instruction type ([5158e99](https://github.com/PolymeshAssociation/polymesh-sdk/commit/5158e99251be03f4b3041d3f4084343a78a27b06))
:bug: handle NFT locked error in nft.canTransfer ([8230c9c](https://github.com/PolymeshAssociation/polymesh-sdk/commit/8230c9c2349a552d10ca94baf33693b92c7d52b1))
:bug: Correct the logic of nft.exists ([b9a85c8](https://github.com/PolymeshAssociation/polymesh-sdk/commit/b9a85c8b077a4d59d58f022710f0e060b68f7391))
:bug: Update the logic of Nft.exists ([7602983](https://github.com/PolymeshAssociation/polymesh-sdk/commit/76029831274279b3e42133733f5232f95e37a4cb))

### Breaking Changes

NA

### JIRA Link

DA-1113

### Checklist

- [ ] Updated the Readme.md (if required) ?
