### PR TITLE
Fix runtime API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@polkadot/dev-ts": "^0.79.3",
     "@polkadot/typegen": "11.2.1",
     "@polymeshassociation/local-signing-manager": "^3.0.1",
-    "@polymeshassociation/polymesh-types": "^5.12.1",
+    "@polymeshassociation/polymesh-types": "^5.12.3",
     "@polymeshassociation/signing-manager-types": "^3.0.0",
     "@polymeshassociation/typedoc-theme": "^1.2.0",
     "@semantic-release/changelog": "^6.0.3",

--- a/src/api/entities/Asset/Base/Settlements/index.ts
+++ b/src/api/entities/Asset/Base/Settlements/index.ts
@@ -20,7 +20,6 @@ import {
   portfolioIdToMeshPortfolioId,
   portfolioIdToPortfolio,
   portfolioLikeToPortfolioId,
-  stringToIdentityId,
   stringToTicker,
 } from '~/utils/conversion';
 import { createProcedureMethod } from '~/utils/internal';
@@ -139,9 +138,9 @@ class BaseSettlements<T extends BaseAsset> extends Namespace<T> {
       amount = args.amount;
       ({ isDivisible } = await parent.details());
       granularResult = await assetApi.canTransferGranular<CanTransferGranularReturn>(
-        stringToIdentityId(fromCustodian.did, context),
+        fromCustodian.did,
         rawFromPortfolio,
-        stringToIdentityId(toCustodian.did, context),
+        toCustodian.did,
         rawToPortfolio,
         stringToTicker(ticker, context),
         bigNumberToBalance(amount, context, isDivisible)
@@ -150,9 +149,9 @@ class BaseSettlements<T extends BaseAsset> extends Namespace<T> {
       const rawNfts = nftToMeshNft(ticker, args.nfts, context);
       [granularResult, nftResult] = await Promise.all([
         assetApi.canTransferGranular<CanTransferGranularReturn>(
-          stringToIdentityId(fromCustodian.did, context),
+          fromCustodian.did,
           rawFromPortfolio,
-          stringToIdentityId(toCustodian.did, context),
+          toCustodian.did,
           rawToPortfolio,
           stringToTicker(ticker, context),
           bigNumberToBalance(amount, context, isDivisible)

--- a/src/polkadot/polymesh/definitions.ts
+++ b/src/polkadot/polymesh/definitions.ts
@@ -72,6 +72,54 @@ export default {
         version: 3,
       },
     ],
+    ComplianceApi: [
+      {
+        methods: {
+          compliance_report: {
+            description: 'Checks all compliance requirements for the given asset_id.',
+            params: [
+              {
+                name: 'assetId',
+                type: 'AssetID',
+              },
+              {
+                name: 'senderIdentity',
+                type: 'IdentityId',
+              },
+              {
+                name: 'receiverIdentity',
+                type: 'IdentityId',
+              },
+            ],
+            type: 'Result<ComplianceReport, DispatchError>',
+          },
+        },
+        version: 2,
+      },
+      {
+        methods: {
+          compliance_report: {
+            description: 'Checks all compliance requirements for the given ticker.',
+            params: [
+              {
+                name: 'ticker',
+                type: 'Ticker',
+              },
+              {
+                name: 'senderIdentity',
+                type: 'IdentityId',
+              },
+              {
+                name: 'receiverIdentity',
+                type: 'IdentityId',
+              },
+            ],
+            type: 'Result<ComplianceReport, DispatchError>',
+          },
+        },
+        version: 1,
+      },
+    ],
     GroupApi: [
       {
         methods: {
@@ -321,6 +369,60 @@ export default {
         version: 1,
       },
     ],
+    PipsApi: [
+      {
+        methods: {
+          get_votes: {
+            description: 'Summary of votes of a proposal given by index',
+            params: [
+              {
+                name: 'index',
+                type: 'PipId',
+              },
+            ],
+            type: 'VoteCount',
+          },
+          proposed_by: {
+            description: 'Retrieves proposal indices started by address',
+            params: [
+              {
+                name: 'address',
+                type: 'AccountId',
+              },
+            ],
+            type: 'Vec<PipId>',
+          },
+          voted_on: {
+            description: 'Retrieves proposal address indices voted on',
+            params: [
+              {
+                name: 'address',
+                type: 'AccountId',
+              },
+            ],
+            type: 'Vec<PipId>',
+          },
+        },
+        version: 1,
+      },
+    ],
+    ProtocolFeeApi: [
+      {
+        methods: {
+          compute_fee: {
+            description: 'Gets the fee of a chargeable extrinsic operation',
+            params: [
+              {
+                name: 'op',
+                type: 'ProtocolOp',
+              },
+            ],
+            type: 'CappedFee',
+          },
+        },
+        version: 1,
+      },
+    ],
     SettlementApi: [
       {
         methods: {
@@ -437,60 +539,6 @@ export default {
         version: 1,
       },
     ],
-    PipsApi: [
-      {
-        methods: {
-          get_votes: {
-            description: 'Summary of votes of a proposal given by index',
-            params: [
-              {
-                name: 'index',
-                type: 'PipId',
-              },
-            ],
-            type: 'VoteCount',
-          },
-          proposed_by: {
-            description: 'Retrieves proposal indices started by address',
-            params: [
-              {
-                name: 'address',
-                type: 'AccountId',
-              },
-            ],
-            type: 'Vec<PipId>',
-          },
-          voted_on: {
-            description: 'Retrieves proposal address indices voted on',
-            params: [
-              {
-                name: 'address',
-                type: 'AccountId',
-              },
-            ],
-            type: 'Vec<PipId>',
-          },
-        },
-        version: 1,
-      },
-    ],
-    ProtocolFeeApi: [
-      {
-        methods: {
-          compute_fee: {
-            description: 'Gets the fee of a chargeable extrinsic operation',
-            params: [
-              {
-                name: 'op',
-                type: 'ProtocolOp',
-              },
-            ],
-            type: 'CappedFee',
-          },
-        },
-        version: 1,
-      },
-    ],
     StakingApi: [
       {
         methods: {
@@ -498,54 +546,6 @@ export default {
             description: 'Retrieves curves parameters',
             params: [],
             type: 'Vec<(Perbill, Perbill)>',
-          },
-        },
-        version: 1,
-      },
-    ],
-    ComplianceApi: [
-      {
-        methods: {
-          compliance_report: {
-            description: 'Checks all compliance requirements for the given asset_id.',
-            params: [
-              {
-                name: 'assetId',
-                type: 'AssetID',
-              },
-              {
-                name: 'senderIdentity',
-                type: 'IdentityId',
-              },
-              {
-                name: 'receiverIdentity',
-                type: 'IdentityId',
-              },
-            ],
-            type: 'Result<ComplianceReport, DispatchError>',
-          },
-        },
-        version: 2,
-      },
-      {
-        methods: {
-          compliance_report: {
-            description: 'Checks all compliance requirements for the given ticker.',
-            params: [
-              {
-                name: 'ticker',
-                type: 'Ticker',
-              },
-              {
-                name: 'senderIdentity',
-                type: 'IdentityId',
-              },
-              {
-                name: 'receiverIdentity',
-                type: 'IdentityId',
-              },
-            ],
-            type: 'Result<ComplianceReport, DispatchError>',
           },
         },
         version: 1,
@@ -1198,6 +1198,7 @@ export default {
       authorizedBy: 'IdentityId',
       expiry: 'Option<Moment>',
       authId: 'u64',
+      count: 'u32',
     },
     AuthorizationData: {
       _enum: {

--- a/src/polkadot/polymesh/types.ts
+++ b/src/polkadot/polymesh/types.ts
@@ -230,6 +230,7 @@ export interface Authorization extends Struct {
   readonly authorizedBy: IdentityId;
   readonly expiry: Option<Moment>;
   readonly authId: u64;
+  readonly count: u32;
 }
 
 /** @name AuthorizationData */

--- a/src/polkadot/schema.ts
+++ b/src/polkadot/schema.ts
@@ -646,6 +646,7 @@ export default {
       authorizedBy: 'IdentityId',
       expiry: 'Option<Moment>',
       authId: 'u64',
+      count: 'u32',
     },
     AuthorizationData: {
       _enum: {
@@ -1696,6 +1697,54 @@ export default {
         version: 3,
       },
     ],
+    ComplianceApi: [
+      {
+        methods: {
+          compliance_report: {
+            description: 'Checks all compliance requirements for the given asset_id.',
+            params: [
+              {
+                name: 'assetId',
+                type: 'AssetID',
+              },
+              {
+                name: 'senderIdentity',
+                type: 'IdentityId',
+              },
+              {
+                name: 'receiverIdentity',
+                type: 'IdentityId',
+              },
+            ],
+            type: 'Result<ComplianceReport, DispatchError>',
+          },
+        },
+        version: 2,
+      },
+      {
+        methods: {
+          compliance_report: {
+            description: 'Checks all compliance requirements for the given ticker.',
+            params: [
+              {
+                name: 'ticker',
+                type: 'Ticker',
+              },
+              {
+                name: 'senderIdentity',
+                type: 'IdentityId',
+              },
+              {
+                name: 'receiverIdentity',
+                type: 'IdentityId',
+              },
+            ],
+            type: 'Result<ComplianceReport, DispatchError>',
+          },
+        },
+        version: 1,
+      },
+    ],
     GroupApi: [
       {
         methods: {
@@ -1945,6 +1994,60 @@ export default {
         version: 1,
       },
     ],
+    PipsApi: [
+      {
+        methods: {
+          get_votes: {
+            description: 'Summary of votes of a proposal given by index',
+            params: [
+              {
+                name: 'index',
+                type: 'PipId',
+              },
+            ],
+            type: 'VoteCount',
+          },
+          proposed_by: {
+            description: 'Retrieves proposal indices started by address',
+            params: [
+              {
+                name: 'address',
+                type: 'AccountId',
+              },
+            ],
+            type: 'Vec<PipId>',
+          },
+          voted_on: {
+            description: 'Retrieves proposal address indices voted on',
+            params: [
+              {
+                name: 'address',
+                type: 'AccountId',
+              },
+            ],
+            type: 'Vec<PipId>',
+          },
+        },
+        version: 1,
+      },
+    ],
+    ProtocolFeeApi: [
+      {
+        methods: {
+          compute_fee: {
+            description: 'Gets the fee of a chargeable extrinsic operation',
+            params: [
+              {
+                name: 'op',
+                type: 'ProtocolOp',
+              },
+            ],
+            type: 'CappedFee',
+          },
+        },
+        version: 1,
+      },
+    ],
     SettlementApi: [
       {
         methods: {
@@ -2061,60 +2164,6 @@ export default {
         version: 1,
       },
     ],
-    PipsApi: [
-      {
-        methods: {
-          get_votes: {
-            description: 'Summary of votes of a proposal given by index',
-            params: [
-              {
-                name: 'index',
-                type: 'PipId',
-              },
-            ],
-            type: 'VoteCount',
-          },
-          proposed_by: {
-            description: 'Retrieves proposal indices started by address',
-            params: [
-              {
-                name: 'address',
-                type: 'AccountId',
-              },
-            ],
-            type: 'Vec<PipId>',
-          },
-          voted_on: {
-            description: 'Retrieves proposal address indices voted on',
-            params: [
-              {
-                name: 'address',
-                type: 'AccountId',
-              },
-            ],
-            type: 'Vec<PipId>',
-          },
-        },
-        version: 1,
-      },
-    ],
-    ProtocolFeeApi: [
-      {
-        methods: {
-          compute_fee: {
-            description: 'Gets the fee of a chargeable extrinsic operation',
-            params: [
-              {
-                name: 'op',
-                type: 'ProtocolOp',
-              },
-            ],
-            type: 'CappedFee',
-          },
-        },
-        version: 1,
-      },
-    ],
     StakingApi: [
       {
         methods: {
@@ -2122,54 +2171,6 @@ export default {
             description: 'Retrieves curves parameters',
             params: [],
             type: 'Vec<(Perbill, Perbill)>',
-          },
-        },
-        version: 1,
-      },
-    ],
-    ComplianceApi: [
-      {
-        methods: {
-          compliance_report: {
-            description: 'Checks all compliance requirements for the given asset_id.',
-            params: [
-              {
-                name: 'assetId',
-                type: 'AssetID',
-              },
-              {
-                name: 'senderIdentity',
-                type: 'IdentityId',
-              },
-              {
-                name: 'receiverIdentity',
-                type: 'IdentityId',
-              },
-            ],
-            type: 'Result<ComplianceReport, DispatchError>',
-          },
-        },
-        version: 2,
-      },
-      {
-        methods: {
-          compliance_report: {
-            description: 'Checks all compliance requirements for the given ticker.',
-            params: [
-              {
-                name: 'ticker',
-                type: 'Ticker',
-              },
-              {
-                name: 'senderIdentity',
-                type: 'IdentityId',
-              },
-              {
-                name: 'receiverIdentity',
-                type: 'IdentityId',
-              },
-            ],
-            type: 'Result<ComplianceReport, DispatchError>',
           },
         },
         version: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,10 +2318,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.3.0"
 
-"@polymeshassociation/polymesh-types@^5.12.1":
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-types/-/polymesh-types-5.12.1.tgz#0b58567f3bd44a42a008060aab780b49741527ba"
-  integrity sha512-jTuHLCsuGenKNxhhjZo5LECq3vzsUEpQ5Q1WzImDOlPBx8kcowWRxNBny8VdKjgs9/VScAlW7qcXYvGu8fDXcA==
+"@polymeshassociation/polymesh-types@^5.12.3":
+  version "5.12.3"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-types/-/polymesh-types-5.12.3.tgz#cfb63728e3f5550bb1e113207dbaa59ff9d20107"
+  integrity sha512-DCMduGzhNwjgHVuCVZah5RFvjtYSrE4B0vsLO6Cf2iNQOKRxEOIyNbjEHO5c9RuLuObahCrYC1U49TpIIYbYbg==
 
 "@polymeshassociation/signing-manager-types@^3.0.0", "@polymeshassociation/signing-manager-types@^3.3.0":
   version "3.3.0"


### PR DESCRIPTION
### Description

- updated polymesh-types package to `5.12.3`
- regenerated types - added missing `count` paramater to `Authorization` type to fix decoding of `identityApi.getFilteredAuthorizations` responses
- removed conversion of portfolio custodian did to `PolymeshPrimitiveIdentityId` for `assetApi.canTransferGranular` calls as it required type for per the schema was `Option<IdentityId>` and did not accept `PolymeshPrimitiveIdentityId` as an acceptable type. The explicit conversion to a Codec type is not required.

### Breaking Changes

N/A

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
