### PR TITLE
feat: 🎸 Use `currentAssetMetadataLocalKey` to get next local ID

### DIFF
--- a/src/api/entities/Asset/Base/Metadata/index.ts
+++ b/src/api/entities/Asset/Base/Metadata/index.ts
@@ -155,15 +155,19 @@ export class Metadata extends Namespace<BaseAsset> {
       context: {
         polymeshApi: {
           query: {
-            asset: { assetMetadataNextLocalKey },
+            asset: { currentAssetMetadataLocalKey },
           },
         },
       },
     } = this;
 
-    const rawId = await assetMetadataNextLocalKey(ticker);
+    const rawId = await currentAssetMetadataLocalKey(ticker);
 
-    return u64ToBigNumber(rawId).plus(1); // "next" is actually the last used
+    if (rawId.isSome) {
+      return u64ToBigNumber(rawId.unwrap()).plus(1);
+    }
+
+    return new BigNumber(1);
   }
 
   /**

--- a/src/api/entities/Asset/__tests__/Base/Metadata.ts
+++ b/src/api/entities/Asset/__tests__/Base/Metadata.ts
@@ -223,13 +223,22 @@ describe('Metadata class', () => {
       jest.restoreAllMocks();
     });
 
-    it('should return the MetadataEntry for requested id and type', async () => {
-      dsMockUtils.createQueryMock('asset', 'assetMetadataNextLocalKey', {
-        returnValue: rawId,
+    it('should return the next local Metadata ID', async () => {
+      dsMockUtils.createQueryMock('asset', 'currentAssetMetadataLocalKey', {
+        returnValue: dsMockUtils.createMockOption(rawId),
       });
 
       const result = await metadata.getNextLocalId();
       expect(result).toEqual(new BigNumber(2));
+    });
+
+    it('should return the next local Metadata ID as 1 for assets with no existing local metadata', async () => {
+      dsMockUtils.createQueryMock('asset', 'currentAssetMetadataLocalKey', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+
+      const result = await metadata.getNextLocalId();
+      expect(result).toEqual(new BigNumber(1));
     });
   });
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -126,7 +126,7 @@ export const PRIVATE_SUPPORTED_NODE_SEMVER = coerce(PRIVATE_SUPPORTED_NODE_VERSI
 /**
  * The Polymesh chain spec version range that is compatible with this version of the SDK
  */
-export const SUPPORTED_SPEC_VERSION_RANGE = '6.2 || 6.3';
+export const SUPPORTED_SPEC_VERSION_RANGE = '6.3';
 
 /**
  * The Polymesh private chain spec version range that is compatible with this version of the SDK


### PR DESCRIPTION
### Description

Replaces the deprecated usage of `assetMetadataNextLocalKey` with `currentAssetMetadataLocalKey`. This is supported with 6.3 changes

### Breaking Changes

NA

### JIRA Link

DA-1200

### Checklist

- [ ] Updated the Readme.md (if required) ?
