### PR TITLE
fix: 🐛 revert `createdAt` being nullable

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -411,7 +411,6 @@ describe('Instruction class', () => {
       queryMultiMock.mockResolvedValueOnce([
         dsMockUtils.createMockInstruction({
           ...rawInstructionDetails,
-          createdAt: dsMockUtils.createMockOption(),
           tradeDate: dsMockUtils.createMockOption(),
           valueDate: dsMockUtils.createMockOption(),
           settlementType: rawSettlementType,
@@ -424,7 +423,7 @@ describe('Instruction class', () => {
 
       expect(result).toMatchObject({
         status,
-        createdAt: null,
+        createdAt,
         tradeDate: null,
         valueDate: null,
         type,

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -333,7 +333,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
 
     return {
       status,
-      createdAt: createdAt.isSome ? momentToDate(createdAt.unwrap()) : null,
+      createdAt: momentToDate(createdAt.unwrap()),
       tradeDate: tradeDate.isSome ? momentToDate(tradeDate.unwrap()) : null,
       valueDate: valueDate.isSome ? momentToDate(valueDate.unwrap()) : null,
       venue: venueId.isSome ? new Venue({ id: u64ToBigNumber(venueId.unwrap()) }, context) : null,

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -39,7 +39,7 @@ export type InstructionEndCondition =
 
 export type InstructionDetails = {
   status: InstructionStatus;
-  createdAt: Date | null;
+  createdAt: Date;
   /**
    * Date at which the trade was agreed upon (optional, for offchain trades)
    */


### PR DESCRIPTION
### Description

This means the method will throw if ran on an executed instruction, but we remain API compatible.

The field should be nullable since when its properly checked the method works as expected.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
