### PR TITLE
feat: 🎸 allow connection to polymesh private networks

### DIFF
--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -457,4 +457,18 @@ export class Network {
 
     return latestBlockFromChain.minus(lastProcessedBlockFromMiddleware);
   }
+
+  /**
+   * Returns whether or not the connected chain node as support for confidential assets
+   */
+  public supportsConfidentialAssets(): boolean {
+    const {
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return !!(query as any).confidentialAsset;
+  }
 }

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -81,7 +81,7 @@ function createMiddlewareApi(
  * Main entry point of the Polymesh SDK
  */
 export class Polymesh {
-  private context: Context = {} as Context;
+  protected context: Context = {} as Context;
 
   // Namespaces
 
@@ -113,7 +113,7 @@ export class Polymesh {
   /**
    * @hidden
    */
-  private constructor(context: Context) {
+  protected constructor(context: Context) {
     this.context = context;
 
     this.claims = new Claims(context);

--- a/src/api/client/__tests__/Network.ts
+++ b/src/api/client/__tests__/Network.ts
@@ -617,4 +617,19 @@ describe('Network Class', () => {
       );
     });
   });
+
+  describe('method: supportsConfidentialAssets', () => {
+    it('should return false if confidentialAsset storage is not defined', () => {
+      const result = network.supportsConfidentialAssets();
+
+      expect(result).toEqual(false);
+    });
+
+    it('should return true if confidentialAsset storage is defined', () => {
+      dsMockUtils.createQueryMock('confidentialAsset', 'someQuery');
+      const result = network.supportsConfidentialAssets();
+
+      expect(result).toEqual(true);
+    });
+  });
 });

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -192,7 +192,11 @@ import {
 } from '~/types';
 import { Consts, Extrinsics, PolymeshTx, Queries, Rpcs } from '~/types/internal';
 import { ArgsType, Mutable, tuple } from '~/types/utils';
-import { STATE_RUNTIME_VERSION_CALL, SYSTEM_VERSION_RPC_CALL } from '~/utils/constants';
+import {
+  CONFIDENTIAL_ASSETS_SUPPORTED_CALL,
+  STATE_RUNTIME_VERSION_CALL,
+  SYSTEM_VERSION_RPC_CALL,
+} from '~/utils/constants';
 
 let apiEmitter: EventEmitter;
 
@@ -311,6 +315,23 @@ export class MockWebSocket {
       data: `{ "result": { "specVersion": "${version}" }, "id": "${STATE_RUNTIME_VERSION_CALL.id}" }`,
     };
     this.onmessage(response);
+  }
+
+  /**
+   * @hidden
+   */
+  sendIsPrivateSupported(supported: boolean): void {
+    if (supported) {
+      const response = {
+        data: `{ "result": "0x0500", "id": "${CONFIDENTIAL_ASSETS_SUPPORTED_CALL.id}" }`,
+      };
+      this.onmessage(response);
+    } else {
+      const response = {
+        data: `{ "result": null, "id": "${CONFIDENTIAL_ASSETS_SUPPORTED_CALL.id}" }`,
+      };
+      this.onmessage(response);
+    }
   }
 }
 

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -57,6 +57,8 @@ import { tuple } from '~/types/utils';
 import {
   MAX_TICKER_LENGTH,
   MINIMUM_SQ_VERSION,
+  PRIVATE_SUPPORTED_NODE_SEMVER,
+  PRIVATE_SUPPORTED_SPEC_SEMVER,
   SUPPORTED_NODE_SEMVER,
   SUPPORTED_SPEC_SEMVER,
 } from '~/utils/constants';
@@ -1242,6 +1244,19 @@ describe('assertExpectedChainVersion', () => {
   it('should resolve if it receives both expected RPC node and chain spec version', () => {
     const signal = assertExpectedChainVersion('ws://example.com');
     client.onopen();
+    client.sendRpcVersion(SUPPORTED_NODE_SEMVER);
+    client.sendSpecVersion(getSpecVersion(SUPPORTED_SPEC_SEMVER));
+    client.sendIsPrivateSupported(false);
+
+    return expect(signal).resolves.not.toThrow();
+  });
+
+  it('should resolve if it receives both expected RPC node and chain spec version for a private node', () => {
+    const signal = assertExpectedChainVersion('ws://example.com');
+    client.onopen();
+    client.sendRpcVersion(PRIVATE_SUPPORTED_NODE_SEMVER);
+    client.sendSpecVersion(getSpecVersion(PRIVATE_SUPPORTED_SPEC_SEMVER));
+    client.sendIsPrivateSupported(true);
 
     return expect(signal).resolves.not.toThrow();
   });
@@ -1250,6 +1265,8 @@ describe('assertExpectedChainVersion', () => {
     const signal = assertExpectedChainVersion('ws://example.com');
     const mismatchedVersion = getMismatchedVersion(SUPPORTED_NODE_SEMVER, 0);
     client.sendRpcVersion(mismatchedVersion);
+    client.sendSpecVersion(getSpecVersion(SUPPORTED_SPEC_SEMVER));
+    client.sendIsPrivateSupported(false);
     const expectedError = new PolymeshError({
       code: ErrorCode.FatalError,
       message: 'Unsupported Polymesh RPC node version. Please upgrade the SDK',
@@ -1264,11 +1281,12 @@ describe('assertExpectedChainVersion', () => {
 
     const mockRpcVersion = getMismatchedVersion(SUPPORTED_NODE_SEMVER);
     client.sendRpcVersion(mockRpcVersion);
+    client.sendIsPrivateSupported(false);
 
     await signal;
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      `This version of the SDK supports Polymesh RPC node version ${SUPPORTED_NODE_VERSION_RANGE}. The node is at version ${mockRpcVersion}. Please upgrade the SDK`
+      `This version of the SDK supports Polymesh RPC node version "${SUPPORTED_NODE_VERSION_RANGE}". The node is at version ${mockRpcVersion}. Please upgrade the SDK`
     );
   });
 
@@ -1276,6 +1294,8 @@ describe('assertExpectedChainVersion', () => {
     const signal = assertExpectedChainVersion('ws://example.com');
     const mismatchedSpecVersion = getMismatchedVersion(SUPPORTED_SPEC_SEMVER, 0);
     client.sendSpecVersion(getSpecVersion(mismatchedSpecVersion));
+    client.sendRpcVersion(SUPPORTED_NODE_SEMVER);
+    client.sendIsPrivateSupported(false);
     const expectedError = new PolymeshError({
       code: ErrorCode.FatalError,
       message: 'Unsupported Polymesh chain spec version. Please upgrade the SDK',
@@ -1288,10 +1308,11 @@ describe('assertExpectedChainVersion', () => {
     const mockSpecVersion = getMismatchedVersion(SUPPORTED_SPEC_SEMVER);
     client.sendSpecVersion(getSpecVersion(mockSpecVersion));
     client.sendRpcVersion(SUPPORTED_NODE_SEMVER);
+    client.sendIsPrivateSupported(false);
     await signal;
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      `This version of the SDK supports Polymesh chain spec version ${SUPPORTED_SPEC_VERSION_RANGE}. The chain spec is at version ${mockSpecVersion}. Please upgrade the SDK`
+      `This version of the SDK supports Polymesh chain spec version "${SUPPORTED_SPEC_VERSION_RANGE}". The chain spec is at version ${mockSpecVersion}. Please upgrade the SDK`
     );
   });
 
@@ -1300,6 +1321,7 @@ describe('assertExpectedChainVersion', () => {
     const mockSpecVersion = getMismatchedVersion(SUPPORTED_SPEC_SEMVER, 2);
     client.sendSpecVersion(getSpecVersion(mockSpecVersion));
     client.sendRpcVersion(SUPPORTED_NODE_SEMVER);
+    client.sendIsPrivateSupported(false);
     await signal;
     expect(warnSpy).toHaveBeenCalledTimes(0);
   });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -111,16 +111,32 @@ export const ROOT_TYPES = rootTypes;
  */
 export const SUPPORTED_NODE_VERSION_RANGE = '6.0 || 6.1 || 6.2';
 
+/**
+ * The Polymesh Private RPC node version range that is compatible with this version of the SDK
+ */
+export const PRIVATE_SUPPORTED_NODE_VERSION_RANGE = '1.0';
+
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 export const SUPPORTED_NODE_SEMVER = coerce(SUPPORTED_NODE_VERSION_RANGE)!.version;
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+export const PRIVATE_SUPPORTED_NODE_SEMVER = coerce(PRIVATE_SUPPORTED_NODE_VERSION_RANGE)!.version;
 
 /**
  * The Polymesh chain spec version range that is compatible with this version of the SDK
  */
 export const SUPPORTED_SPEC_VERSION_RANGE = '6.0 || 6.1 || 6.2';
 
+/**
+ * The Polymesh private chain spec version range that is compatible with this version of the SDK
+ */
+export const PRIVATE_SUPPORTED_SPEC_VERSION_RANGE = '1.0';
+
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 export const SUPPORTED_SPEC_SEMVER = coerce(SUPPORTED_SPEC_VERSION_RANGE)!.version;
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+export const PRIVATE_SUPPORTED_SPEC_SEMVER = coerce(PRIVATE_SUPPORTED_SPEC_VERSION_RANGE)!.version;
 
 export const SYSTEM_VERSION_RPC_CALL = {
   jsonrpc: '2.0',
@@ -136,6 +152,12 @@ export const STATE_RUNTIME_VERSION_CALL = {
   id: 'specVersion',
 };
 
+export const CONFIDENTIAL_ASSETS_SUPPORTED_CALL = {
+  jsonrpc: '2.0',
+  method: 'state_getStorage',
+  params: ['0xf6afad37710306d11e7d6ebd45ca59f8751e9d00f07967cf7f57d464b264066c'],
+  id: 'confidentialAssetsSupported',
+};
 /**
  * Maximum amount of legs allowed in a single instruction
  */


### PR DESCRIPTION
### Description

allows for SDK to connect and interact with polymesh private networks. Some internal properties are now marked "protected" instead of "private" to allow extension. Middleware types updated to latest SQ

### Breaking Changes

None

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
