### PR TITLE
fix: 🐛 include `entities/types.ts` in typedoc generation

### DIFF
--- a/scripts/prepareCodeForDocs.js
+++ b/scripts/prepareCodeForDocs.js
@@ -12,6 +12,7 @@
  *
  * Steps 1, 5 and 6 are handled outside this script
  */
+/* eslint-disable */
 const ts = require('typescript');
 const replace = require('replace-in-file');
 const path = require('path');

--- a/sdk-docs-typedoc.json
+++ b/sdk-docs-typedoc.json
@@ -20,7 +20,6 @@
     "src/base/Context.ts",
     "src/base/Procedure.ts",
     "**/sandbox.ts",
-    "src/api/entities/types.ts",
     "src/api/entities/Namespace.ts",
     "src/types/internal.ts",
     "src/utils/**",

--- a/sdk-docs-typedoc.json
+++ b/sdk-docs-typedoc.json
@@ -7,7 +7,6 @@
     "src/generated/types.ts",
     "src/types/index.ts",
     "src/types/utils",
-    "src/utils/index.ts",
     "src/base"
   ],
   "entryPointStrategy": "expand",

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -381,6 +381,7 @@ type IsFungibleLegGuard = (leg: InstructionLeg) => leg is FungibleLeg;
  *
  * @example ```ts
  * const fungibleGuard = await isFungibleLegBuilder(leg, context)
+ * ```
  */
 export const isFungibleLegBuilder = async (
   leg: InstructionLeg,

--- a/typedoc.json
+++ b/typedoc.json
@@ -20,7 +20,6 @@
     "src/base/Context.ts",
     "src/base/Procedure.ts",
     "**/sandbox.ts",
-    "src/api/entities/types.ts",
     "src/api/entities/Namespace.ts",
     "src/types/internal.ts",
     "src/utils/**",

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,10 +7,9 @@
     "src/generated/types.ts",
     "src/types/index.ts",
     "src/types/utils",
-    "src/utils/index.ts",
     "src/base"
   ],
-  "entryPointStrategy": "Expand",
+  "entryPointStrategy": "expand",
   "out": "docs",
   "plugin": ["typedoc-github-wiki-theme", "typedoc-plugin-markdown"],
   "theme": "github-wiki",


### PR DESCRIPTION
### Description

After last change, type docs was giving bunch of warning for missing types from `entities/types.ts` because it was exluded from typedoc generation. This will include `entities/types.ts` in typedoc generation

### Breaking Changes

NA

### JIRA Link

DA-1151

### Checklist

- [ ] Updated the Readme.md (if required) ?
