### PR TITLE
feat: 🎸 add `result` when submitting offline transactions

### DIFF
--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -217,13 +217,13 @@ export class Network {
 
     transaction.addSignature(payload.address, signature, payload);
 
-    if (context.supportsSubscription()) {
-      const submissionDetails: SubmissionDetails = {
-        blockHash: '',
-        transactionHash: transaction.hash.toString(),
-        transactionIndex: new BigNumber(0),
-      };
+    const submissionDetails: SubmissionDetails = {
+      blockHash: '',
+      transactionHash: transaction.hash.toString(),
+      transactionIndex: new BigNumber(-1),
+    } as SubmissionDetails;
 
+    if (context.supportsSubscription()) {
       return new Promise((resolve, reject) => {
         const gettingUnsub = transaction.send(receipt => {
           const { status } = receipt;
@@ -276,6 +276,7 @@ export class Network {
                 reject(error);
               });
             } else if (receipt.isFinalized) {
+              submissionDetails.result = receipt;
               finishing = Promise.all([unsubscribing]).then(() => {
                 resolve(submissionDetails);
               });
@@ -298,6 +299,7 @@ export class Network {
         blockHash: hashToString(result.status.asFinalized),
         transactionHash: hashToString(transaction.hash),
         transactionIndex: new BigNumber(result.txIndex!),
+        result,
       };
     }
   }

--- a/src/api/client/__tests__/Network.ts
+++ b/src/api/client/__tests__/Network.ts
@@ -551,7 +551,14 @@ describe('Network Class', () => {
       (context.polymeshApi as any).tx = jest.fn().mockReturnValue(transaction);
 
       const signature = '0x01';
-      await network.submitTransaction(mockPayload, signature);
+      const result = await network.submitTransaction(mockPayload, signature);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          transactionHash: '0x01',
+          result: expect.any(Object),
+        })
+      );
     });
 
     it('should handle non prefixed hex strings', async () => {
@@ -636,14 +643,21 @@ describe('Network Class', () => {
         status: dsMockUtils.createMockExtrinsicStatus({
           Finalized: dsMockUtils.createMockHash('blockHash'),
         }),
-        txHash: dsMockUtils.createMockHash('bond'),
+        txHash: dsMockUtils.createMockHash('txHash'),
         txIndex: 1,
       });
 
       jest.spyOn(baseUtils, 'pollForTransactionFinalization').mockResolvedValue(fakeReceipt);
 
       const signature = '0x01';
-      await network.submitTransaction(mockPayload, signature);
+      const result = await network.submitTransaction(mockPayload, signature);
+
+      expect(result).toEqual({
+        blockHash: 'blockHash',
+        transactionHash: '0x01',
+        transactionIndex: new BigNumber(1),
+        result: fakeReceipt,
+      });
     });
   });
 

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -1,4 +1,5 @@
 import { ApiOptions } from '@polkadot/api/types';
+import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
 import { TxTag } from '~/types';
@@ -46,6 +47,10 @@ export interface SubmissionDetails {
   blockHash: string;
   transactionIndex: BigNumber;
   transactionHash: string;
+  /**
+   * The raw result of the transaction. Contains event data for the transaction
+   */
+  result: ISubmittableResult;
 }
 
 /**


### PR DESCRIPTION
### Description

add `result: ISubmittable` to `SubmittableResult`, allowing consumers to read event data for their submitted transaction

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

[DA-1221](https://polymesh.atlassian.net/browse/DA-1221)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1221]: https://polymesh.atlassian.net/browse/DA-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ