### PR TITLE
feat: 🎸 Add asset holders namespace for NFT collections

### DIFF
--- a/src/api/entities/Asset/NonFungible/AssetHolders/index.ts
+++ b/src/api/entities/Asset/NonFungible/AssetHolders/index.ts
@@ -1,0 +1,50 @@
+import BigNumber from 'bignumber.js';
+
+import { Identity, Namespace, Nft } from '~/internal';
+import { nftCollectionHolders } from '~/middleware/queries';
+import { Query } from '~/middleware/types';
+import { IdentityHeldNfts, NftCollection, ResultSet } from '~/types';
+import { Ensured } from '~/types/utils';
+import { calculateNextKey } from '~/utils/internal';
+
+/**
+ * Handles all NFT Holders related functionality
+ */
+export class AssetHolders extends Namespace<NftCollection> {
+  /**
+   * Retrieve all the NFT Holders with their holdings
+   *
+   * @note uses the middlewareV2
+   */
+  public async get(opts: {
+    size?: BigNumber;
+    start?: BigNumber;
+  }): Promise<ResultSet<IdentityHeldNfts>> {
+    const {
+      context,
+      parent: { ticker },
+    } = this;
+
+    const { size, start } = opts;
+
+    const {
+      data: {
+        nftHolders: { totalCount, nodes },
+      },
+    } = await context.queryMiddleware<Ensured<Query, 'nftHolders'>>(
+      nftCollectionHolders(ticker, size, start)
+    );
+
+    const data = nodes.map(({ nftIds, identityId }) => ({
+      identity: new Identity({ did: identityId }, context),
+      nfts: nftIds.map((id: string) => new Nft({ id: new BigNumber(id), ticker }, context)),
+    }));
+
+    const next = calculateNextKey(new BigNumber(totalCount), nodes.length, start);
+
+    return {
+      data,
+      next,
+    };
+  }
+}

--- a/src/api/entities/Asset/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/NonFungible/NftCollection.ts
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js';
 
 import { BaseAsset } from '~/api/entities/Asset/Base';
 import { NonFungibleSettlements } from '~/api/entities/Asset/Base/Settlements';
+import { AssetHolders } from '~/api/entities/Asset/NonFungible/AssetHolders';
 import { issueNft } from '~/api/procedures/issueNft';
 import {
   Context,
@@ -56,6 +57,7 @@ const sumNftIssuance = (
  * Class used to manage NFT functionality
  */
 export class NftCollection extends BaseAsset {
+  public assetHolders: AssetHolders;
   public settlements: NonFungibleSettlements;
   /**
    * Issues a new NFT for the collection
@@ -83,6 +85,7 @@ export class NftCollection extends BaseAsset {
     super(identifiers, context);
 
     const { ticker } = identifiers;
+    this.assetHolders = new AssetHolders(this, context);
     this.settlements = new NonFungibleSettlements(this, context);
 
     this.transferOwnership = createProcedureMethod(

--- a/src/api/entities/Asset/__tests__/NonFungible/AssetHolders.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/AssetHolders.ts
@@ -1,0 +1,101 @@
+import BigNumber from 'bignumber.js';
+
+import { Context, Namespace } from '~/internal';
+import { nftCollectionHolders } from '~/middleware/queries';
+import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
+import { NftCollection } from '~/types';
+
+import { AssetHolders } from '../../NonFungible/AssetHolders';
+
+jest.mock(
+  '~/api/entities/Asset/NonFungible',
+  require('~/testUtils/mocks/entities').mockNftCollectionModule('~/api/entities/Asset/NonFungible')
+);
+jest.mock(
+  '~/api/entities/Identity',
+  require('~/testUtils/mocks/entities').mockIdentityModule('~/api/entities/Identity')
+);
+
+describe('AssetHolder class', () => {
+  beforeAll(() => {
+    entityMockUtils.initMocks();
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should extend namespace', () => {
+    expect(AssetHolders.prototype instanceof Namespace).toBe(true);
+  });
+
+  describe('method: get', () => {
+    const ticker = 'TICKER';
+    let assetHolders: AssetHolders;
+    let collection: NftCollection;
+    let context: Context;
+
+    beforeAll(() => {
+      dsMockUtils.initMocks();
+    });
+
+    beforeEach(() => {
+      context = dsMockUtils.getContextInstance();
+      collection = entityMockUtils.getNftCollectionInstance({ ticker });
+      assetHolders = new AssetHolders(collection, context);
+
+      const nftHoldersResponse = {
+        nodes: [
+          {
+            identityId: 'someDid',
+            nftIds: [1],
+          },
+          {
+            identityId: 'anotherDid',
+            nftIds: [2],
+          },
+        ],
+        totalCount: 2,
+      };
+
+      dsMockUtils.createApolloQueryMock(
+        nftCollectionHolders(ticker, new BigNumber(2), new BigNumber(0)),
+        {
+          nftHolders: nftHoldersResponse,
+        }
+      );
+    });
+
+    afterEach(() => {
+      dsMockUtils.reset();
+    });
+
+    afterAll(() => {
+      dsMockUtils.cleanup();
+    });
+
+    it('should retrieve all the NFT Holders with NFTs', async () => {
+      const result = await assetHolders.get({ size: new BigNumber(2), start: new BigNumber(0) });
+
+      expect(result).toEqual({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            identity: expect.objectContaining({ did: 'someDid' }),
+            nfts: [expect.objectContaining({ id: new BigNumber(1) })],
+          }),
+          expect.objectContaining({
+            identity: expect.objectContaining({ did: 'anotherDid' }),
+            nfts: [expect.objectContaining({ id: new BigNumber(2) })],
+          }),
+        ]),
+        next: null,
+      });
+    });
+  });
+});

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -55,6 +55,14 @@ export interface IdentityBalance {
   balance: BigNumber;
 }
 
+/**
+ * Represents the holdings of an NFT holder
+ */
+export interface IdentityHeldNfts {
+  identity: Identity;
+  nfts: Nft[];
+}
+
 export interface TransferRestrictionResult {
   restriction: TransferRestriction;
   result: boolean;

--- a/src/middleware/__tests__/queries.ts
+++ b/src/middleware/__tests__/queries.ts
@@ -23,6 +23,7 @@ import {
   metadataQuery,
   multiSigProposalQuery,
   multiSigProposalVotesQuery,
+  nftCollectionHolders,
   nftHoldersQuery,
   nftTransactionQuery,
   polyxTransactionsQuery,
@@ -622,5 +623,24 @@ describe('customClaimTypeQuery', () => {
     const result = customClaimTypeQuery(size, start, dids);
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({ size: size.toNumber(), start: start.toNumber(), dids });
+  });
+});
+
+describe('nftCollectionHoldersQuery', () => {
+  it('should pass the variables to the grapqhl query', () => {
+    const ticker = 'TICKER';
+    let result = nftCollectionHolders('TICKER');
+
+    expect(result.query).toBeDefined();
+    expect(result.variables).toEqual({ assetId: 'TICKER' });
+
+    result = nftCollectionHolders(ticker, new BigNumber(1), new BigNumber(0));
+
+    expect(result.query).toBeDefined();
+    expect(result.variables).toEqual({
+      assetId: ticker,
+      size: 1,
+      start: 0,
+    });
   });
 });

--- a/src/middleware/queries.ts
+++ b/src/middleware/queries.ts
@@ -1657,3 +1657,36 @@ export function customClaimTypeQuery(
     variables: { size: size?.toNumber(), start: start?.toNumber(), dids },
   };
 }
+
+/**
+ * @hidden
+ *
+ * Get holders on an NFT Collection
+ */
+export function nftCollectionHolders(
+  assetId: string,
+  size?: BigNumber,
+  start?: BigNumber
+): QueryOptions<PaginatedQueryArgs<QueryArgs<NftHolder, 'assetId'>>> {
+  const query = gql`
+    query NftCollectionHolders($assetId: String!, $size: Int, $start: Int) {
+      nftHolders(
+        first: $size
+        offset: $start
+        filter: { assetId: { equalTo: $assetId }, nftIds: { notEqualTo: [] } }
+        orderBy: IDENTITY_ID_DESC
+      ) {
+        nodes {
+          identityId
+          nftIds
+        }
+        totalCount
+      }
+    }
+  `;
+
+  return {
+    query,
+    variables: { size: size?.toNumber(), start: start?.toNumber(), assetId },
+  };
+}


### PR DESCRIPTION
### Description

add `assetHolders.get` to NFT collections for fetching all holders of an NFT collection, along with the specific NFTs they hold

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

✅ Closes: [DA-1004](https://polymesh.atlassian.net/browse/DA-1004)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1004]: https://polymesh.atlassian.net/browse/DA-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ