### PR TITLE
feat: 🎸 allow MultiSig signers to submit proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,29 @@ Creating transactions is a two-step process. First a procedure is created, which
   const newAsset = await createAssetProc.run()
 ```
 
+#### Creating MultiSig Proposals
+
+If the signingAccount is a MultiSig signer, then the transaction will need to be ran with `.runAsProposal()` instead of the usual `.run()`.
+The underlying transaction will be wrapped with `multiSig.createProposalAsKey` extrinsic and will resolve to the MultiSig proposal created.
+
+Approving and rejecting existing proposals are an exception and should be submitted with `.run()`. If your application supports
+MultiSig signers, then the procedure's `multiSig` param can be checked to ensure the correct method is called.
+
+```typescript
+  const createAssetProc = await polyClient.assets.createAsset(
+    args,
+    {
+      signingAccount: multiSigSigner
+    }
+  )
+  createAssetProc.multiSig // indicates the acting MultiSig. If set `runAsProposal` must be used
+  const proposal = await createAssetProc.runAsProposal()
+
+  const rejectProc = await proposal.reject({ signingAccount: multiSigSigner })
+  rejectProc.multiSig // returns `null`. Rejecting a proposal does not get wrapped
+  await rejectProc.run()
+```
+
 #### Reading Data
 
 The SDK exposes getter functions that will return entities, which may have their own functions:

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -340,6 +340,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       throw new PolymeshError({
         code: ErrorCode.DataUnavailable,
         message: 'There is no Identity associated with this Account',
+        data: { address },
       });
     }
 

--- a/src/api/procedures/__tests__/consumeAddMultiSigSignerAuthorization.ts
+++ b/src/api/procedures/__tests__/consumeAddMultiSigSignerAuthorization.ts
@@ -302,7 +302,7 @@ describe('consumeAddMultiSigSignerAuthorization procedure', () => {
         ConsumeAddMultiSigSignerAuthorizationParams,
         void
       >(mockContext);
-      const { address } = mockContext.getSigningAccount();
+      const { address } = await mockContext.getActingAccount();
       const constructorParams = {
         authId,
         expiry: null,

--- a/src/api/procedures/__tests__/consumeAddRelayerPayingKeyAuthorization.ts
+++ b/src/api/procedures/__tests__/consumeAddRelayerPayingKeyAuthorization.ts
@@ -84,7 +84,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -116,7 +116,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -157,7 +157,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: false,
     });
 
@@ -203,7 +203,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -231,7 +231,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
       } as unknown as ConsumeAddRelayerPayingKeyAuthorizationParams);
 
       expect(result).toEqual({
-        signingAccount: mockContext.getSigningAccount(),
+        actingAccount: mockContext.getSigningAccount(),
         calledByTarget: true,
       });
     });
@@ -244,7 +244,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
         void,
         Storage
       >(mockContext, {
-        signingAccount: targetAccount,
+        actingAccount: targetAccount,
         calledByTarget: true,
       });
       const constructorParams = {
@@ -282,7 +282,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
         void,
         Storage
       >(mockContext, {
-        signingAccount: targetAccount,
+        actingAccount: targetAccount,
         calledByTarget: false,
       });
       boundFunc = getAuthorization.bind(proc);
@@ -300,7 +300,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
         void,
         Storage
       >(mockContext, {
-        signingAccount: entityMockUtils.getAccountInstance({
+        actingAccount: entityMockUtils.getAccountInstance({
           address: 'someOtherAddress',
           getIdentity: undefined,
         }),
@@ -322,7 +322,7 @@ describe('consumeAddRelayerPayingKeyAuthorization procedure', () => {
         void,
         Storage
       >(mockContext, {
-        signingAccount: entityMockUtils.getAccountInstance({
+        actingAccount: entityMockUtils.getAccountInstance({
           address: 'someOtherAddress',
           getIdentity: entityMockUtils.getIdentityInstance({ did: 'someOtherDid', isEqual: false }),
         }),

--- a/src/api/procedures/__tests__/consumeJoinOrRotateAuthorization.ts
+++ b/src/api/procedures/__tests__/consumeJoinOrRotateAuthorization.ts
@@ -89,7 +89,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -126,7 +126,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -163,7 +163,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -211,7 +211,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -259,7 +259,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -301,7 +301,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: true,
     });
 
@@ -345,7 +345,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       void,
       Storage
     >(mockContext, {
-      signingAccount: targetAccount,
+      actingAccount: targetAccount,
       calledByTarget: false,
     });
 
@@ -392,7 +392,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
     proc = procedureMockUtils.getInstance<ConsumeJoinOrRotateAuthorizationParams, void, Storage>(
       mockContext,
       {
-        signingAccount: targetAccount,
+        actingAccount: targetAccount,
         calledByTarget: true,
       }
     );
@@ -442,7 +442,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       } as unknown as ConsumeJoinOrRotateAuthorizationParams);
 
       expect(result).toEqual({
-        signingAccount: mockContext.getSigningAccount(),
+        actingAccount: mockContext.getSigningAccount(),
         calledByTarget: true,
       });
     });
@@ -455,7 +455,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
         void,
         Storage
       >(mockContext, {
-        signingAccount: targetAccount,
+        actingAccount: targetAccount,
         calledByTarget: true,
       });
       const { address } = mockContext.getSigningAccount();
@@ -502,7 +502,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       proc = procedureMockUtils.getInstance<ConsumeJoinOrRotateAuthorizationParams, void, Storage>(
         mockContext,
         {
-          signingAccount: targetAccount,
+          actingAccount: targetAccount,
           calledByTarget: false,
         }
       );
@@ -525,7 +525,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       proc = procedureMockUtils.getInstance<ConsumeJoinOrRotateAuthorizationParams, void, Storage>(
         mockContext,
         {
-          signingAccount: targetAccount,
+          actingAccount: targetAccount,
           calledByTarget: false,
         }
       );
@@ -550,7 +550,7 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
       proc = procedureMockUtils.getInstance<ConsumeJoinOrRotateAuthorizationParams, void, Storage>(
         mockContext,
         {
-          signingAccount: targetAccount,
+          actingAccount: targetAccount,
           calledByTarget: true,
         }
       );

--- a/src/api/procedures/__tests__/createChildIdentity.ts
+++ b/src/api/procedures/__tests__/createChildIdentity.ts
@@ -29,6 +29,7 @@ jest.mock(
 describe('createChildIdentity procedure', () => {
   let mockContext: Mocked<Context>;
   let identity: Identity;
+  let actingAccount: Account;
   let rawIdentity: PolymeshPrimitivesIdentityId;
   let childAccount: Account;
   let rawChildAccount: AccountId;
@@ -58,6 +59,7 @@ describe('createChildIdentity procedure', () => {
     rawChildAccount = dsMockUtils.createMockAccountId(childAccount.address);
 
     identity = entityMockUtils.getIdentityInstance();
+    actingAccount = entityMockUtils.getAccountInstance();
     rawIdentity = dsMockUtils.createMockIdentityId(identity.did);
 
     mockContext = dsMockUtils.getContextInstance({
@@ -103,7 +105,7 @@ describe('createChildIdentity procedure', () => {
 
     const proc = procedureMockUtils.getInstance<CreateChildIdentityParams, ChildIdentity, Storage>(
       mockContext,
-      { identity }
+      { identity, actingAccount }
     );
 
     return expect(
@@ -124,7 +126,7 @@ describe('createChildIdentity procedure', () => {
 
     const proc = procedureMockUtils.getInstance<CreateChildIdentityParams, ChildIdentity, Storage>(
       mockContext,
-      { identity }
+      { identity, actingAccount }
     );
 
     return expect(
@@ -143,7 +145,7 @@ describe('createChildIdentity procedure', () => {
 
     const proc = procedureMockUtils.getInstance<CreateChildIdentityParams, ChildIdentity, Storage>(
       mockContext,
-      { identity }
+      { identity, actingAccount }
     );
 
     return expect(
@@ -158,7 +160,7 @@ describe('createChildIdentity procedure', () => {
   it('should add a create ChildIdentity transaction to the queue', async () => {
     const proc = procedureMockUtils.getInstance<CreateChildIdentityParams, ChildIdentity, Storage>(
       mockContext,
-      { identity }
+      { identity, actingAccount }
     );
 
     const createChildIdentityTransaction = dsMockUtils.createTxMock(
@@ -181,7 +183,7 @@ describe('createChildIdentity procedure', () => {
     it('should return the appropriate roles and permissions', async () => {
       let proc = procedureMockUtils.getInstance<CreateChildIdentityParams, ChildIdentity, Storage>(
         mockContext,
-        { identity }
+        { identity, actingAccount }
       );
       let boundFunc = getAuthorization.bind(proc);
 
@@ -194,11 +196,14 @@ describe('createChildIdentity procedure', () => {
         },
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (actingAccount.isEqual as any).mockReturnValue(false);
+
       proc = procedureMockUtils.getInstance<CreateChildIdentityParams, ChildIdentity, Storage>(
         dsMockUtils.getContextInstance({
           signingAccountIsEqual: false,
         }),
-        { identity }
+        { identity, actingAccount }
       );
 
       boundFunc = getAuthorization.bind(proc);
@@ -224,6 +229,9 @@ describe('createChildIdentity procedure', () => {
       expect(result).toEqual({
         identity: expect.objectContaining({
           did: 'someDid',
+        }),
+        actingAccount: expect.objectContaining({
+          address: '0xdummy',
         }),
       });
     });

--- a/src/api/procedures/__tests__/modifyAllowance.ts
+++ b/src/api/procedures/__tests__/modifyAllowance.ts
@@ -144,10 +144,10 @@ describe('modifyAllowance procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return the appropriate roles and permissions', () => {
+    it('should return the appropriate roles and permissions', async () => {
       const boundFunc = getAuthorization.bind(proc);
 
-      let result = boundFunc(args);
+      let result = await boundFunc(args);
       expect(result).toEqual({
         roles: true,
         permissions: {
@@ -155,7 +155,7 @@ describe('modifyAllowance procedure', () => {
         },
       });
 
-      result = boundFunc({ ...args, operation: AllowanceOperation.Increase });
+      result = await boundFunc({ ...args, operation: AllowanceOperation.Increase });
       expect(result).toEqual({
         roles: true,
         permissions: {
@@ -163,7 +163,7 @@ describe('modifyAllowance procedure', () => {
         },
       });
 
-      result = boundFunc({ ...args, operation: AllowanceOperation.Decrease });
+      result = await boundFunc({ ...args, operation: AllowanceOperation.Decrease });
       expect(result).toEqual({
         roles: true,
         permissions: {
@@ -173,7 +173,7 @@ describe('modifyAllowance procedure', () => {
 
       subsidy.subsidizer.isEqual = jest.fn().mockReturnValue(false);
 
-      result = boundFunc(args);
+      result = await boundFunc(args);
       expect(result).toEqual({
         roles: 'Only the subsidizer is allowed to modify the allowance of a Subsidy',
         permissions: {

--- a/src/api/procedures/__tests__/modifySignerPermissions.ts
+++ b/src/api/procedures/__tests__/modifySignerPermissions.ts
@@ -119,6 +119,7 @@ describe('modifySignerPermissions procedure', () => {
       mockContext,
       {
         identity,
+        actingAccount: account,
       }
     );
 
@@ -183,7 +184,7 @@ describe('modifySignerPermissions procedure', () => {
 
     const proc = procedureMockUtils.getInstance<ModifySignerPermissionsParams, void, Storage>(
       mockContext,
-      { identity }
+      { identity, actingAccount: account }
     );
 
     return expect(
@@ -197,7 +198,7 @@ describe('modifySignerPermissions procedure', () => {
     it('should return the appropriate roles and permissions', async () => {
       let proc = procedureMockUtils.getInstance<ModifySignerPermissionsParams, void, Storage>(
         mockContext,
-        { identity }
+        { identity, actingAccount: account }
       );
       let boundFunc = getAuthorization.bind(proc);
 
@@ -210,11 +211,12 @@ describe('modifySignerPermissions procedure', () => {
         },
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (account.isEqual as any).mockReturnValue(false);
+
       proc = procedureMockUtils.getInstance<ModifySignerPermissionsParams, void, Storage>(
-        dsMockUtils.getContextInstance({
-          signingAccountIsEqual: false,
-        }),
-        { identity }
+        dsMockUtils.getContextInstance(),
+        { identity, actingAccount: account }
       );
 
       boundFunc = getAuthorization.bind(proc);
@@ -239,6 +241,9 @@ describe('modifySignerPermissions procedure', () => {
       expect(result).toEqual({
         identity: expect.objectContaining({
           did: 'someDid',
+        }),
+        actingAccount: expect.objectContaining({
+          address: '0xdummy',
         }),
       });
     });

--- a/src/api/procedures/acceptPrimaryKeyRotation.ts
+++ b/src/api/procedures/acceptPrimaryKeyRotation.ts
@@ -77,25 +77,25 @@ export async function prepareStorage(
 ): Promise<Storage> {
   const { context } = this;
 
-  const signingAccount = context.getSigningAccount();
+  const actingAccount = await context.getActingAccount();
 
   const getAuthRequest = async (
     auth: BigNumber | AuthorizationRequest
   ): Promise<AuthorizationRequest> => {
     if (auth && auth instanceof BigNumber) {
-      return signingAccount.authorizations.getOne({ id: auth });
+      return actingAccount.authorizations.getOne({ id: auth });
     }
     return auth;
   };
 
   const ownerAuthRequest = await getAuthRequest(ownerAuth);
 
-  let calledByTarget = signingAccount.isEqual(ownerAuthRequest.target);
+  let calledByTarget = actingAccount.isEqual(ownerAuthRequest.target);
 
   let cddAuthRequest;
   if (cddAuth) {
     cddAuthRequest = await getAuthRequest(cddAuth);
-    calledByTarget = calledByTarget && signingAccount.isEqual(cddAuthRequest.target);
+    calledByTarget = calledByTarget && actingAccount.isEqual(cddAuthRequest.target);
   }
 
   return {

--- a/src/api/procedures/consumeAddMultiSigSignerAuthorization.ts
+++ b/src/api/procedures/consumeAddMultiSigSignerAuthorization.ts
@@ -44,7 +44,7 @@ export async function prepareConsumeAddMultiSigSignerAuthorization(
   const rawAuthId = bigNumberToU64(authId, context);
 
   if (!accept) {
-    const { address } = context.getSigningAccount();
+    const { address } = await context.getActingAccount();
 
     const paidByThirdParty = address === signerToString(target);
     const addTransactionArgs: { paidForBy?: Identity } = {};
@@ -87,14 +87,14 @@ export async function getAuthorization(
 
   let hasRoles;
 
-  const signingAccount = context.getSigningAccount();
-  const identity = await signingAccount.getIdentity();
+  const actingAccount = await context.getActingAccount();
+  const identity = await actingAccount.getIdentity();
 
   let calledByTarget: boolean;
 
   let permissions;
   if (target instanceof Account) {
-    calledByTarget = target.isEqual(signingAccount);
+    calledByTarget = target.isEqual(actingAccount);
     hasRoles = calledByTarget;
     // An account accepting multisig cannot be part of an Identity, so we cannot check for permissions
   } else {

--- a/src/api/procedures/consumeAddRelayerPayingKeyAuthorization.ts
+++ b/src/api/procedures/consumeAddRelayerPayingKeyAuthorization.ts
@@ -18,7 +18,7 @@ export interface ConsumeAddRelayerPayingKeyAuthorizationParams {
 }
 
 export interface Storage {
-  signingAccount: Account;
+  actingAccount: Account;
   calledByTarget: boolean;
 }
 
@@ -102,7 +102,7 @@ export async function getAuthorization(
 ): Promise<ProcedureAuthorization> {
   const { issuer } = authRequest;
   const {
-    storage: { signingAccount, calledByTarget },
+    storage: { actingAccount, calledByTarget },
   } = this;
   let hasRoles = calledByTarget;
 
@@ -114,7 +114,7 @@ export async function getAuthorization(
     };
   }
 
-  const identity = await signingAccount.getIdentity();
+  const identity = await actingAccount.getIdentity();
 
   hasRoles = hasRoles || !!identity?.isEqual(issuer);
 
@@ -139,11 +139,11 @@ export async function prepareStorage(
 
   // AddRelayerPayingKey Authorizations always target an Account
   const targetAccount = target as Account;
-  const signingAccount = context.getSigningAccount();
-  const calledByTarget = targetAccount.isEqual(signingAccount);
+  const actingAccount = await context.getActingAccount();
+  const calledByTarget = targetAccount.isEqual(actingAccount);
 
   return {
-    signingAccount,
+    actingAccount,
     calledByTarget,
   };
 }

--- a/src/api/procedures/consumeAuthorizationRequests.ts
+++ b/src/api/procedures/consumeAuthorizationRequests.ts
@@ -126,7 +126,7 @@ export async function getAuthorization(
     let condition;
 
     if (target instanceof Account) {
-      const account = context.getSigningAccount();
+      const account = await context.getActingAccount();
       condition = target.isEqual(account);
     } else {
       identity = await fetchIdentity();

--- a/src/api/procedures/consumeJoinOrRotateAuthorization.ts
+++ b/src/api/procedures/consumeJoinOrRotateAuthorization.ts
@@ -18,7 +18,7 @@ export interface ConsumeJoinOrRotateAuthorizationParams {
 }
 
 export interface Storage {
-  signingAccount: Account;
+  actingAccount: Account;
   calledByTarget: boolean;
 }
 
@@ -124,7 +124,7 @@ export async function getAuthorization(
 ): Promise<ProcedureAuthorization> {
   const { issuer } = authRequest;
   const {
-    storage: { signingAccount, calledByTarget },
+    storage: { actingAccount, calledByTarget },
   } = this;
   let hasRoles = calledByTarget;
 
@@ -142,7 +142,7 @@ export async function getAuthorization(
     };
   }
 
-  const identity = await signingAccount.getIdentity();
+  const identity = await actingAccount.getIdentity();
 
   /*
    * if the target is removing the auth request and they don't have an Identity,
@@ -178,11 +178,11 @@ export async function prepareStorage(
 
   // JoinIdentity Authorizations always target an Account
   const targetAccount = target as Account;
-  const signingAccount = context.getSigningAccount();
-  const calledByTarget = targetAccount.isEqual(signingAccount);
+  const actingAccount = await context.getActingAccount();
+  const calledByTarget = targetAccount.isEqual(actingAccount);
 
   return {
-    signingAccount,
+    actingAccount,
     calledByTarget,
   };
 }

--- a/src/api/procedures/leaveIdentity.ts
+++ b/src/api/procedures/leaveIdentity.ts
@@ -16,10 +16,10 @@ export async function prepareLeaveIdentity(
     context,
   } = this;
 
-  const signingAccount = context.getSigningAccount();
-  const signingIdentity = await signingAccount.getIdentity();
+  const actingAccount = await context.getActingAccount();
+  const actingIdentity = await actingAccount.getIdentity();
 
-  if (!signingIdentity) {
+  if (!actingIdentity) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
       message: 'There is no Identity associated to the signing Account',
@@ -27,13 +27,13 @@ export async function prepareLeaveIdentity(
   }
   const [accountPermission] = await getSecondaryAccountPermissions(
     {
-      accounts: [signingAccount],
-      identity: signingIdentity,
+      accounts: [actingAccount],
+      identity: actingIdentity,
     },
     context
   );
 
-  const isSecondaryAccount = accountPermission && signingAccount.isEqual(accountPermission.account);
+  const isSecondaryAccount = accountPermission && actingAccount.isEqual(accountPermission.account);
   if (!isSecondaryAccount) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,

--- a/src/api/procedures/modifyAllowance.ts
+++ b/src/api/procedures/modifyAllowance.ts
@@ -95,19 +95,19 @@ export async function prepareModifyAllowance(
  *
  * To modify the allowance for a Subsidy, the caller must be the subsidizer
  */
-export function getAuthorization(
+export async function getAuthorization(
   this: Procedure<ModifyAllowanceParams, void>,
   args: ModifyAllowanceParams
-): ProcedureAuthorization {
+): Promise<ProcedureAuthorization> {
   const { context } = this;
   const {
     subsidy: { subsidizer },
     operation,
   } = args;
 
-  const currentAccount = context.getSigningAccount();
+  const actingAccount = await context.getActingAccount();
 
-  const hasRoles = subsidizer.isEqual(currentAccount);
+  const hasRoles = subsidizer.isEqual(actingAccount);
 
   const transactionMap = {
     [AllowanceOperation.Increase]: TxTags.relayer.IncreasePolyxLimit,

--- a/src/api/procedures/quitSubsidy.ts
+++ b/src/api/procedures/quitSubsidy.ts
@@ -66,7 +66,7 @@ export async function getAuthorization(
     },
   } = args;
 
-  const { address } = context.getSigningAccount();
+  const { address } = await context.getActingAccount();
 
   const hasRoles = [beneficiaryAddress, subsidizerAddress].includes(address);
 

--- a/src/api/procedures/subsidizeAccount.ts
+++ b/src/api/procedures/subsidizeAccount.ts
@@ -31,7 +31,10 @@ export async function prepareSubsidizeAccount(
 
   const { address: beneficiaryAddress } = account;
 
-  const identity = await context.getSigningIdentity();
+  const [identity, subsidizer] = await Promise.all([
+    context.getSigningIdentity(),
+    context.getActingAccount(),
+  ]);
 
   const authorizationRequests = await identity.authorizations.getSent();
 
@@ -62,7 +65,7 @@ export async function prepareSubsidizeAccount(
     type: AuthorizationType.AddRelayerPayingKey,
     value: {
       beneficiary: account,
-      subsidizer: context.getSigningAccount(),
+      subsidizer,
       allowance,
     },
   };

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -108,6 +108,11 @@ export interface ProcedureOpts {
    * More information can be found [here](https://wiki.polkadot.network/docs/build-protocol-info#transaction-mortality). Note the Polymesh chain will **never** reap Accounts, so the risk of a replay attack is mitigated.
    */
   mortality?: MortalityProcedureOpt;
+
+  /**
+   * These options will only apply when the `signingAccount` is a MultiSig signer and the transaction is being wrapped as a proposal
+   */
+  multiSigOpts?: MultiSigProcedureOpt;
 }
 
 /**
@@ -129,6 +134,13 @@ export interface MortalProcedureOptValue {
    * @note this value should not exceed 4096, which is the chain's `BlockHashCount` as the lesser of the two will be used.
    */
   readonly lifetime?: BigNumber;
+}
+
+export interface MultiSigProcedureOpt {
+  /**
+   * The block number for which the proposal expires
+   */
+  expiry?: Date;
 }
 
 export type MortalityProcedureOpt = ImmortalProcedureOptValue | MortalProcedureOptValue;

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -444,7 +444,7 @@ export class Context {
   /**
    * @hidden
    *
-   * Retrieve the signing Account
+   * Retrieve the account that will sign the transaction
    *
    * @throws if there is no signing Account associated to the SDK instance
    */
@@ -452,6 +452,24 @@ export class Context {
     const address = this.getSigningAddress();
 
     return new Account({ address }, this);
+  }
+
+  /**
+   * @hidden
+   *
+   * Retrieve the account that is acting. Like `getSigningAccount`, except this method will consider MultiSig signers
+   * and return the acting MultiSig account instead. This should be used when the account is involved in the extrinsic,
+   * such as accepting a "join identity" authorization.
+   *
+   * @throws if there is no signing Account associated to the SDK instance
+   */
+  public async getActingAccount(): Promise<Account> {
+    const signingAccount = this.getSigningAccount();
+
+    const multiSig = await signingAccount.getMultiSig();
+
+    // Return as Account to ensure consistent comparison via uuid
+    return multiSig ? new Account({ address: multiSig.address }, this) : signingAccount;
   }
 
   /**

--- a/src/base/PolymeshTransaction.ts
+++ b/src/base/PolymeshTransaction.ts
@@ -2,6 +2,7 @@ import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
+import { isMultiSigNoWrapTx } from '~/base/utils';
 import { Context, PolymeshTransactionBase } from '~/internal';
 import { TxTag, TxTags } from '~/types';
 import { PolymeshTx, TransactionConstructionData, TransactionSpec } from '~/types/internal';
@@ -87,13 +88,20 @@ export class PolymeshTransaction<
     this.feeMultiplier = feeMultiplier;
     this.protocolFee = fee;
     this.paidForBy = paidForBy;
+
+    // some transactions should never be MultiSig proposals, like approving a proposal
+    if (isMultiSigNoWrapTx(this.tag)) {
+      this.multiSig = null;
+    }
   }
 
   // eslint-disable-next-line require-jsdoc
   protected composeTx(): SubmittableExtrinsic<'promise', ISubmittableResult> {
     const { transaction, args } = this;
 
-    return transaction(...args);
+    const tx = transaction(...args);
+
+    return this.wrapProposalIfNeeded(tx);
   }
 
   // eslint-disable-next-line require-jsdoc

--- a/src/base/PolymeshTransactionBatch.ts
+++ b/src/base/PolymeshTransactionBatch.ts
@@ -94,9 +94,11 @@ export class PolymeshTransactionBatch<
       },
     } = this;
 
-    return utility.batchAll(
+    const tx = utility.batchAll(
       this.transactionData.map(({ transaction, args }) => transaction(...args))
     );
+
+    return this.wrapProposalIfNeeded(tx);
   }
 
   /**

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -663,6 +663,62 @@ describe('Context class', () => {
     });
   });
 
+  describe('method: getActingAccount', () => {
+    beforeAll(() => {
+      jest.spyOn(utilsInternalModule, 'assertAddressValid').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return the signing Account if its not a MultiSig signer', async () => {
+      const address = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
+      const context = await Context.create({
+        polymeshApi: dsMockUtils.getApiInstance(),
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+        signingManager: dsMockUtils.getSigningManagerInstance({
+          getAccounts: [address],
+        }),
+      });
+
+      const result = await context.getActingAccount();
+      expect(result).toEqual(expect.objectContaining({ address }));
+    });
+
+    it('should return the acting Account if the signer is a MultiSig signer', async () => {
+      const address = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
+      const context = await Context.create({
+        polymeshApi: dsMockUtils.getApiInstance(),
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+        signingManager: dsMockUtils.getSigningManagerInstance({
+          getAccounts: [address],
+        }),
+      });
+      entityMockUtils.configureMocks({
+        accountOptions: {
+          getMultiSig: entityMockUtils.getMultiSigInstance({ address: 'someMultiAddress' }),
+        },
+      });
+
+      const result = await context.getActingAccount();
+      expect(result).toEqual(expect.objectContaining({ address: 'someMultiAddress' }));
+    });
+
+    it('should throw an error if there is no Account associated with the SDK', async () => {
+      const context = await Context.create({
+        polymeshApi: dsMockUtils.getApiInstance(),
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      expect(() => context.getSigningAccount()).toThrow(
+        'There is no signing Account associated with the SDK instance'
+      );
+    });
+  });
+
   describe('method: getIdentity', () => {
     beforeAll(() => {
       jest.spyOn(utilsInternalModule, 'assertAddressValid').mockImplementation();

--- a/src/base/__tests__/PolymeshTransaction.ts
+++ b/src/base/__tests__/PolymeshTransaction.ts
@@ -31,13 +31,14 @@ describe('Polymesh Transaction class', () => {
   });
 
   describe('method: toTransactionSpec', () => {
-    it('should return the tx spec of a transaction', () => {
-      const transaction = dsMockUtils.createTxMock('asset', 'registerTicker');
-      const args = tuple('FOO');
-      const resolver = (): number => 1;
-      const transformer = (): number => 2;
-      const paidForBy = entityMockUtils.getIdentityInstance();
+    const transaction = dsMockUtils.createTxMock('asset', 'registerTicker');
+    const args = tuple('FOO');
+    const resolver = (): number => 1;
+    const transformer = (): number => 2;
+    const paidForBy = entityMockUtils.getIdentityInstance();
+    const multiSig = entityMockUtils.getMultiSigInstance();
 
+    it('should return the tx spec of a transaction', () => {
       const tx = new PolymeshTransaction(
         {
           ...txSpec,
@@ -59,6 +60,33 @@ describe('Polymesh Transaction class', () => {
         args,
         fee: txSpec.fee,
         feeMultiplier: new BigNumber(10),
+      });
+    });
+
+    it('should include multiSig if present', () => {
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver,
+          transformer,
+          feeMultiplier: new BigNumber(10),
+          paidForBy,
+          multiSig,
+        },
+        context
+      );
+
+      expect(PolymeshTransaction.toTransactionSpec(tx)).toEqual({
+        resolver,
+        transformer,
+        paidForBy,
+        transaction,
+        args,
+        fee: txSpec.fee,
+        feeMultiplier: new BigNumber(10),
+        multiSig,
       });
     });
   });

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
 import * as baseUtils from '~/base/utils';
 import {
   Context,
+  MultiSigProposal,
   PolymeshError,
   PolymeshTransaction,
   PolymeshTransactionBase,
@@ -18,9 +19,11 @@ import { fakePromise, fakePromises } from '~/testUtils';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
 import { createMockSigningPayload, MockTxStatus } from '~/testUtils/mocks/dataSources';
 import { Mocked } from '~/testUtils/types';
-import { ErrorCode, PayingAccountType, TransactionStatus, TxTags } from '~/types';
+import { ErrorCode, MultiSig, PayingAccountType, TransactionStatus, TxTags } from '~/types';
 import { tuple } from '~/types/utils';
+import { DUMMY_ACCOUNT_ID } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';
+import * as utilsInternalModule from '~/utils/internal';
 
 describe('Polymesh Transaction Base class', () => {
   let context: Mocked<Context>;
@@ -737,6 +740,209 @@ describe('Polymesh Transaction Base class', () => {
       );
 
       return expect(tx.run()).rejects.toThrow(expectedError);
+    });
+
+    it('should throw an error if called with a multiSig signer', async () => {
+      const transaction = dsMockUtils.createTxMock('staking', 'bond', { autoResolve: false });
+      context.supportsSubscription.mockReturnValue(false);
+
+      const args = tuple('FOO');
+      const txWithArgsMock = transaction(...args);
+
+      txWithArgsMock.signAndSend.mockRejectedValue(new Error('some error'));
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message:
+          '`.run` cannot be used with a MultiSig signer. `.runAsProposal` should be called instead',
+      });
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          multiSig: entityMockUtils.getMultiSigInstance(),
+          resolver: undefined,
+        },
+        context
+      );
+
+      return expect(tx.run()).rejects.toThrow(expectedError);
+    });
+  });
+
+  describe('method: runAsProposal', () => {
+    let getBlockMock: jest.Mock;
+    let multiSig: MultiSig;
+    let filterEventRecordsSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      getBlockMock = dsMockUtils.createRpcMock('chain', 'getBlock');
+      getBlockMock.mockResolvedValue(
+        dsMockUtils.createMockSignedBlock({
+          block: {
+            header: {
+              number: dsMockUtils.createMockCompact(dsMockUtils.createMockU32(new BigNumber(1))),
+              parentHash: 'hash',
+              stateRoot: 'hash',
+              extrinsicsRoot: 'hash',
+            },
+            extrinsics: undefined,
+          },
+        })
+      );
+
+      const proposalId = new BigNumber(2);
+      const rawProposalId = dsMockUtils.createMockU64(proposalId);
+
+      filterEventRecordsSpy = jest.spyOn(utilsInternalModule, 'filterEventRecords');
+      when(filterEventRecordsSpy)
+        .calledWith(expect.any(Object), 'multiSig', 'ProposalAdded')
+        .mockReturnValue([dsMockUtils.createMockIEvent([undefined, undefined, rawProposalId])]);
+
+      multiSig = entityMockUtils.getMultiSigInstance({
+        address: DUMMY_ACCOUNT_ID,
+        getCreator: entityMockUtils.getIdentityInstance({
+          getPrimaryAccount: {
+            account: entityMockUtils.getAccountInstance({
+              getBalance: { total: new BigNumber(1000), free: new BigNumber(1000) },
+            }),
+          },
+        }),
+      });
+    });
+
+    it('should execute the underlying transaction with the provided arguments, setting the tx and block hash when finished', async () => {
+      const underlyingTx = dsMockUtils.createTxMock('asset', 'registerTicker');
+      const args = [dsMockUtils.createMockText('A_TICKER')];
+
+      const transaction = dsMockUtils.createTxMock('multiSig', 'createProposalAsKey', {
+        autoResolve: MockTxStatus.Succeeded,
+      });
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction: underlyingTx,
+          args,
+          resolver: 3,
+          multiSig,
+        },
+        context
+      );
+
+      const runAsProposalPromise = tx.runAsProposal();
+
+      const result = await runAsProposalPromise;
+
+      expect(underlyingTx).toHaveBeenCalledWith(...args);
+      expect(transaction).toHaveBeenCalled();
+
+      expect(result).toBeInstanceOf(MultiSigProposal);
+      expect(tx.status).toEqual(TransactionStatus.Succeeded);
+      expect(() => tx.result).toThrow(PolymeshError); // MultiSig Proposal would mess up the type
+    });
+
+    it('should use multiSigOpts.expiry if it is provided', async () => {
+      const underlyingTx = dsMockUtils.createTxMock('asset', 'registerTicker');
+      const args = [dsMockUtils.createMockText('A_TICKER')];
+
+      dsMockUtils.createTxMock('multiSig', 'createProposalAsKey', {
+        autoResolve: MockTxStatus.Succeeded,
+      });
+
+      const expiry = new Date('10/14/1987');
+
+      const dateToMomentSpy = jest.spyOn(utilsConversionModule, 'dateToMoment');
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction: underlyingTx,
+          args,
+          resolver: 3,
+          multiSig,
+          multiSigOpts: { expiry },
+        },
+        context
+      );
+
+      await tx.runAsProposal();
+
+      expect(dateToMomentSpy).toHaveBeenCalledWith(expiry, context);
+    });
+
+    it('should throw an error if trying to run a transaction that already ran', async () => {
+      const underlyingTx = dsMockUtils.createTxMock('asset', 'registerTicker');
+      const args = [dsMockUtils.createMockText('A_TICKER')];
+
+      dsMockUtils.createTxMock('multiSig', 'createProposalAsKey', {});
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction: underlyingTx,
+          args,
+          resolver: 3,
+          multiSig,
+        },
+        context
+      );
+
+      await tx.runAsProposal();
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.General,
+        message: 'Cannot re-run a Transaction',
+      });
+
+      return expect(tx.runAsProposal()).rejects.toThrow(expectedError);
+    });
+
+    it('should not wrap the transaction in a proposal if its to approve a proposal', () => {
+      const transaction = dsMockUtils.createTxMock('multiSig', 'approveAsKey');
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args: [],
+          resolver: 3,
+          multiSig,
+        },
+        context
+      );
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message:
+          '`.run` should be used instead. Either the signing account is not a MultiSig signer, or the transaction is to approve or reject a MultiSig proposal',
+      });
+
+      return expect(tx.runAsProposal()).rejects.toThrow(expectedError);
+    });
+
+    it('should throw an error from running the transaction', async () => {
+      const underlyingTx = dsMockUtils.createTxMock('asset', 'registerTicker');
+
+      dsMockUtils.createTxMock('multiSig', 'createProposalAsKey', {
+        autoResolve: MockTxStatus.Aborted,
+      });
+      const args = [dsMockUtils.createMockText('A_TICKER')];
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction: underlyingTx,
+          args,
+          resolver: 3,
+          multiSig,
+        },
+        context
+      );
+
+      await expect(tx.runAsProposal()).rejects.toThrow(PolymeshError);
     });
   });
 

--- a/src/base/__tests__/Procedure.ts
+++ b/src/base/__tests__/Procedure.ts
@@ -31,6 +31,14 @@ jest.mock(
   )
 );
 
+const ticker = 'MY_ASSET';
+const secondaryAccounts = ['0x1', '0x2'];
+const procArgs = {
+  ticker,
+  secondaryAccounts,
+};
+const returnValue = 'good';
+
 describe('Procedure class', () => {
   let context: MockContext;
 
@@ -303,16 +311,8 @@ describe('Procedure class', () => {
     });
 
     it('should prepare and return a transaction spec with the corresponding transactions, arguments, fees and return value', async () => {
-      const ticker = 'MY_ASSET';
-      const secondaryAccounts = ['0x1', '0x2'];
-      const procArgs = {
-        ticker,
-        secondaryAccounts,
-      };
       const tx1 = dsMockUtils.createTxMock('asset', 'registerTicker');
       const tx2 = dsMockUtils.createTxMock('identity', 'cddRegisterDid');
-
-      const returnValue = 'good';
 
       const func1 = async function (
         this: Procedure<typeof procArgs, string>,
@@ -330,7 +330,7 @@ describe('Procedure class', () => {
       const proc1 = new Procedure(func1);
 
       const transaction = await proc1.prepare({ args: procArgs }, context, {
-        signingAccount: 'something',
+        signingAccount: entityMockUtils.getAccountInstance(),
         nonce: new BigNumber(15),
       });
 
@@ -351,9 +351,9 @@ describe('Procedure class', () => {
             expect.objectContaining({ transaction: tx2, args: [secondaryAccounts] }),
           ]),
         }),
-        { ...context, signingAddress: 'something', nonce: new BigNumber(15) }
+        { ...context, signingAddress: 'someAddress', nonce: new BigNumber(15) }
       );
-      expect(context.setSigningAddress).toHaveBeenCalledWith('something');
+      expect(context.setSigningAddress).toHaveBeenCalledWith('someAddress');
       expect(context.setNonce).toHaveBeenCalledWith(new BigNumber(15));
 
       const func2 = async function (
@@ -370,7 +370,7 @@ describe('Procedure class', () => {
       const proc2 = new Procedure(func2);
 
       const transaction2 = await proc2.prepare({ args: procArgs }, context, {
-        signingAccount: 'something',
+        signingAccount: entityMockUtils.getAccountInstance(),
       });
 
       const constructorMock = polymeshTransactionMockUtils.getTransactionConstructorMock();
@@ -383,11 +383,11 @@ describe('Procedure class', () => {
         expect.objectContaining({ transaction: tx1, args: [ticker] }),
         {
           ...context,
-          signingAddress: 'something',
+          signingAddress: 'someAddress',
           nonce: new BigNumber(-1),
         }
       );
-      expect(context.setSigningAddress).toHaveBeenCalledWith('something');
+      expect(context.setSigningAddress).toHaveBeenCalledWith('someAddress');
 
       const func3 = async function (
         this: Procedure<typeof procArgs, string>,
@@ -402,7 +402,7 @@ describe('Procedure class', () => {
       const proc3 = new Procedure(func3);
 
       const transaction3 = await proc3.prepare({ args: procArgs }, context, {
-        signingAccount: 'something',
+        signingAccount: entityMockUtils.getAccountInstance(),
         nonce: () => new BigNumber(10),
       });
 
@@ -414,11 +414,11 @@ describe('Procedure class', () => {
         expect.objectContaining({ transaction: tx1, args: [ticker] }),
         {
           ...context,
-          signingAddress: 'something',
+          signingAddress: 'someAddress',
           nonce: new BigNumber(10),
         }
       );
-      expect(context.setSigningAddress).toHaveBeenCalledWith('something');
+      expect(context.setSigningAddress).toHaveBeenCalledWith('someAddress');
       expect(context.setNonce).toHaveBeenCalledWith(new BigNumber(10));
 
       constructorMock.mockReset();
@@ -426,7 +426,7 @@ describe('Procedure class', () => {
       const nonce = (): Promise<BigNumber> => Promise.resolve(new BigNumber(15));
 
       await proc3.prepare({ args: procArgs }, context, {
-        signingAccount: 'something',
+        signingAccount: entityMockUtils.getAccountInstance(),
         nonce,
       });
 
@@ -434,7 +434,7 @@ describe('Procedure class', () => {
         expect.objectContaining({ transaction: tx1, args: [ticker] }),
         {
           ...context,
-          signingAddress: 'something',
+          signingAddress: 'someAddress',
           nonce: new BigNumber(15),
         }
       );
@@ -444,7 +444,7 @@ describe('Procedure class', () => {
       constructorMock.mockReset();
 
       await proc3.prepare({ args: procArgs }, context, {
-        signingAccount: 'something',
+        signingAccount: entityMockUtils.getAccountInstance(),
         nonce: Promise.resolve(new BigNumber(12)),
       });
 
@@ -452,7 +452,7 @@ describe('Procedure class', () => {
         expect.objectContaining({ transaction: tx1, args: [ticker] }),
         {
           ...context,
-          signingAddress: 'something',
+          signingAddress: 'someAddress',
           nonce: new BigNumber(12),
         }
       );
@@ -460,14 +460,41 @@ describe('Procedure class', () => {
       expect(context.setNonce).toHaveBeenCalledWith(new BigNumber(12));
     });
 
-    it('should throw any errors encountered during preparation', () => {
-      const ticker = 'MY_ASSET';
-      const secondaryAccounts = ['0x1', '0x2'];
-      const procArgs = {
-        ticker,
-        secondaryAccounts,
+    it('should detect when signer is a MultiSig signer', async () => {
+      const tx = dsMockUtils.createTxMock('asset', 'registerTicker');
+
+      const constructorMock = polymeshTransactionMockUtils.getTransactionConstructorMock();
+
+      const func = async function (
+        this: Procedure<typeof procArgs, string>,
+        args: typeof procArgs
+      ): Promise<BatchTransactionSpec<string, [[string]]>> {
+        return {
+          transactions: [{ transaction: tx, args: [args.ticker] }],
+          resolver: returnValue,
+        };
       };
 
+      const proc = new Procedure(func);
+
+      await proc.prepare({ args: procArgs }, context, {
+        signingAccount: entityMockUtils.getAccountInstance({
+          getMultiSig: entityMockUtils.getMultiSigInstance({ address: 'someMultiSigAddress' }),
+        }),
+        nonce: Promise.resolve(new BigNumber(12)),
+      });
+
+      expect(constructorMock).toHaveBeenCalledWith(
+        expect.objectContaining({ transaction: tx, args: [ticker] }),
+        {
+          ...context,
+          signingAddress: 'someAddress',
+          nonce: new BigNumber(12),
+        }
+      );
+    });
+
+    it('should throw any errors encountered during preparation', () => {
       const errorMsg = 'failed';
       const func = async function (
         this: Procedure<typeof procArgs, string>
@@ -481,12 +508,6 @@ describe('Procedure class', () => {
     });
 
     it("should throw an error if the caller doesn't have the appropriate roles", async () => {
-      const ticker = 'MY_ASSET';
-      const secondaryAccounts = ['0x1', '0x2'];
-      const procArgs = {
-        ticker,
-        secondaryAccounts,
-      };
       const func = async function (
         this: Procedure<typeof procArgs, string>
       ): Promise<TransactionSpec<string, [string]>> {

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -125,6 +125,10 @@ export enum PayingAccountType {
    * the caller Account is responsible of paying the fees
    */
   Caller = 'Caller',
+  /**
+   * The creator of the MultiSig is responsible for paying the fees
+   */
+  MultiSigCreator = 'MultiSigCreator',
 }
 
 /**
@@ -143,7 +147,7 @@ export type PayingAccount =
       allowance: BigNumber;
     }
   | {
-      type: PayingAccountType.Caller | PayingAccountType.Other;
+      type: PayingAccountType.Caller | PayingAccountType.Other | PayingAccountType.MultiSigCreator;
       account: Account;
     };
 

--- a/src/base/utils.ts
+++ b/src/base/utils.ts
@@ -11,10 +11,12 @@ import {
   ArrayTransactionArgument,
   ComplexTransactionArgument,
   ErrorCode,
+  MultiSigTx,
   PlainTransactionArgument,
   SimpleEnumTransactionArgument,
   TransactionArgument,
   TransactionArgumentType,
+  TxTag,
 } from '~/types';
 import { ROOT_TYPES } from '~/utils/constants';
 import { bigNumberToU32, createRawExtrinsicStatus } from '~/utils/conversion';
@@ -280,4 +282,17 @@ export const pollForTransactionFinalization = async (
     status: rawStatus,
     events: relatedEvents,
   });
+};
+
+/**
+ * @hidden
+ */
+const multiSigNoWrapTxs: TxTag[] = [MultiSigTx.ApproveAsKey, MultiSigTx.RejectAsKey];
+
+/**
+ * @hidden
+ * @returns `true` if a tag is an exception to the rule "All multiSig signer transactions should be wrapped as proposals"
+ */
+export const isMultiSigNoWrapTx = (tag: TxTag): boolean => {
+  return multiSigNoWrapTxs.includes(tag);
 };

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -848,10 +848,12 @@ function configureContext(opts: ContextOptions): void {
         checkPermissions: jest.fn().mockResolvedValue(opts.checkPermissions),
         isFrozen: jest.fn().mockResolvedValue(opts.isFrozen),
         isEqual: jest.fn().mockReturnValue(opts.signingAccountIsEqual),
+        getMultiSig: jest.fn().mockResolvedValue(null),
       })
     : getSigningAccount.mockImplementation(() => {
         throw new Error('There is no Account associated with the SDK');
       });
+  const getActingAccount = getSigningAccount;
   const signingAddress = opts.withSigningManager ? opts.signingAddress : undefined;
   const getSigningAddress = jest.fn();
   opts.withSigningManager
@@ -869,6 +871,7 @@ function configureContext(opts: ContextOptions): void {
     nonce,
     getSigningIdentity,
     getSigningAccount,
+    getActingAccount,
     getSigningAddress,
     accountBalance: jest.fn().mockResolvedValue(opts.balance),
     accountSubsidy: jest.fn().mockResolvedValue(opts.subsidy),

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -27,6 +27,8 @@ import {
   KnownAssetType,
   KnownNftType,
   MortalityProcedureOpt,
+  MultiSig,
+  MultiSigProcedureOpt,
   PermissionGroupType,
   Role,
   SignerValue,
@@ -175,6 +177,14 @@ export interface BaseTransactionSpec<ReturnValue, TransformedReturnValue = Retur
    *   they try to execute a transaction with `paidForBy` set, the fees will be paid for by the `paidForBy` Identity
    */
   paidForBy?: Identity;
+
+  /**
+   * If present that means the current transaction is a MultiSigProposal and the `signingAccount` is a signer for this MultiSig
+   *
+   * The proposal will be executed on chain after enough signers have approved the transaction
+   */
+  multiSig?: MultiSig;
+
   /**
    * value that the transaction will return once it has run, or a function that returns that value
    */
@@ -239,6 +249,10 @@ export interface TransactionConstructionData {
    * how long the transaction should be valid for
    */
   mortality: MortalityProcedureOpt;
+  /**
+   * options that specify details for MultiSig proposals
+   */
+  multiSigOpts?: MultiSigProcedureOpt;
 }
 
 export interface AuthTarget {

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -939,6 +939,7 @@ export function assertAddressValid(address: string, ss58Format: BigNumber): void
     throw new PolymeshError({
       code: ErrorCode.ValidationError,
       message: 'The supplied address is not a valid SS58 address',
+      data: { address, expectedFormat: ss58Format.toString() },
     });
   }
 
@@ -947,7 +948,7 @@ export function assertAddressValid(address: string, ss58Format: BigNumber): void
       code: ErrorCode.ValidationError,
       message: "The supplied address is not encoded with the chain's SS58 format",
       data: {
-        ss58Format,
+        ss58Format: ss58Format.toString(),
       },
     });
   }


### PR DESCRIPTION
### Description

add `runAsProposal` method to procedures. This is to be used when the signingAccount is a MultiSig signer. The transaction will be wrapped as a multiSig proposal, which will be executed when enough signers approve

### Breaking Changes

None

### JIRA Link

[DA-1249](https://polymesh.atlassian.net/browse/DA-1249)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1249]: https://polymesh.atlassian.net/browse/DA-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ