### PR TITLE
fix: 🐛 v7 multiSig errors by using payer/admin over creator

### DIFF
--- a/src/api/entities/Account/MultiSig/index.ts
+++ b/src/api/entities/Account/MultiSig/index.ts
@@ -212,7 +212,7 @@ export class MultiSig extends Account {
   /**
    * Returns the Identity of the MultiSig admin. This Identity can add or remove signers directly without creating a MultiSigProposal first.
    */
-  public async getAdmin(): Promise<Identity> {
+  public async getAdmin(): Promise<Identity | null> {
     const {
       context: {
         polymeshApi: {
@@ -232,10 +232,7 @@ export class MultiSig extends Account {
     const rawAddress = addressToKey(address, context);
     const rawAdminDid = await multiSig.adminDid(rawAddress);
     if (rawAdminDid.isNone) {
-      throw new PolymeshError({
-        code: ErrorCode.DataUnavailable,
-        message: 'No creator was found for this MultiSig address',
-      });
+      return null;
     }
 
     const did = identityIdToString(rawAdminDid.unwrap());
@@ -244,7 +241,7 @@ export class MultiSig extends Account {
   }
 
   /**
-   * Returns the payer for the MultiSig. If set
+   * Returns the payer for the MultiSig, if set the primary account of the identity will pay for any fees the MultiSig may incur
    */
   public async getPayer(): Promise<Identity | null> {
     const {

--- a/src/api/entities/Account/__tests__/MultiSig.ts
+++ b/src/api/entities/Account/__tests__/MultiSig.ts
@@ -285,9 +285,7 @@ describe('MultiSig class', () => {
         returnValue: createMockOption(),
       });
 
-      return expect(multiSig.getAdmin()).rejects.toThrow(
-        'No creator was found for this MultiSig address'
-      );
+      return expect(multiSig.getAdmin()).resolves.toBeNull();
     });
   });
 

--- a/src/api/procedures/__tests__/evaluateMultiSigProposal.ts
+++ b/src/api/procedures/__tests__/evaluateMultiSigProposal.ts
@@ -95,6 +95,8 @@ describe('evaluateMultiSigProposal', () => {
       multiSig: entityMockUtils.getMultiSigInstance({
         address: multiSigAddress,
         getCreator: creator,
+        getPayer: creator,
+        getAdmin: creator,
         details: {
           signers: [
             new Account({ address: 'someAddress' }, mockContext),
@@ -213,6 +215,7 @@ describe('evaluateMultiSigProposal', () => {
           multiSig: entityMockUtils.getMultiSigInstance({
             address: multiSigAddress,
             getCreator: creator,
+            getPayer: creator,
             details: {
               signers: [
                 new Account({ address: 'someAddress' }, mockContext),

--- a/src/api/procedures/__tests__/linkTickerToAsset.ts
+++ b/src/api/procedures/__tests__/linkTickerToAsset.ts
@@ -5,6 +5,7 @@ import {
   getAuthorization,
   Params,
   prepareLinkTickerToAsset,
+  prepareStorage,
   Storage,
 } from '~/api/procedures/linkTickerToAsset';
 import { Context, PolymeshError } from '~/internal';
@@ -124,12 +125,33 @@ describe('linkTickerToAsset procedure', () => {
   });
 
   it('should throw an error if the ticker is already linked', async () => {
-    mockContext.isV6 = true;
     const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
       status: TickerReservationStatus.AssetCreated,
     });
 
     return expect(prepareLinkTickerToAsset.call(proc, args)).rejects.toThrow(PolymeshError);
+  });
+
+  describe('prepareStorage', () => {
+    it('should return the ticker reservations status', async () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        status: TickerReservationStatus.AssetCreated,
+      });
+      entityMockUtils.configureMocks({
+        tickerReservationOptions: {
+          details: { status: TickerReservationStatus.Reserved },
+        },
+      });
+
+      const boundFunc = prepareStorage.bind(proc);
+
+      const result = await boundFunc({
+        ticker: 'TICKER',
+        asset: entityMockUtils.getFungibleAssetInstance(),
+      });
+
+      expect(result).toEqual({ status: TickerReservationStatus.Reserved });
+    });
   });
 
   describe('getAuthorization', () => {

--- a/src/api/procedures/__tests__/modifyMultiSig.ts
+++ b/src/api/procedures/__tests__/modifyMultiSig.ts
@@ -128,10 +128,10 @@ describe('modifyMultiSig procedure', () => {
     return expect(prepareModifyMultiSig.call(proc, args)).rejects.toThrowError(expectedError);
   });
 
-  it('should throw an error if called by someone who is not the creator', () => {
+  it('should throw an error if called by someone who is not the admin', () => {
     const args = {
       multiSig: entityMockUtils.getMultiSigInstance({
-        getCreator: getIdentityInstance({ isEqual: false }),
+        getAdmin: getIdentityInstance({ isEqual: false }),
       }),
       signers: [getAccountInstance()],
     };
@@ -147,7 +147,7 @@ describe('modifyMultiSig procedure', () => {
 
     const expectedError = new PolymeshError({
       code: ErrorCode.ValidationError,
-      message: 'A MultiSig can only be modified by its creator',
+      message: 'A MultiSig can only be modified by its admin',
     });
 
     return expect(prepareModifyMultiSig.call(proc, args)).rejects.toThrowError(expectedError);

--- a/src/api/procedures/evaluateMultiSigProposal.ts
+++ b/src/api/procedures/evaluateMultiSigProposal.ts
@@ -57,8 +57,8 @@ export async function prepareMultiSigProposalEvaluation(
     ? signerToSignatory(signingAccount, context)
     : stringToAccountId(signingAccount.address, context);
 
-  const [creator, { signers: multiSigSigners }, { status }, hasVoted] = await Promise.all([
-    proposal.multiSig.getCreator(), // NOSONAR
+  const [payer, { signers: multiSigSigners }, { status }, hasVoted] = await Promise.all([
+    proposal.multiSig.getPayer(),
     proposal.multiSig.details(),
     proposal.details(),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -125,7 +125,7 @@ export async function prepareMultiSigProposalEvaluation(
 
   return {
     transaction,
-    paidForBy: creator,
+    paidForBy: payer ?? undefined,
     args: [rawMultiSigAddress, rawProposalId],
     resolver: undefined,
   };

--- a/src/api/procedures/modifyMultiSig.ts
+++ b/src/api/procedures/modifyMultiSig.ts
@@ -46,9 +46,9 @@ export async function prepareModifyMultiSig(
   } = this;
   const { signers, multiSig } = args;
 
-  const [signingIdentity, creator] = await Promise.all([
+  const [signingIdentity, admin] = await Promise.all([
     context.getSigningIdentity(),
-    multiSig.getCreator(), // NOSONAR
+    multiSig.getAdmin(),
   ]);
 
   if (!signersToAdd.length && !signersToRemove.length) {
@@ -58,10 +58,10 @@ export async function prepareModifyMultiSig(
         'The given signers are equal to the current signers. At least one signer should be added or removed',
     });
   }
-  if (!creator.isEqual(signingIdentity)) {
+  if (!admin || !admin.isEqual(signingIdentity)) {
     throw new PolymeshError({
       code: ErrorCode.ValidationError,
-      message: 'A MultiSig can only be modified by its creator',
+      message: 'A MultiSig can only be modified by its admin',
     });
   }
 

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -943,14 +943,21 @@ export abstract class PolymeshTransactionBase<
 
     // For MultiSig the fees come from the creator's primary key
     if (multiSig) {
-      const multiId = await multiSig.getCreator(); // NOSONAR
+      const multiId = await multiSig.getPayer();
 
-      const { account } = await multiId.getPrimaryAccount();
+      if (multiId) {
+        const { account } = await multiId.getPrimaryAccount();
 
-      return {
-        account,
-        type: PayingAccountType.MultiSigCreator,
-      };
+        return {
+          account,
+          type: PayingAccountType.MultiSigCreator,
+        };
+      } else {
+        return {
+          type: PayingAccountType.Caller,
+          account: multiSig,
+        };
+      }
     }
 
     const caller = context.getSigningAccount();

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -364,6 +364,8 @@ interface MultiSigOptions extends AccountOptions {
   address?: string;
   details?: { signers: Signer[]; requiredSignatures: BigNumber };
   getCreator?: EntityGetter<Identity>;
+  getAdmin?: EntityGetter<Identity | null>;
+  getPayer?: EntityGetter<Identity | null>;
 }
 interface MultiSigProposalOptions extends EntityOptions {
   id?: BigNumber;
@@ -2027,6 +2029,8 @@ const MockMultiSigClass = createMockEntityClass<MultiSigOptions>(
     checkPermissions!: jest.Mock;
     details!: jest.Mock;
     getCreator!: jest.Mock;
+    getAdmin!: jest.Mock;
+    getPayer!: jest.Mock;
 
     /**
      * @hidden
@@ -2050,6 +2054,8 @@ const MockMultiSigClass = createMockEntityClass<MultiSigOptions>(
       this.checkPermissions = createEntityGetterMock(opts.checkPermissions);
       this.details = createEntityGetterMock(opts.details);
       this.getCreator = createEntityGetterMock(opts.getCreator);
+      this.getAdmin = createEntityGetterMock(opts.getAdmin);
+      this.getPayer = createEntityGetterMock(opts.getPayer);
     }
   },
   () => ({
@@ -2072,6 +2078,8 @@ const MockMultiSigClass = createMockEntityClass<MultiSigOptions>(
       requiredSignatures: new BigNumber(0),
     },
     getCreator: getIdentityInstance(),
+    getAdmin: getIdentityInstance(),
+    getPayer: getIdentityInstance(),
     authorizationsGetReceived: [],
     authorizationsGetOne: getAuthorizationRequestInstance(),
     getMultiSig: null,


### PR DESCRIPTION
### Description

fix issues when creating proposals due to some calls not being updated to the getAdmin/getPayer calls vs legacy getCreator call

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
