### PR TITLE
fix: 🐛 allow joined account to accept rotate to secondary auth

### DIFF
--- a/src/api/procedures/__tests__/consumeJoinOrRotateAuthorization.ts
+++ b/src/api/procedures/__tests__/consumeJoinOrRotateAuthorization.ts
@@ -121,6 +121,11 @@ describe('consumeJoinOrRotateAuthorization procedure', () => {
   });
 
   it('should throw an error if the target Account is already part of an Identity', () => {
+    targetAccount = entityMockUtils.getAccountInstance({
+      address: targetAddress,
+      getIdentity: entityMockUtils.getIdentityInstance({ isEqual: false }),
+    });
+
     const proc = procedureMockUtils.getInstance<
       ConsumeJoinOrRotateAuthorizationParams,
       void,

--- a/src/api/procedures/__tests__/utils.ts
+++ b/src/api/procedures/__tests__/utils.ts
@@ -1024,7 +1024,7 @@ describe('authorization request validations', () => {
     it('should throw if the target already has an Identity', () => {
       const mockIssuer = entityMockUtils.getIdentityInstance({ hasValidCdd: true });
       const mockTarget = entityMockUtils.getAccountInstance({
-        getIdentity: entityMockUtils.getIdentityInstance(),
+        getIdentity: entityMockUtils.getIdentityInstance({ isEqual: false }),
       });
       const auth = new AuthorizationRequest(
         {
@@ -1045,6 +1045,25 @@ describe('authorization request validations', () => {
       return expect(assertAuthorizationRequestValid(auth, mockContext)).rejects.toThrowError(
         expectedError
       );
+    });
+
+    it('should not throw if the target is already associated to the identity', () => {
+      const mockIssuer = entityMockUtils.getIdentityInstance({ hasValidCdd: true });
+      const mockTarget = entityMockUtils.getAccountInstance({
+        getIdentity: entityMockUtils.getIdentityInstance({ isEqual: true }),
+      });
+      const auth = new AuthorizationRequest(
+        {
+          authId: new BigNumber(1),
+          target: mockTarget,
+          issuer: mockIssuer,
+          expiry,
+          data,
+        },
+        mockContext
+      );
+
+      return expect(assertAuthorizationRequestValid(auth, mockContext)).resolves.not.toThrow();
     });
   });
 
@@ -1450,7 +1469,7 @@ describe('authorization request validations', () => {
     it('should throw if the target already has an Identity', () => {
       const mockIssuer = entityMockUtils.getIdentityInstance({ hasValidCdd: true });
       const unavailableTarget = entityMockUtils.getAccountInstance({
-        getIdentity: entityMockUtils.getIdentityInstance(),
+        getIdentity: entityMockUtils.getIdentityInstance({ isEqual: false }),
       });
       const auth = new AuthorizationRequest(
         {

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1613,12 +1613,12 @@ export interface ModifyMultiSigParams {
   requiredSignatures?: BigNumber;
 }
 
-interface JoinCreatorAsPrimary {
+export interface JoinCreatorAsPrimary {
   asPrimary: true;
   cddAuthId?: BigNumber;
 }
 
-interface JoinCreatorAsSecondary {
+export interface JoinCreatorAsSecondary {
   asPrimary?: false;
   /**
    * (optional) Permissions to grant the MultiSig. Defaults to none

--- a/src/api/procedures/utils.ts
+++ b/src/api/procedures/utils.ts
@@ -537,16 +537,19 @@ async function assertJoinOrRotateAuthorizationValid(
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
       message: 'Issuing Identity does not have a valid CDD claim',
+      data: { issuer: issuer.did },
     });
   }
 
   assertIsAccount(target);
 
   const targetIdentity = await target.getIdentity();
-  if (targetIdentity) {
+
+  if (targetIdentity && !targetIdentity.isEqual(issuer)) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
       message: 'The target Account already has an associated Identity',
+      data: { associatedIdentity: targetIdentity.did },
     });
   }
 }


### PR DESCRIPTION
### Description

previously the auth `rotatePrimaryKeyToSecondary` was unable to be accepted by a key already joined to the identity, although it is allowed by the chain

### Breaking Changes

None

### JIRA Link

✅ Closes: DA-1310

### Checklist

- [ ] Updated the Readme.md (if required) ?
