### PR TITLE
fix: 🐛 allow reject a proposal by creator with no other votes + modify required signatures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     needs: [test]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-artifacts
           path: coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           mv coverage/coverage-final.json coverage/coverage-${{matrix.shard}}.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-artifacts
+          name: coverage-artifacts-${{ matrix.os }}-${{ strategy.job-index }}
           path: coverage/
 
   sonar:
@@ -57,7 +57,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-artifacts
+          pattern: coverage-artifacts-*
+          merge-multiple: true
           path: coverage
       - name: Process Coverage
         run: npx nyc report --reporter lcov --reporter text --reporter clover -t coverage
@@ -66,9 +67,9 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v5
         with:
-          name: coverage-artifacts
+          name: coverage-artifacts-*
           failOnError: false
 
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           mv coverage/clover.xml coverage/clover-${{matrix.shard}}.xml
           mv coverage/lcov.info coverage/lcov-${{matrix.shard}}.info
           mv coverage/coverage-final.json coverage/coverage-${{matrix.shard}}.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts
           path: coverage/

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "typedoc-github-wiki-theme": "^1.0.1",
     "typedoc-plugin-markdown": "3.17.1",
     "typescript": "4.6.2",
-    "webpack": "^5.88.2",
+    "webpack": "5.94.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4",
     "websocket-as-promised": "^2.0.1"

--- a/src/api/entities/Account/MultiSig/index.ts
+++ b/src/api/entities/Account/MultiSig/index.ts
@@ -223,7 +223,10 @@ export class MultiSig extends Account {
   /**
    * Modify the signers for the MultiSig. The signing Account must belong to the Identity of the creator of the MultiSig
    */
-  public modify: ProcedureMethod<Pick<ModifyMultiSigParams, 'signers'>, void>;
+  public modify: ProcedureMethod<
+    Pick<ModifyMultiSigParams, 'signers' | 'requiredSignatures'>,
+    void
+  >;
 
   /**
    * Attach a MultiSig directly to the creator's identity. This method bypasses the usual authorization step to join an identity

--- a/src/api/procedures/__tests__/modifyMultiSig.ts
+++ b/src/api/procedures/__tests__/modifyMultiSig.ts
@@ -425,11 +425,9 @@ describe('modifyMultiSig procedure', () => {
         message: 'The number of required signatures should not exceed the number of signers',
       });
 
-      try {
-        assertRequiredSignersExceedsSigners(2, new BigNumber(2), undefined, new BigNumber(4));
-      } catch (error) {
-        expect(error).toEqual(expectedError);
-      }
+      expect(() =>
+        assertRequiredSignersExceedsSigners(2, new BigNumber(2), undefined, new BigNumber(4))
+      ).toThrow(expectedError);
     });
 
     it('should throw an error if the number of signers is less than required signatures', () => {
@@ -438,11 +436,9 @@ describe('modifyMultiSig procedure', () => {
         message: 'The number of signers should not be less than the number of required signatures',
       });
 
-      try {
-        assertRequiredSignersExceedsSigners(2, new BigNumber(3), [newSigner1, newSigner2]);
-      } catch (error) {
-        expect(error).toEqual(expectedError);
-      }
+      expect(() =>
+        assertRequiredSignersExceedsSigners(2, new BigNumber(3), [newSigner1, newSigner2])
+      ).toThrow(expectedError);
     });
 
     it('should throw an error if the number of signers is less than required signatures to be set', () => {
@@ -451,16 +447,14 @@ describe('modifyMultiSig procedure', () => {
         message: 'The number of signers should not be less than the number of required signatures',
       });
 
-      try {
+      expect(() =>
         assertRequiredSignersExceedsSigners(
           2,
           new BigNumber(2),
           [newSigner1, newSigner2],
           new BigNumber(3)
-        );
-      } catch (error) {
-        expect(error).toEqual(expectedError);
-      }
+        )
+      ).toThrow(expectedError);
     });
   });
 
@@ -472,11 +466,9 @@ describe('modifyMultiSig procedure', () => {
           'The given signers are equal to the current signers. At least one signer should be added or removed',
       });
 
-      try {
-        assertNoDataChange(new BigNumber(2), [], [], [oldSigner1, oldSigner2]);
-      } catch (error) {
-        expect(error).toEqual(expectedError);
-      }
+      expect(() => assertNoDataChange(new BigNumber(2), [], [], [oldSigner1, oldSigner2])).toThrow(
+        expectedError
+      );
     });
     it('should throw an error if required signatures to be set equals current', () => {
       const expectedError = new PolymeshError({
@@ -485,11 +477,9 @@ describe('modifyMultiSig procedure', () => {
           'The given required signatures are equal to the current required signatures. The number of required signatures should be different',
       });
 
-      try {
-        assertNoDataChange(new BigNumber(2), [], [], undefined, new BigNumber(2));
-      } catch (error) {
-        expect(error).toEqual(expectedError);
-      }
+      expect(() =>
+        assertNoDataChange(new BigNumber(2), [], [], undefined, new BigNumber(2))
+      ).toThrow(expectedError);
     });
   });
 
@@ -500,11 +490,7 @@ describe('modifyMultiSig procedure', () => {
         message: 'The number of required signatures should be at least 1',
       });
 
-      try {
-        assertValidRequiredSignatures(new BigNumber(0));
-      } catch (error) {
-        expect(error).toEqual(expectedError);
-      }
+      expect(() => assertValidRequiredSignatures(new BigNumber(0))).toThrow(expectedError);
     });
   });
 

--- a/src/api/procedures/evaluateMultiSigProposal.ts
+++ b/src/api/procedures/evaluateMultiSigProposal.ts
@@ -53,7 +53,12 @@ export async function prepareMultiSigProposalEvaluation(
 
   const rawSigner = signerToSignatory(signingAccount, context);
 
-  const [creator, { signers: multiSigSigners }, { status }, hasVoted] = await Promise.all([
+  const [
+    creator,
+    { signers: multiSigSigners },
+    { status, approvalAmount, rejectionAmount },
+    hasVoted,
+  ] = await Promise.all([
     proposal.multiSig.getCreator(),
     proposal.multiSig.details(),
     proposal.details(),
@@ -71,7 +76,9 @@ export async function prepareMultiSigProposalEvaluation(
     });
   }
 
-  if (boolToBoolean(hasVoted)) {
+  const totalVotes = approvalAmount.plus(rejectionAmount).toNumber();
+
+  if (boolToBoolean(hasVoted) && totalVotes > 1) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
       message: 'The signing Account has already voted for this MultiSig Proposal',

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1606,7 +1606,11 @@ export interface ModifyMultiSigParams {
   /**
    * The signers to set for the MultiSig
    */
-  signers: Signer[];
+  signers?: Signer[];
+  /**
+   * The required number of signatures for the MultiSig
+   */
+  requiredSignatures?: BigNumber;
 }
 
 interface JoinCreatorAsPrimary {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2333,7 +2333,7 @@
   resolved "https://registry.yarnpkg.com/@polymeshassociation/typedoc-theme/-/typedoc-theme-1.2.0.tgz#c5d548053301f5c1a2f1f1e0e8f8b475612f590d"
   integrity sha512-MeZlnm8l3TlkhPw3nY+7CY2CiOojg7PSAZ0QTmEtvf4pqUTlTGXCgdr8HfNdXAHN6fIGfR2PBKJqFyOh1sf5OQ==
 
-"@prettier/eslint@npm:prettier-eslint@^15.0.1":
+"@prettier/eslint@npm:prettier-eslint@^15.0.1", prettier-eslint@15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-15.0.1.tgz#2543a43e9acec2a9767ad6458165ce81f353db9c"
   integrity sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==
@@ -2674,15 +2674,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/eslint-scope@^3.7.3":
-  version "3.7.7"
-  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
-  integrity sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==
-  dependencies:
-    "@types/eslint" "*"
-    "@types/estree" "*"
-
-"@types/eslint@*", "@types/eslint@^8.4.2":
+"@types/eslint@^8.4.2":
   version "8.56.10"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.10.tgz#eb2370a73bf04a901eeba8f22595c7ee0f7eb58d"
   integrity sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==
@@ -3333,10 +3325,10 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
-  integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -5171,9 +5163,9 @@ electron-to-chromium@^1.4.668:
   integrity sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ==
 
 elliptic@^6.5.3, elliptic@^6.5.5:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.5.tgz#c715e09f78b6923977610d4c2346d6ce22e6dded"
-  integrity sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==
+  version "6.5.7"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
+  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"
@@ -5220,10 +5212,18 @@ encoding@^0.1.13:
   dependencies:
     iconv-lite "^0.6.2"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.16.0, enhanced-resolve@^5.7.0:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.7.0:
   version "5.16.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz#e8bc63d51b826d6f1cbc0a150ecb5a8b0c62e567"
   integrity sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
+enhanced-resolve@^5.17.1:
+  version "5.17.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz#67bfbbcc2f81d511be77d686a90267ef7f898a15"
+  integrity sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -9617,26 +9617,6 @@ prettier-eslint-cli@7.1.0:
     rxjs "^7.5.6"
     yargs "^13.1.1"
 
-prettier-eslint@15.0.1:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-15.0.1.tgz#2543a43e9acec2a9767ad6458165ce81f353db9c"
-  integrity sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==
-  dependencies:
-    "@types/eslint" "^8.4.2"
-    "@types/prettier" "^2.6.0"
-    "@typescript-eslint/parser" "^5.10.0"
-    common-tags "^1.4.0"
-    dlv "^1.1.0"
-    eslint "^8.7.0"
-    indent-string "^4.0.0"
-    lodash.merge "^4.6.0"
-    loglevel-colored-level-prefix "^1.0.0"
-    prettier "^2.5.1"
-    pretty-format "^23.0.1"
-    require-relative "^0.8.7"
-    typescript "^4.5.4"
-    vue-eslint-parser "^8.0.1"
-
 prettier@2.8.8, prettier@^2.5.1:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
@@ -10873,7 +10853,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10890,15 +10870,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -10951,7 +10922,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10971,13 +10942,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11941,21 +11905,20 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.88.2:
-  version "5.91.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.91.0.tgz#ffa92c1c618d18c878f06892bbdc3373c71a01d9"
-  integrity sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==
+webpack@5.94.0:
+  version "5.94.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.94.0.tgz#77a6089c716e7ab90c1c67574a28da518a20970f"
+  integrity sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==
   dependencies:
-    "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.5"
     "@webassemblyjs/ast" "^1.12.1"
     "@webassemblyjs/wasm-edit" "^1.12.1"
     "@webassemblyjs/wasm-parser" "^1.12.1"
     acorn "^8.7.1"
-    acorn-import-assertions "^1.9.0"
+    acorn-import-attributes "^1.9.5"
     browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.16.0"
+    enhanced-resolve "^5.17.1"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -12071,7 +12034,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12093,15 +12056,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Description

- allows a multiSig propoposal to be rejected by creator if no other votes have been casted
- allows modifying the required signatures for a multiSig

### Breaking Changes



### JIRA Link

https://polymesh.atlassian.net/browse/DA-1288

