### PR TITLE
refactor: 💡 export InstructionStatusEnum as value, not as type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,4 +28,4 @@ export {
 export { ClaimScopeTypeEnum, MiddlewareScope, SettlementDirectionEnum } from '~/middleware/typesV1';
 export { CountryCode, ModuleName, TxTag, TxTags };
 
-export type SettlementResultEnum = InstructionStatusEnum;
+export { InstructionStatusEnum as SettlementResultEnum };


### PR DESCRIPTION
### Description

allow users to reference values of InstructionStatusEnum by exporting it as a value instead of only the type

### Breaking Changes

None

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
