### PR TITLE
feat: 🎸 Add option to issue tokens in a specific portfolio

### DIFF
--- a/src/api/entities/Asset/Fungible/Issuance/index.ts
+++ b/src/api/entities/Asset/Fungible/Issuance/index.ts
@@ -22,8 +22,6 @@ export class Issuance extends Namespace<FungibleAsset> {
 
   /**
    * Issue a certain amount of Asset tokens to the caller's default portfolio
-   *
-   * @param args.amount - amount of Asset tokens to be issued
    */
   public issue: ProcedureMethod<IssueTokensParams, FungibleAsset>;
 }

--- a/src/api/entities/Asset/Fungible/Issuance/index.ts
+++ b/src/api/entities/Asset/Fungible/Issuance/index.ts
@@ -1,7 +1,5 @@
-import BigNumber from 'bignumber.js';
-
 import { Context, FungibleAsset, issueTokens, Namespace } from '~/internal';
-import { ProcedureMethod } from '~/types';
+import { IssueTokensParams, ProcedureMethod } from '~/types';
 import { createProcedureMethod } from '~/utils/internal';
 
 /**
@@ -27,5 +25,5 @@ export class Issuance extends Namespace<FungibleAsset> {
    *
    * @param args.amount - amount of Asset tokens to be issued
    */
-  public issue: ProcedureMethod<{ amount: BigNumber }, FungibleAsset>;
+  public issue: ProcedureMethod<IssueTokensParams, FungibleAsset>;
 }

--- a/src/api/entities/Asset/Fungible/index.ts
+++ b/src/api/entities/Asset/Fungible/index.ts
@@ -104,8 +104,6 @@ export class FungibleAsset extends BaseAsset {
 
   /**
    * Redeem (burn) an amount of this Asset's tokens
-   *
-   * @note tokens are removed from the caller's Default Portfolio
    */
   public redeem: ProcedureMethod<RedeemTokensParams, void>;
 

--- a/src/api/entities/Asset/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/NonFungible/NftCollection.ts
@@ -5,9 +5,9 @@ import BigNumber from 'bignumber.js';
 import { BaseAsset } from '~/api/entities/Asset/Base';
 import { NonFungibleSettlements } from '~/api/entities/Asset/Base/Settlements';
 import { AssetHolders } from '~/api/entities/Asset/NonFungible/AssetHolders';
-import { issueNft } from '~/api/procedures/issueNft';
 import {
   Context,
+  issueNft,
   Nft,
   nftControllerTransfer,
   PolymeshError,

--- a/src/api/entities/Asset/__tests__/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/NftCollection.ts
@@ -491,6 +491,7 @@ describe('NftCollection class', () => {
 
       const args = {
         metadata: [],
+        portfolioId: new BigNumber(1),
       };
 
       const expectedTransaction =

--- a/src/api/procedures/__tests__/issueNft.ts
+++ b/src/api/procedures/__tests__/issueNft.ts
@@ -6,8 +6,8 @@ import { when } from 'jest-when';
 import { Nft } from '~/api/entities/Asset/NonFungible/Nft';
 import {
   getAuthorization,
-  IssueNftParams,
   issueNftResolver,
+  Params,
   prepareIssueNft,
   prepareStorage,
   Storage,
@@ -66,7 +66,7 @@ describe('issueNft procedure', () => {
 
   describe('prepareStorage', () => {
     it('should return the NftCollection', () => {
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext);
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext);
       const boundFunc = prepareStorage.bind(proc);
 
       const result = boundFunc({
@@ -127,7 +127,7 @@ describe('issueNft procedure', () => {
       mockContext.getSigningIdentity.mockResolvedValue(entityMockUtils.getIdentityInstance());
 
       const transaction = dsMockUtils.createTxMock('nft', 'issueNft');
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance(),
       });
 
@@ -149,7 +149,7 @@ describe('issueNft procedure', () => {
       );
       nftInputToMetadataValueSpy.mockReturnValue([]);
       const transaction = dsMockUtils.createTxMock('nft', 'issueNft');
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance(),
       });
       const result = await prepareIssueNft.call(proc, args);
@@ -172,7 +172,7 @@ describe('issueNft procedure', () => {
       );
       nftInputToMetadataValueSpy.mockReturnValue([]);
       const transaction = dsMockUtils.createTxMock('nft', 'issueNft');
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance(),
       });
       const result = await prepareIssueNft.call(proc, args);
@@ -197,7 +197,7 @@ describe('issueNft procedure', () => {
       nftInputToMetadataValueSpy.mockReturnValue([]);
 
       const transaction = dsMockUtils.createTxMock('nft', 'issueNft');
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance(),
       });
       const result = await prepareIssueNft.call(proc, args);
@@ -219,7 +219,7 @@ describe('issueNft procedure', () => {
 
       dsMockUtils.createTxMock('nft', 'issueNft');
 
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance(),
       });
 
@@ -241,7 +241,7 @@ describe('issueNft procedure', () => {
 
       dsMockUtils.createTxMock('nft', 'issueNft');
 
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance({
           collectionKeys: [
             { type: MetadataType.Global, id: new BigNumber(1), specs: {}, name: 'Example Global' },
@@ -270,7 +270,7 @@ describe('issueNft procedure', () => {
 
       dsMockUtils.createTxMock('nft', 'issueNft');
 
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance({
           collectionKeys: [
             {
@@ -291,7 +291,7 @@ describe('issueNft procedure', () => {
 
   describe('getAuthorization', () => {
     it('should return the appropriate roles and permissions', () => {
-      const proc = procedureMockUtils.getInstance<IssueNftParams, Nft, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<Params, Nft, Storage>(mockContext, {
         collection: entityMockUtils.getNftCollectionInstance({ ticker }),
       });
       const boundFunc = getAuthorization.bind(proc);

--- a/src/api/procedures/__tests__/issueTokens.ts
+++ b/src/api/procedures/__tests__/issueTokens.ts
@@ -5,7 +5,7 @@ import { when } from 'jest-when';
 
 import {
   getAuthorization,
-  IssueTokensParams,
+  Params,
   prepareIssueTokens,
   prepareStorage,
   Storage,
@@ -63,9 +63,7 @@ describe('issueTokens procedure', () => {
 
   describe('prepareStorage', () => {
     it('should return the Asset', () => {
-      const proc = procedureMockUtils.getInstance<IssueTokensParams, FungibleAsset, Storage>(
-        mockContext
-      );
+      const proc = procedureMockUtils.getInstance<Params, FungibleAsset, Storage>(mockContext);
       const boundFunc = prepareStorage.bind(proc);
 
       const result = boundFunc({
@@ -95,12 +93,9 @@ describe('issueTokens procedure', () => {
       },
     });
 
-    const proc = procedureMockUtils.getInstance<IssueTokensParams, FungibleAsset, Storage>(
-      mockContext,
-      {
-        asset: entityMockUtils.getFungibleAssetInstance(),
-      }
-    );
+    const proc = procedureMockUtils.getInstance<Params, FungibleAsset, Storage>(mockContext, {
+      asset: entityMockUtils.getFungibleAssetInstance(),
+    });
 
     let error;
 
@@ -141,12 +136,9 @@ describe('issueTokens procedure', () => {
       .mockReturnValue(rawAmount);
 
     const transaction = dsMockUtils.createTxMock('asset', 'issue');
-    const proc = procedureMockUtils.getInstance<IssueTokensParams, FungibleAsset, Storage>(
-      mockContext,
-      {
-        asset: entityMockUtils.getFungibleAssetInstance(),
-      }
-    );
+    const proc = procedureMockUtils.getInstance<Params, FungibleAsset, Storage>(mockContext, {
+      asset: entityMockUtils.getFungibleAssetInstance(),
+    });
 
     const result = await prepareIssueTokens.call(proc, args);
     expect(result).toEqual({
@@ -216,12 +208,9 @@ describe('issueTokens procedure', () => {
         .calledWith(amount, mockContext, isDivisible)
         .mockReturnValue(rawAmount);
       const transaction = dsMockUtils.createTxMock('asset', 'issue');
-      const proc = procedureMockUtils.getInstance<IssueTokensParams, FungibleAsset, Storage>(
-        mockContext,
-        {
-          asset: entityMockUtils.getFungibleAssetInstance(),
-        }
-      );
+      const proc = procedureMockUtils.getInstance<Params, FungibleAsset, Storage>(mockContext, {
+        asset: entityMockUtils.getFungibleAssetInstance(),
+      });
       const result = await prepareIssueTokens.call(proc, args);
 
       expect(result).toEqual({
@@ -254,12 +243,9 @@ describe('issueTokens procedure', () => {
         .calledWith(amount, mockContext, isDivisible)
         .mockReturnValue(rawAmount);
       const transaction = dsMockUtils.createTxMock('asset', 'issue');
-      const proc = procedureMockUtils.getInstance<IssueTokensParams, FungibleAsset, Storage>(
-        mockContext,
-        {
-          asset: entityMockUtils.getFungibleAssetInstance(),
-        }
-      );
+      const proc = procedureMockUtils.getInstance<Params, FungibleAsset, Storage>(mockContext, {
+        asset: entityMockUtils.getFungibleAssetInstance(),
+      });
       const result = await prepareIssueTokens.call(proc, args);
 
       expect(result).toEqual({
@@ -292,12 +278,9 @@ describe('issueTokens procedure', () => {
         .calledWith(amount, mockContext, isDivisible)
         .mockReturnValue(rawAmount);
       const transaction = dsMockUtils.createTxMock('asset', 'issue');
-      const proc = procedureMockUtils.getInstance<IssueTokensParams, FungibleAsset, Storage>(
-        mockContext,
-        {
-          asset: entityMockUtils.getFungibleAssetInstance(),
-        }
-      );
+      const proc = procedureMockUtils.getInstance<Params, FungibleAsset, Storage>(mockContext, {
+        asset: entityMockUtils.getFungibleAssetInstance(),
+      });
       const result = await prepareIssueTokens.call(proc, args);
 
       expect(result).toEqual({
@@ -310,12 +293,9 @@ describe('issueTokens procedure', () => {
 
   describe('getAuthorization', () => {
     it('should return the appropriate roles and permissions', () => {
-      const proc = procedureMockUtils.getInstance<IssueTokensParams, FungibleAsset, Storage>(
-        mockContext,
-        {
-          asset: entityMockUtils.getFungibleAssetInstance({ ticker }),
-        }
-      );
+      const proc = procedureMockUtils.getInstance<Params, FungibleAsset, Storage>(mockContext, {
+        asset: entityMockUtils.getFungibleAssetInstance({ ticker }),
+      });
       const boundFunc = getAuthorization.bind(proc);
 
       expect(boundFunc()).toEqual({

--- a/src/api/procedures/issueNft.ts
+++ b/src/api/procedures/issueNft.ts
@@ -1,9 +1,8 @@
 import { ISubmittableResult } from '@polkadot/types/types';
-import BigNumber from 'bignumber.js';
 
 import { Nft } from '~/api/entities/Asset/NonFungible/Nft';
 import { Context, NftCollection, PolymeshError, Procedure } from '~/internal';
-import { ErrorCode, NftMetadataInput, TxTags } from '~/types';
+import { ErrorCode, IssueNftParams, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import {
   meshNftToNftId,
@@ -13,11 +12,9 @@ import {
 } from '~/utils/conversion';
 import { filterEventRecords } from '~/utils/internal';
 
-export interface IssueNftParams {
+export type Params = IssueNftParams & {
   ticker: string;
-  portfolioId?: BigNumber;
-  metadata: NftMetadataInput[];
-}
+};
 
 export interface Storage {
   collection: NftCollection;
@@ -40,8 +37,8 @@ export const issueNftResolver =
  * @hidden
  */
 export async function prepareIssueNft(
-  this: Procedure<IssueNftParams, Nft, Storage>,
-  args: IssueNftParams
+  this: Procedure<Params, Nft, Storage>,
+  args: Params
 ): Promise<TransactionSpec<Nft, ExtrinsicParams<'nft', 'issueNft'>>> {
   const {
     context: {
@@ -99,9 +96,7 @@ export async function prepareIssueNft(
 /**
  * @hidden
  */
-export function getAuthorization(
-  this: Procedure<IssueNftParams, Nft, Storage>
-): ProcedureAuthorization {
+export function getAuthorization(this: Procedure<Params, Nft, Storage>): ProcedureAuthorization {
   const {
     storage: { collection },
   } = this;
@@ -117,10 +112,7 @@ export function getAuthorization(
 /**
  * @hidden
  */
-export function prepareStorage(
-  this: Procedure<IssueNftParams, Nft, Storage>,
-  { ticker }: IssueNftParams
-): Storage {
+export function prepareStorage(this: Procedure<Params, Nft, Storage>, { ticker }: Params): Storage {
   const { context } = this;
 
   return {
@@ -131,5 +123,5 @@ export function prepareStorage(
 /**
  * @hidden
  */
-export const issueNft = (): Procedure<IssueNftParams, Nft, Storage> =>
+export const issueNft = (): Procedure<Params, Nft, Storage> =>
   new Procedure(prepareIssueNft, getAuthorization, prepareStorage);

--- a/src/api/procedures/issueTokens.ts
+++ b/src/api/procedures/issueTokens.ts
@@ -1,16 +1,12 @@
-import BigNumber from 'bignumber.js';
-
 import { FungibleAsset, PolymeshError, Procedure } from '~/internal';
-import { ErrorCode, TxTags } from '~/types';
+import { ErrorCode, IssueTokensParams, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import { MAX_BALANCE } from '~/utils/constants';
 import { bigNumberToBalance, portfolioToPortfolioKind, stringToTicker } from '~/utils/conversion';
 
-export interface IssueTokensParams {
-  amount: BigNumber;
+export type Params = IssueTokensParams & {
   ticker: string;
-  portfolioId?: BigNumber;
-}
+};
 
 export interface Storage {
   asset: FungibleAsset;
@@ -20,8 +16,8 @@ export interface Storage {
  * @hidden
  */
 export async function prepareIssueTokens(
-  this: Procedure<IssueTokensParams, FungibleAsset, Storage>,
-  args: IssueTokensParams
+  this: Procedure<Params, FungibleAsset, Storage>,
+  args: Params
 ): Promise<TransactionSpec<FungibleAsset, ExtrinsicParams<'asset', 'issue'>>> {
   const {
     context: {
@@ -70,7 +66,7 @@ export async function prepareIssueTokens(
  * @hidden
  */
 export function getAuthorization(
-  this: Procedure<IssueTokensParams, FungibleAsset, Storage>
+  this: Procedure<Params, FungibleAsset, Storage>
 ): ProcedureAuthorization {
   const {
     storage: { asset },
@@ -88,8 +84,8 @@ export function getAuthorization(
  * @hidden
  */
 export function prepareStorage(
-  this: Procedure<IssueTokensParams, FungibleAsset, Storage>,
-  { ticker }: IssueTokensParams
+  this: Procedure<Params, FungibleAsset, Storage>,
+  { ticker }: Params
 ): Storage {
   const { context } = this;
 
@@ -101,5 +97,5 @@ export function prepareStorage(
 /**
  * @hidden
  */
-export const issueTokens = (): Procedure<IssueTokensParams, FungibleAsset, Storage> =>
+export const issueTokens = (): Procedure<Params, FungibleAsset, Storage> =>
   new Procedure(prepareIssueTokens, getAuthorization, prepareStorage);

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -644,6 +644,14 @@ export interface CreateAssetParams {
   initialStatistics?: InputStatType[];
 }
 
+export interface IssueTokensParams {
+  amount: BigNumber;
+  /**
+   * portfolio to which the Asset tokens will be issued (optional, default is the default portfolio)
+   */
+  portfolioId?: BigNumber;
+}
+
 export interface CreateAssetWithTickerParams extends CreateAssetParams {
   ticker: string;
 }

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -645,6 +645,9 @@ export interface CreateAssetParams {
 }
 
 export interface IssueTokensParams {
+  /**
+   * amount of Asset tokens to be issued
+   */
   amount: BigNumber;
   /**
    * portfolio to which the Asset tokens will be issued (optional, default is the default portfolio)
@@ -1053,6 +1056,9 @@ export interface ModifyPrimaryIssuanceAgentParams {
 }
 
 export interface RedeemTokensParams {
+  /**
+   * amount of Asset tokens to be redeemed
+   */
   amount: BigNumber;
   /**
    * portfolio (or portfolio ID) from which Assets will be redeemed (optional, defaults to the default Portfolio)

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1035,7 +1035,10 @@ export type NftMetadataInput = {
 
 export type IssueNftParams = {
   metadata: NftMetadataInput[];
-  portfolio?: PortfolioLike;
+  /**
+   * portfolio to which the NFTCollection will be issued (optional, default is the default portfolio)
+   */
+  portfolioId?: BigNumber;
 };
 
 export interface ModifyPrimaryIssuanceAgentParams {

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -36,6 +36,7 @@ export { createVenue } from '~/api/procedures/createVenue';
 export { inviteAccount } from '~/api/procedures/inviteAccount';
 export { subsidizeAccount } from '~/api/procedures/subsidizeAccount';
 export { issueTokens } from '~/api/procedures/issueTokens';
+export { issueNft } from '~/api/procedures/issueNft';
 export { modifyClaims } from '~/api/procedures/modifyClaims';
 export { modifyInstructionAffirmation } from '~/api/procedures/modifyInstructionAffirmation';
 export { modifyAsset } from '~/api/procedures/modifyAsset';

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -35,7 +35,7 @@ export { createNftCollection } from '~/api/procedures/createNftCollection';
 export { createVenue } from '~/api/procedures/createVenue';
 export { inviteAccount } from '~/api/procedures/inviteAccount';
 export { subsidizeAccount } from '~/api/procedures/subsidizeAccount';
-export { issueTokens, IssueTokensParams } from '~/api/procedures/issueTokens';
+export { issueTokens } from '~/api/procedures/issueTokens';
 export { modifyClaims } from '~/api/procedures/modifyClaims';
 export { modifyInstructionAffirmation } from '~/api/procedures/modifyInstructionAffirmation';
 export { modifyAsset } from '~/api/procedures/modifyAsset';


### PR DESCRIPTION
### Description

When the option was added to specify portfolio on issuance, the interface didn't get updated (https://github.com/PolymeshAssociation/polymesh-sdk/pull/1025/files). This adds the option to specify portfolio on issuance. 

(This was encountered while covering edge cases in middleware tests.)

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
