### PR TITLE
fix: 🐛 return MultiSig from getAccount with no signers

### DIFF
--- a/src/api/client/__tests__/AccountManagement.ts
+++ b/src/api/client/__tests__/AccountManagement.ts
@@ -206,8 +206,8 @@ describe('AccountManagement class', () => {
 
     it('should return an Account object with the passed address', async () => {
       const params = { address: 'testAddress' };
-      dsMockUtils.createQueryMock('multiSig', 'multiSigSigners', {
-        returnValue: [],
+      dsMockUtils.createQueryMock('multiSig', 'multiSigToIdentity', {
+        returnValue: dsMockUtils.createMockIdentityId(),
       });
 
       const result = await accountManagement.getAccount(params);
@@ -218,8 +218,8 @@ describe('AccountManagement class', () => {
 
     it('should return a MultiSig instance if the address is for a MultiSig', async () => {
       const params = { address: 'testAddress' };
-      dsMockUtils.createQueryMock('multiSig', 'multiSigSigners', {
-        entries: [[['someSignerAddress'], 'someSignerAddress']],
+      dsMockUtils.createQueryMock('multiSig', 'multiSigToIdentity', {
+        returnValue: dsMockUtils.createMockIdentityId('someDid'),
       });
 
       const result = await accountManagement.getAccount(params);

--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -466,8 +466,8 @@ describe('Account class', () => {
 
   describe('method: isFrozen', () => {
     beforeAll(() => {
-      dsMockUtils.createQueryMock('multiSig', 'multiSigSigners', {
-        returnValue: [],
+      dsMockUtils.createQueryMock('multiSig', 'multiSigToIdentity', {
+        returnValue: dsMockUtils.createMockIdentityId(),
       });
     });
 

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -2103,10 +2103,10 @@ export async function getAccount(
   const { address } = args;
 
   const rawAddress = stringToAccountId(address, context);
-  const rawSigners = await multiSig.multiSigSigners.entries(rawAddress);
-  if (rawSigners.length > 0) {
-    return new MultiSig(args, context);
+  const identity = await multiSig.multiSigToIdentity(rawAddress);
+  if (identity.isEmpty) {
+    return new Account(args, context);
   }
 
-  return new Account(args, context);
+  return new MultiSig(args, context);
 }


### PR DESCRIPTION
### Description

previously a MultiSig with no signers would be mistaken for a regular account. This occurs when no account has accepted the authorization

### Breaking Changes

None

### JIRA Link

None

### Checklist

- [ ] Updated the Readme.md (if required) ?
