### PR TITLE
fix: 🐛 Remove future block constraint on `endAfterBlock`

### DIFF
--- a/src/api/procedures/__tests__/addInstruction.ts
+++ b/src/api/procedures/__tests__/addInstruction.ts
@@ -653,25 +653,6 @@ describe('addInstruction procedure', () => {
         ],
       })
     ).rejects.toThrowError(expectedError);
-
-    await expect(
-      prepareAddInstruction.call(proc, {
-        venueId,
-        instructions: [
-          {
-            legs: [
-              {
-                from,
-                to,
-                amount,
-                asset: entityMockUtils.getFungibleAssetInstance({ ticker: asset }),
-              },
-            ],
-            endAfterBlock: new BigNumber(100),
-          },
-        ],
-      })
-    ).rejects.toThrowError(expectedError);
   });
 
   it('should throw an error if the value date is before the trade date', async () => {

--- a/src/api/procedures/addInstruction.ts
+++ b/src/api/procedures/addInstruction.ts
@@ -143,13 +143,7 @@ function getEndCondition(
 
     endCondition = { type: InstructionType.SettleOnBlock, endBlock };
   } else if ('endAfterBlock' in instruction && instruction.endAfterBlock) {
-    const { endAfterBlock } = instruction;
-
-    if (endAfterBlock.lte(latestBlock)) {
-      errorIndex = index;
-    }
-
-    endCondition = { type: InstructionType.SettleManual, endAfterBlock };
+    endCondition = { type: InstructionType.SettleManual, endAfterBlock: instruction.endAfterBlock };
   } else {
     endCondition = { type: InstructionType.SettleOnAffirmation };
   }


### PR DESCRIPTION
### Description

This will allow to set an older block as `endAfterBlock` while creating an instruction, eventually allowing the manual execution at any time

### Breaking Changes

NA

### JIRA Link

DA-1129

### Checklist

- [ ] Updated the Readme.md (if required) ?
