### PR TITLE
fix: 🐛 allow non-agents to pre-approve assets

### DIFF
--- a/src/api/procedures/__tests__/toggleTickerPreApproval.ts
+++ b/src/api/procedures/__tests__/toggleTickerPreApproval.ts
@@ -121,7 +121,7 @@ describe('toggleTickerPreApproval procedure', () => {
       expect(boundFunc(args)).toEqual({
         permissions: {
           transactions: [TxTags.asset.PreApproveTicker],
-          assets: [expect.objectContaining({ ticker })],
+          assets: [],
           portfolios: [],
         },
       });
@@ -131,7 +131,7 @@ describe('toggleTickerPreApproval procedure', () => {
       expect(boundFunc(args)).toEqual({
         permissions: {
           transactions: [TxTags.asset.RemoveTickerPreApproval],
-          assets: [expect.objectContaining({ ticker })],
+          assets: [],
           portfolios: [],
         },
       });

--- a/src/api/procedures/toggleTickerPreApproval.ts
+++ b/src/api/procedures/toggleTickerPreApproval.ts
@@ -1,4 +1,4 @@
-import { BaseAsset, PolymeshError, Procedure } from '~/internal';
+import { PolymeshError, Procedure } from '~/internal';
 import { ErrorCode, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import { stringToTicker } from '~/utils/conversion';
@@ -56,15 +56,14 @@ export async function prepareToggleTickerPreApproval(
  */
 export function getAuthorization(
   this: Procedure<Params, void>,
-  { ticker, preApprove }: Params
+  { preApprove }: Params
 ): ProcedureAuthorization {
-  const { context } = this;
   return {
     permissions: {
       transactions: [
         preApprove ? TxTags.asset.PreApproveTicker : TxTags.asset.RemoveTickerPreApproval,
       ],
-      assets: [new BaseAsset({ ticker }, context)],
+      assets: [],
       portfolios: [],
     },
   };


### PR DESCRIPTION
### Description

correct authorization logic that was preventing non asset agents from pre-approving assets

### Breaking Changes

None

### JIRA Link

None

### Checklist

- [ ] Updated the Readme.md (if required) ?
