### PR TITLE
fix: 🐛 Update middleware queries to support latest graphql

### DIFF
--- a/src/api/entities/DividendDistribution/__tests__/index.ts
+++ b/src/api/entities/DividendDistribution/__tests__/index.ts
@@ -281,11 +281,16 @@ describe('DividendDistribution class', () => {
 
       dsMockUtils.createApolloQueryMock(
         distributionQuery({
-          id: `${ticker}/${id.toString()}`,
+          assetId: ticker,
+          localId: id.toNumber(),
         }),
         {
-          distribution: {
-            taxes: fakeTax.toNumber(),
+          distributions: {
+            nodes: [
+              {
+                taxes: fakeTax.toNumber(),
+              },
+            ],
           },
         }
       );
@@ -302,11 +307,16 @@ describe('DividendDistribution class', () => {
 
       dsMockUtils.createApolloQueryMock(
         distributionQuery({
-          id: `${ticker}/${id.toString()}`,
+          assetId: ticker,
+          localId: id.toNumber(),
         }),
         {
-          distribution: {
-            taxes: 0,
+          distributions: {
+            nodes: [
+              {
+                taxes: 0,
+              },
+            ],
           },
         }
       );

--- a/src/api/entities/DividendDistribution/index.ts
+++ b/src/api/entities/DividendDistribution/index.ts
@@ -449,9 +449,10 @@ export class DividendDistribution extends CorporateActionBase {
       context,
     } = this;
 
-    const taxPromise = context.queryMiddleware<Ensured<Query, 'distribution'>>(
+    const taxPromise = context.queryMiddleware<Ensured<Query, 'distributions'>>(
       distributionQuery({
-        id: `${ticker}/${id.toString()}`,
+        assetId: ticker,
+        localId: id.toNumber(),
       })
     );
 
@@ -459,7 +460,7 @@ export class DividendDistribution extends CorporateActionBase {
       exists,
       {
         data: {
-          distribution: { taxes },
+          distributions: { nodes },
         },
       },
     ] = await Promise.all([this.exists(), taxPromise]);
@@ -471,7 +472,7 @@ export class DividendDistribution extends CorporateActionBase {
       });
     }
 
-    return new BigNumber(taxes).shiftedBy(-6);
+    return new BigNumber(nodes[0].taxes).shiftedBy(-6);
   }
 
   /**

--- a/src/middleware/__tests__/queries.ts
+++ b/src/middleware/__tests__/queries.ts
@@ -360,7 +360,8 @@ describe('tickerExternalAgentActionsQuery', () => {
 describe('distributionQuery', () => {
   it('should pass the variables to the grapqhl query', () => {
     const variables = {
-      id: '123',
+      assetId: 'TICKER',
+      localId: 1,
     };
 
     const result = distributionQuery(variables);

--- a/src/middleware/queries.ts
+++ b/src/middleware/queries.ts
@@ -76,9 +76,11 @@ export function latestBlockQuery(): QueryOptions {
  */
 export function heartbeatQuery(): QueryOptions {
   const query = gql`
-    query {
-      block(id: "1") {
-        id
+    query heartbeat {
+      blocks(filter: { blockId: { equalTo: 1 } }) {
+        nodes {
+          blockId
+        }
       }
     }
   `;
@@ -857,12 +859,14 @@ export function tickerExternalAgentActionsQuery(
  * Get distribution details for a CAId
  */
 export function distributionQuery(
-  variables: QueryArgs<Distribution, 'id'>
-): QueryOptions<QueryArgs<Distribution, 'id'>> {
+  variables: QueryArgs<Distribution, 'assetId' | 'localId'>
+): QueryOptions<QueryArgs<Distribution, 'assetId' | 'localId'>> {
   const query = gql`
-    query DistributionQuery($id: String!) {
-      distribution(id: $id) {
-        taxes
+    query DistributionQuery($assetId: String!, $localId: Int!) {
+      distributions(filter: { assetId: { equalTo: $assetId }, localId: { equalTo: $localId } }) {
+        nodes {
+          taxes
+        }
       }
     }
   `;


### PR DESCRIPTION
### Description

After the latest changes in SQ wrt historical state tracking, the graphql queries querying the node entity directly expect `_id: UUID!` instead of the `id: ID!`, causing a couple of queries to break. 

This PR changes the format of both the queries to work correctly. 

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
