### PR TITLE
fix: 🐛 allow asset requirements with custom types to be read

### DIFF
--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -2770,15 +2770,7 @@ export const createMockClaim = (
       }
     | { Exempted: PolymeshPrimitivesIdentityClaimScope }
     | { Blocked: PolymeshPrimitivesIdentityClaimScope }
-  // | {
-  //     InvestorUniqueness: [
-  //       PolymeshPrimitivesIdentityClaimScope,
-  //       PolymeshPrimitivesIdentityId,
-  //       PolymeshPrimitivesCddId
-  //     ];
-  //   }
-  // | { InvestorUniquenessV2: PolymeshPrimitivesCddId }
-  // | 'NoData'
+    | { Custom: [u32, Option<PolymeshPrimitivesIdentityClaimScope>] }
 ): PolymeshPrimitivesIdentityClaimClaim =>
   createMockEnum<PolymeshPrimitivesIdentityClaimClaim>(claim);
 

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -4028,7 +4028,32 @@ describe('claimToMeshClaim and meshClaimToClaim', () => {
 
       result = meshClaimToClaim(claim);
       expect(result).toEqual(fakeResult);
+
+      const customClaimTypeId = new BigNumber(1);
+      fakeResult = {
+        type: ClaimType.Custom,
+        customClaimTypeId,
+        scope,
+      };
+
+      claim = dsMockUtils.createMockClaim({
+        Custom: [
+          dsMockUtils.createMockU32(customClaimTypeId),
+          dsMockUtils.createMockOption(
+            dsMockUtils.createMockScope({ Identity: dsMockUtils.createMockIdentityId(scope.value) })
+          ),
+        ],
+      });
+
+      result = meshClaimToClaim(claim);
+      expect(result).toEqual(fakeResult);
     });
+  });
+
+  it('should throw an error with an unknown type', () => {
+    expect(() => meshClaimToClaim({} as PolymeshPrimitivesIdentityClaimClaim)).toThrow(
+      UnreachableCaseError
+    );
   });
 });
 
@@ -4242,6 +4267,19 @@ describe('meshClaimTypeToClaimType and claimTypeToMeshClaimType', () => {
 
       result = meshClaimTypeToClaimType(claimType);
       expect(result).toEqual(fakeResult);
+
+      fakeResult = ClaimType.Custom;
+
+      claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+      result = meshClaimTypeToClaimType(claimType);
+      expect(result).toEqual(fakeResult);
+    });
+
+    it('should throw an error if it unparses an unknown type', () => {
+      expect(() =>
+        meshClaimTypeToClaimType({} as unknown as PolymeshPrimitivesIdentityClaimClaimType)
+      ).toThrow(UnreachableCaseError);
     });
   });
 

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -2288,7 +2288,8 @@ export function middlewareEventDetailsToEventIdentifier(
  * @hidden
  */
 export function meshClaimToClaim(claim: PolymeshPrimitivesIdentityClaimClaim): Claim {
-  if (claim.isJurisdiction) {
+  const type = claim.type;
+  if (type === 'Jurisdiction') {
     const [code, scope] = claim.asJurisdiction;
     return {
       type: ClaimType.Jurisdiction,
@@ -2297,59 +2298,72 @@ export function meshClaimToClaim(claim: PolymeshPrimitivesIdentityClaimClaim): C
     };
   }
 
-  if (claim.isAccredited) {
+  if (type === 'Accredited') {
     return {
       type: ClaimType.Accredited,
       scope: meshScopeToScope(claim.asAccredited),
     };
   }
 
-  if (claim.isAffiliate) {
+  if (type === 'Affiliate') {
     return {
       type: ClaimType.Affiliate,
       scope: meshScopeToScope(claim.asAffiliate),
     };
   }
 
-  if (claim.isBuyLockup) {
+  if (type === 'BuyLockup') {
     return {
       type: ClaimType.BuyLockup,
       scope: meshScopeToScope(claim.asBuyLockup),
     };
   }
 
-  if (claim.isSellLockup) {
+  if (type === 'SellLockup') {
     return {
       type: ClaimType.SellLockup,
       scope: meshScopeToScope(claim.asSellLockup),
     };
   }
 
-  if (claim.isCustomerDueDiligence) {
+  if (type === 'CustomerDueDiligence') {
     return {
       type: ClaimType.CustomerDueDiligence,
       id: cddIdToString(claim.asCustomerDueDiligence),
     };
   }
 
-  if (claim.isKnowYourCustomer) {
+  if (type === 'KnowYourCustomer') {
     return {
       type: ClaimType.KnowYourCustomer,
       scope: meshScopeToScope(claim.asKnowYourCustomer),
     };
   }
 
-  if (claim.isExempted) {
+  if (type === 'Exempted') {
     return {
       type: ClaimType.Exempted,
       scope: meshScopeToScope(claim.asExempted),
     };
   }
 
-  return {
-    type: ClaimType.Blocked,
-    scope: meshScopeToScope(claim.asBlocked),
-  };
+  if (type === 'Custom') {
+    const [rawId, scope] = claim.asCustom;
+    return {
+      type: ClaimType.Custom,
+      scope: meshScopeToScope(scope.unwrapOrDefault()),
+      customClaimTypeId: u32ToBigNumber(rawId),
+    };
+  }
+
+  if (type === 'Blocked') {
+    return {
+      type: ClaimType.Blocked,
+      scope: meshScopeToScope(claim.asBlocked),
+    };
+  }
+
+  throw new UnreachableCaseError(type);
 }
 
 /**
@@ -2389,39 +2403,48 @@ export function stringToTargetIdentity(
 export function meshClaimTypeToClaimType(
   claimType: PolymeshPrimitivesIdentityClaimClaimType
 ): ClaimType {
-  if (claimType.isJurisdiction) {
+  const type = claimType.type;
+  if (type === 'Jurisdiction') {
     return ClaimType.Jurisdiction;
   }
 
-  if (claimType.isAccredited) {
+  if (type === 'Accredited') {
     return ClaimType.Accredited;
   }
 
-  if (claimType.isAffiliate) {
+  if (type === 'Affiliate') {
     return ClaimType.Affiliate;
   }
 
-  if (claimType.isBuyLockup) {
+  if (type === 'BuyLockup') {
     return ClaimType.BuyLockup;
   }
 
-  if (claimType.isSellLockup) {
+  if (type === 'SellLockup') {
     return ClaimType.SellLockup;
   }
 
-  if (claimType.isCustomerDueDiligence) {
+  if (type === 'CustomerDueDiligence') {
     return ClaimType.CustomerDueDiligence;
   }
 
-  if (claimType.isKnowYourCustomer) {
+  if (type === 'KnowYourCustomer') {
     return ClaimType.KnowYourCustomer;
   }
 
-  if (claimType.isExempted) {
+  if (type === 'Exempted') {
     return ClaimType.Exempted;
   }
 
-  return ClaimType.Blocked;
+  if (type === 'Custom') {
+    return ClaimType.Custom;
+  }
+
+  if (type === 'Blocked') {
+    return ClaimType.Blocked;
+  }
+
+  throw new UnreachableCaseError(type);
 }
 
 /**


### PR DESCRIPTION
### Description

fixes an issue where compliance requirements using custom types would cause `asset.compliance.requirements.get()` to fail

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

✅ Closes: DA-1319

### Checklist

- [ ] Updated the Readme.md (if required) ?
