### PR TITLE
fix: 🐛 throw catchable connect errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![js-semistandard-style](https://img.shields.io/badge/code%20style-semistandard-brightgreen.svg?style=flat-square)](https://github.com/standard/semistandard)
-[![Types](https://img.shields.io/npm/types/@polymeshassociation/polymesh-sdk)](https://)
+[![Types](https://img.shields.io/npm/types/@polymeshassociation/polymesh-sdk)](https://www.npmjs.com/package/@polymeshassociation/polymesh-sdk)
 [![npm](https://img.shields.io/npm/v/@polymeshassociation/polymesh-sdk)](https://www.npmjs.com/package/@polymeshassociation/polymesh-sdk)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=PolymeshAssociation_polymesh-sdk&metric=coverage)](https://sonarcloud.io/summary/new_code?id=PolymeshAssociation_polymesh-sdk)

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -20,9 +20,9 @@ import {
 import { signerToString } from '~/utils/conversion';
 import {
   assertExpectedChainVersion,
-  assertExpectedSqVersion,
   createProcedureMethod,
   extractProtocol,
+  warnUnexpectedSqVersion,
 } from '~/utils/internal';
 
 import { AccountManagement } from './AccountManagement';
@@ -151,8 +151,7 @@ export class Polymesh {
 
     const { metadata, noInitWarn, typesBundle } = polkadot ?? {};
 
-    // Defer `await` on any checks to minimize total startup time
-    const requiredChecks: Promise<void>[] = [assertExpectedChainVersion(nodeUrl)];
+    await assertExpectedChainVersion(nodeUrl);
 
     try {
       const { types, rpc, signedExtensions, runtime } = schema;
@@ -212,10 +211,8 @@ export class Polymesh {
         }
       };
 
-      requiredChecks.push(checkMiddleware(), assertExpectedSqVersion(context));
+      await Promise.all([checkMiddleware(), warnUnexpectedSqVersion(context)]);
     }
-
-    await Promise.all(requiredChecks);
 
     return new Polymesh(context);
   }

--- a/src/api/client/__tests__/Polymesh.ts
+++ b/src/api/client/__tests__/Polymesh.ts
@@ -51,7 +51,7 @@ describe('Polymesh Class', () => {
       .mockClear()
       .mockImplementation()
       .mockResolvedValue(undefined);
-    jest.spyOn(internalUtils, 'assertExpectedSqVersion').mockImplementation();
+    jest.spyOn(internalUtils, 'warnUnexpectedSqVersion').mockImplementation();
     dsMockUtils.configureMocks({ contextOptions: undefined });
   });
 

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -77,7 +77,6 @@ import {
   asNftId,
   assertAddressValid,
   assertExpectedChainVersion,
-  assertExpectedSqVersion,
   assertIdentityExists,
   assertIsInteger,
   assertIsPositive,
@@ -117,6 +116,7 @@ import {
   serialize,
   sliceBatchReceipt,
   unserialize,
+  warnUnexpectedSqVersion,
 } from '../internal';
 
 jest.mock(
@@ -1151,7 +1151,7 @@ describe('getExemptedIds', () => {
   });
 });
 
-describe('assertExpectedSqVersion', () => {
+describe('warnUnexpectedSqVersion', () => {
   let warnSpy: jest.SpyInstance;
   let context: MockContext;
 
@@ -1183,7 +1183,7 @@ describe('assertExpectedSqVersion', () => {
         ],
       },
     });
-    const promise = assertExpectedSqVersion(dsMockUtils.getContextInstance());
+    const promise = warnUnexpectedSqVersion(dsMockUtils.getContextInstance());
 
     await expect(promise).resolves.not.toThrow();
 
@@ -1200,7 +1200,7 @@ describe('assertExpectedSqVersion', () => {
         ],
       },
     });
-    await assertExpectedSqVersion(context);
+    await warnUnexpectedSqVersion(context);
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
@@ -1214,7 +1214,7 @@ describe('assertExpectedSqVersion', () => {
         nodes: [],
       },
     });
-    await assertExpectedSqVersion(context);
+    await warnUnexpectedSqVersion(context);
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -1412,7 +1412,7 @@ function assertExpectedSpecVersion(
  *
  * Checks SQ version compatibility with the SDK
  */
-export async function assertExpectedSqVersion(context: Context): Promise<void> {
+export async function warnUnexpectedSqVersion(context: Context): Promise<void> {
   const {
     data: {
       subqueryVersions: {


### PR DESCRIPTION
### Description

`Polymesh.connect` throws catchable connect errors. Previously it would crash on node, or clutter the console with `Abnormal closure` in the browser

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

✅ Closes: [DA-1251](https://polymesh.atlassian.net/browse/DA-1251)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1251]: https://polymesh.atlassian.net/browse/DA-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ