### PR TITLE
feat: 🎸 add `MultiSig.joinCreator` method

### DIFF
--- a/src/api/entities/Account/MultiSig/index.ts
+++ b/src/api/entities/Account/MultiSig/index.ts
@@ -2,13 +2,15 @@ import BigNumber from 'bignumber.js';
 
 import { UniqueIdentifiers } from '~/api/entities/Account';
 import { MultiSigProposal } from '~/api/entities/MultiSigProposal';
-import { Account, Context, Identity, modifyMultiSig, PolymeshError } from '~/internal';
+import { Account, Context, Identity, joinCreator, modifyMultiSig, PolymeshError } from '~/internal';
 import { multiSigProposalsQuery } from '~/middleware/queries';
 import { Query } from '~/middleware/types';
 import {
   ErrorCode,
+  JoinCreatorParams,
   ModifyMultiSigParams,
   MultiSigDetails,
+  OptionalArgsProcedureMethod,
   ProcedureMethod,
   ProposalStatus,
   ResultSet,
@@ -38,6 +40,13 @@ export class MultiSig extends Account {
     this.modify = createProcedureMethod(
       {
         getProcedureAndArgs: modifyArgs => [modifyMultiSig, { multiSig: this, ...modifyArgs }],
+      },
+      context
+    );
+    this.joinCreator = createProcedureMethod(
+      {
+        getProcedureAndArgs: joinArgs => [joinCreator, { multiSig: this, ...joinArgs }],
+        optionalArgs: true,
       },
       context
     );
@@ -219,4 +228,13 @@ export class MultiSig extends Account {
    * Modify the signers for the MultiSig. The signing Account must belong to the Identity of the creator of the MultiSig
    */
   public modify: ProcedureMethod<Pick<ModifyMultiSigParams, 'signers'>, void>;
+
+  /**
+   * Attach a MultiSig directly to the creator's identity. This method bypasses the usual authorization step to join an identity
+   *
+   * @note the caller should be the MultiSig creator's primary key
+   *
+   * @note To attach the MultiSig to an identity other than the creator's, {@link api/client/AccountManagement!AccountManagement.inviteAccount | inviteAccount} can be used instead. The MultiSig will then need to accept the created authorization
+   */
+  public joinCreator: OptionalArgsProcedureMethod<JoinCreatorParams, void>;
 }

--- a/src/api/entities/Account/__tests__/MultiSig.ts
+++ b/src/api/entities/Account/__tests__/MultiSig.ts
@@ -274,7 +274,7 @@ describe('MultiSig class', () => {
 
   describe('method: modify', () => {
     const account = entityMockUtils.getAccountInstance({ address });
-    it('should prepare the procedure and return the resulting transaction queue', async () => {
+    it('should prepare the procedure and return the resulting procedure', async () => {
       const expectedTransaction = 'someQueue' as unknown as PolymeshTransaction<void>;
       const args = {
         signers: [account],
@@ -284,9 +284,26 @@ describe('MultiSig class', () => {
         .calledWith({ args: { multiSig, ...args }, transformer: undefined }, context, {})
         .mockResolvedValue(expectedTransaction);
 
-      const queue = await multiSig.modify(args);
+      const procedure = await multiSig.modify(args);
 
-      expect(queue).toBe(expectedTransaction);
+      expect(procedure).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: joinCreator', () => {
+    it('should prepare the procedure and return the resulting procedure', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+      const args = {
+        asPrimary: true,
+      };
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args: { multiSig, ...args }, transformer: undefined }, context, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const procedure = await multiSig.joinCreator(args);
+
+      expect(procedure).toBe(expectedTransaction);
     });
   });
 });

--- a/src/api/procedures/__tests__/joinCreator.ts
+++ b/src/api/procedures/__tests__/joinCreator.ts
@@ -1,0 +1,232 @@
+import { AccountId } from '@polkadot/types/interfaces';
+import {
+  PolymeshPrimitivesSecondaryKeyPermissions,
+  PolymeshPrimitivesTicker,
+} from '@polkadot/types/lookup';
+import { when } from 'jest-when';
+
+import { getAuthorization, Params, prepareJoinCreator } from '~/api/procedures/joinCreator';
+import { Context, PolymeshError } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import {
+  ErrorCode,
+  MultiSig,
+  Permissions,
+  PermissionType,
+  TickerReservationStatus,
+  TxTags,
+} from '~/types';
+import { PolymeshTx } from '~/types/internal';
+import { DUMMY_ACCOUNT_ID } from '~/utils/constants';
+import * as utilsConversionModule from '~/utils/conversion';
+jest.mock(
+  '~/api/entities/TickerReservation',
+  require('~/testUtils/mocks/entities').mockTickerReservationModule(
+    '~/api/entities/TickerReservation'
+  )
+);
+
+describe('joinCreator procedure', () => {
+  let mockContext: Mocked<Context>;
+  let stringToAccountIdSpy: jest.SpyInstance<AccountId, [string, Context]>;
+  let permissionsToMeshPermissionsSpy: jest.SpyInstance<
+    PolymeshPrimitivesSecondaryKeyPermissions,
+    [Permissions, Context]
+  >;
+  let multiSig: MultiSig;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks({});
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    stringToAccountIdSpy = jest.spyOn(utilsConversionModule, 'stringToAccountId');
+    permissionsToMeshPermissionsSpy = jest.spyOn(
+      utilsConversionModule,
+      'permissionsToMeshPermissions'
+    );
+  });
+
+  let makePrimaryTx: PolymeshTx<[PolymeshPrimitivesTicker]>;
+  let makeSecondaryTx: PolymeshTx<[]>;
+  let setPermissionsTx: PolymeshTx<[]>;
+
+  beforeEach(() => {
+    entityMockUtils.configureMocks({
+      tickerReservationOptions: {
+        details: {
+          owner: entityMockUtils.getIdentityInstance({ did: 'someOtherDid' }),
+          expiryDate: null,
+          status: TickerReservationStatus.Free,
+        },
+      },
+    });
+
+    dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+      returnValue: dsMockUtils.createMockTickerRegistrationConfig(),
+    });
+
+    multiSig = entityMockUtils.getMultiSigInstance({ address: DUMMY_ACCOUNT_ID });
+
+    makePrimaryTx = dsMockUtils.createTxMock('multiSig', 'makeMultisigPrimary');
+    makeSecondaryTx = dsMockUtils.createTxMock('multiSig', 'makeMultisigSecondary');
+    setPermissionsTx = dsMockUtils.createTxMock('identity', 'setSecondaryKeyPermissions');
+
+    mockContext = dsMockUtils.getContextInstance();
+
+    when(stringToAccountIdSpy)
+      .calledWith(multiSig.address, mockContext)
+      .mockReturnValue('rawMultiSigAddr' as unknown as AccountId);
+
+    permissionsToMeshPermissionsSpy.mockReturnValue(
+      'mockPermissions' as unknown as PolymeshPrimitivesSecondaryKeyPermissions
+    );
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if the caller is not the creator', async () => {
+    multiSig = entityMockUtils.getMultiSigInstance({
+      getCreator: entityMockUtils.getIdentityInstance({ did: 'creatorDid', isEqual: false }),
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const expectedError = new PolymeshError({
+      message:
+        'A MultiSig can only be join its creator. Instead `accountManagement.inviteAccount` can be used, and the resulting auth accepted',
+      code: ErrorCode.ValidationError,
+    });
+
+    return expect(prepareJoinCreator.call(proc, { asPrimary: true, multiSig })).rejects.toThrow(
+      expectedError
+    );
+  });
+
+  it('should return a `makeMultiSigPrimary` transaction when being joined as primary', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const result = await prepareJoinCreator.call(proc, { asPrimary: true, multiSig });
+
+    expect(result).toEqual({
+      transaction: makePrimaryTx,
+      args: ['rawMultiSigAddr', null],
+      resolver: undefined,
+    });
+  });
+
+  it('should return a `makeMultisigSecondary` transaction when being joined as secondary', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const result = await prepareJoinCreator.call(proc, { asPrimary: false, multiSig });
+
+    expect(result).toEqual({
+      transaction: makeSecondaryTx,
+      args: ['rawMultiSigAddr'],
+      resolver: undefined,
+    });
+  });
+
+  it('should return a batch transaction when appropriate', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const result = await prepareJoinCreator.call(proc, {
+      asPrimary: false,
+      multiSig,
+      permissions: {
+        assets: {
+          type: PermissionType.Include,
+          values: [entityMockUtils.getFungibleAssetInstance()],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      transactions: [
+        {
+          transaction: makeSecondaryTx,
+          args: ['rawMultiSigAddr'],
+          resolver: undefined,
+        },
+        {
+          transaction: setPermissionsTx,
+          args: ['rawMultiSigAddr', 'mockPermissions'],
+          resolver: undefined,
+        },
+      ],
+      resolver: undefined,
+    });
+  });
+});
+
+describe('getAuthorization', () => {
+  let mockContext: Context;
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance();
+  });
+
+  it('should return the appropriate roles and permissions for as primary', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const boundFunc = getAuthorization.bind(proc);
+
+    expect(boundFunc({ asPrimary: true, multiSig: entityMockUtils.getMultiSigInstance() })).toEqual(
+      {
+        permissions: {
+          transactions: [TxTags.multiSig.MakeMultisigPrimary],
+          assets: [],
+          portfolios: [],
+        },
+      }
+    );
+  });
+
+  it('should return the appropriate roles and permissions for as secondary', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const boundFunc = getAuthorization.bind(proc);
+
+    expect(
+      boundFunc({ asPrimary: false, multiSig: entityMockUtils.getMultiSigInstance() })
+    ).toEqual({
+      permissions: {
+        transactions: [TxTags.multiSig.MakeMultisigSecondary],
+        assets: [],
+        portfolios: [],
+      },
+    });
+  });
+
+  it('should return the appropriate roles and permissions for as secondary with permissions', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const boundFunc = getAuthorization.bind(proc);
+
+    expect(
+      boundFunc({
+        asPrimary: false,
+        multiSig: entityMockUtils.getMultiSigInstance(),
+        permissions: {},
+      })
+    ).toEqual({
+      permissions: {
+        transactions: [
+          TxTags.multiSig.MakeMultisigSecondary,
+          TxTags.identity.SetPermissionToSigner,
+        ],
+        assets: [],
+        portfolios: [],
+      },
+    });
+  });
+});

--- a/src/api/procedures/joinCreator.ts
+++ b/src/api/procedures/joinCreator.ts
@@ -1,0 +1,134 @@
+import { AccountId } from '@polkadot/types/interfaces';
+import { PolymeshPrimitivesSecondaryKeyPermissions } from '@polkadot/types/lookup';
+
+import { PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, JoinCreatorParams, MultiSig, TxTags } from '~/types';
+import {
+  BatchTransactionSpec,
+  ExtrinsicParams,
+  ProcedureAuthorization,
+  TransactionSpec,
+} from '~/types/internal';
+import {
+  bigNumberToU64,
+  permissionsLikeToPermissions,
+  permissionsToMeshPermissions,
+  stringToAccountId,
+} from '~/utils/conversion';
+import { assembleBatchTransactions, optionize } from '~/utils/internal';
+
+export type Params = { multiSig: MultiSig } & JoinCreatorParams;
+
+/**
+ * @hidden
+ */
+export async function prepareJoinCreator(
+  this: Procedure<Params, void>,
+  args: Params
+): Promise<
+  | TransactionSpec<void, ExtrinsicParams<'multiSig', 'makeMultisigPrimary'>>
+  | TransactionSpec<void, ExtrinsicParams<'multiSig', 'makeMultisigSecondary'>>
+  | BatchTransactionSpec<void, unknown[][]>
+> {
+  const {
+    context,
+    context: {
+      polymeshApi: { tx },
+    },
+  } = this;
+  const { multiSig, asPrimary } = args;
+
+  const [signingIdentity, creator] = await Promise.all([
+    context.getSigningIdentity(),
+    multiSig.getCreator(),
+  ]);
+
+  if (!creator.isEqual(signingIdentity)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message:
+        'A MultiSig can only be join its creator. Instead `accountManagement.inviteAccount` can be used, and the resulting auth accepted',
+      data: { creatorDid: creator.did, signingDid: signingIdentity.did },
+    });
+  }
+
+  const rawMultiSigId = stringToAccountId(multiSig.address, context);
+
+  if (asPrimary) {
+    const rawCddAuthIdOpt = optionize(bigNumberToU64)(args.cddAuthId, context);
+    return {
+      transaction: tx.multiSig.makeMultisigPrimary,
+      args: [rawMultiSigId, rawCddAuthIdOpt],
+      resolver: undefined,
+    };
+  }
+
+  const { permissions } = args;
+
+  if (!permissions) {
+    return {
+      transaction: tx.multiSig.makeMultisigSecondary,
+      args: [rawMultiSigId],
+      resolver: undefined,
+    };
+  }
+
+  const parsedPermissions = permissionsLikeToPermissions(permissions, context);
+  const rawPermissions = permissionsToMeshPermissions(parsedPermissions, context);
+
+  const makeSecondaryArgs: [AccountId] = [rawMultiSigId];
+  const permissionsArgs: [AccountId, PolymeshPrimitivesSecondaryKeyPermissions] = [
+    rawMultiSigId,
+    rawPermissions,
+  ];
+
+  const makeTx = {
+    transaction: tx.multiSig.makeMultisigSecondary,
+    argsArray: [makeSecondaryArgs],
+  };
+
+  const permissionTx = {
+    transaction: tx.identity.setSecondaryKeyPermissions,
+    argsArray: [permissionsArgs],
+  };
+
+  const transactions = assembleBatchTransactions([makeTx, permissionTx] as const);
+
+  return {
+    transactions,
+    resolver: undefined,
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void>,
+  args: Params
+): ProcedureAuthorization {
+  const { asPrimary } = args;
+  const transactions = [];
+  if (asPrimary) {
+    transactions.push(TxTags.multiSig.MakeMultisigPrimary);
+  } else {
+    transactions.push(TxTags.multiSig.MakeMultisigSecondary);
+    if (args.permissions) {
+      transactions.push(TxTags.identity.SetPermissionToSigner);
+    }
+  }
+
+  return {
+    permissions: {
+      transactions,
+      assets: [],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const joinCreator = (): Procedure<Params, void> =>
+  new Procedure(prepareJoinCreator, getAuthorization);

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1574,6 +1574,21 @@ export interface ModifyMultiSigParams {
   signers: Signer[];
 }
 
+interface JoinCreatorAsPrimary {
+  asPrimary: true;
+  cddAuthId?: BigNumber;
+}
+
+interface JoinCreatorAsSecondary {
+  asPrimary?: false;
+  /**
+   * (optional) Permissions to grant the MultiSig. Defaults to none
+   */
+  permissions?: PermissionsLike;
+}
+
+export type JoinCreatorParams = JoinCreatorAsPrimary | JoinCreatorAsSecondary;
+
 export type SetMetadataParams =
   | { value: string; details?: MetadataValueDetails }
   | { details: MetadataValueDetails };

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -169,3 +169,4 @@ export { toggleTickerPreApproval } from '~/api/procedures/toggleTickerPreApprova
 export { allowIdentityToCreatePortfolios } from '~/api/procedures/allowIdentityToCreatePortfolios';
 export { revokeIdentityToCreatePortfolios } from '~/api/procedures/revokeIdentityToCreatePortfolios';
 export { rotatePrimaryKeyToSecondary } from '~/api/procedures/rotatePrimaryKeyToSecondary';
+export { joinCreator } from '~/api/procedures/joinCreator';


### PR DESCRIPTION
### Description

allows multiSig to directly join creator identity without the need for accepting an authorization

### Breaking Changes

None

### JIRA Link

✅ Closes: [DA-1250](https://polymesh.atlassian.net/browse/DA-1250)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1250]: https://polymesh.atlassian.net/browse/DA-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ