### PR TITLE
chore: 🤖 use stats runtime API to get transfer restriction errs

### DIFF
--- a/src/api/entities/Account/MultiSig/index.ts
+++ b/src/api/entities/Account/MultiSig/index.ts
@@ -62,6 +62,7 @@ export class MultiSig extends Account {
       { getProcedureAndArgs: adminArgs => [setMultiSigAdmin, { multiSig: this, ...adminArgs }] },
       context
     );
+
     this.removePayer = createProcedureMethod(
       {
         getProcedureAndArgs: () => [removeMultiSigPayer, { multiSig: this }],
@@ -384,5 +385,5 @@ export class MultiSig extends Account {
    *
    * @deprecated this method is only available in v6 as in v7 the MultiSig is automatically attached to the creator's identity
    */
-  public joinCreator: OptionalArgsProcedureMethod<JoinCreatorParams, void> | (() => never);
+  public joinCreator: OptionalArgsProcedureMethod<JoinCreatorParams, void>;
 }

--- a/src/api/entities/Asset/__tests__/Base/Settlements.ts
+++ b/src/api/entities/Asset/__tests__/Base/Settlements.ts
@@ -10,7 +10,7 @@ import { when } from 'jest-when';
 
 import { FungibleSettlements, NonFungibleSettlements } from '~/api/entities/Asset/Base/Settlements';
 import { Context, Namespace, PolymeshTransaction } from '~/internal';
-import { ComplianceReport } from '~/polkadot/polymesh';
+import { ComplianceReport, TransferCondition } from '~/polkadot/polymesh';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import {
@@ -192,10 +192,24 @@ describe('Settlements class', () => {
           .createCallMock('complianceApi', 'complianceReport')
           .mockReturnValue(complianceReportResponse);
 
+        const statsReportResponse = 'statsReportResponse' as unknown as Result<
+          Vec<TransferCondition>,
+          DispatchError
+        >;
+        dsMockUtils
+          .createCallMock('statisticsApi', 'transferRestrictionsReport')
+          .mockReturnValue(statsReportResponse);
+
         const expected = 'breakdown' as unknown as TransferBreakdown;
 
         when(transferReportToTransferBreakdownSpy)
-          .calledWith(transferReportResponse, undefined, complianceReportResponse, mockContext)
+          .calledWith(
+            transferReportResponse,
+            undefined,
+            complianceReportResponse,
+            statsReportResponse,
+            mockContext
+          )
           .mockReturnValue(expected);
 
         const result = await settlements.canTransfer({ to: toDid, amount });
@@ -266,12 +280,6 @@ describe('Settlements class', () => {
         .createCallMock('nftApi', 'transferReport')
         .mockReturnValue(nftTransferReportResponse);
 
-      const transferReportResponse = 'transferReportResponse' as unknown as Vec<DispatchError>;
-
-      dsMockUtils
-        .createCallMock('assetApi', 'transferReport')
-        .mockReturnValue(transferReportResponse);
-
       const complianceReportResponse = 'complianceReportResponse' as unknown as Result<
         ComplianceReport,
         DispatchError
@@ -281,13 +289,23 @@ describe('Settlements class', () => {
         .createCallMock('complianceApi', 'complianceReport')
         .mockReturnValue(complianceReportResponse);
 
+      const statsReportResponse = 'statsReportResponse' as unknown as Result<
+        Vec<TransferCondition>,
+        DispatchError
+      >;
+
+      dsMockUtils
+        .createCallMock('statisticsApi', 'transferRestrictionsReport')
+        .mockReturnValue(statsReportResponse);
+
       const expected = 'breakdown' as unknown as TransferBreakdown;
 
       when(transferReportToTransferBreakdownSpy)
         .calledWith(
-          transferReportResponse,
+          undefined,
           nftTransferReportResponse,
           complianceReportResponse,
+          statsReportResponse,
           mockContext
         )
         .mockReturnValue(expected);

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -130,7 +130,7 @@ export interface TransferBreakdown {
   /**
    * how the transfer adheres to the asset's compliance rules
    */
-  compliance?: Compliance;
+  compliance: Compliance;
   /**
    * list of transfer restrictions and whether the transfer satisfies each one
    */

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -1995,6 +1995,37 @@ export const createMockBTreeSet = <T extends Codec>(
 /**
  * @hidden
  */
+export const createMockVec = <T extends Codec>(
+  items: Vec<T> | unknown[] = []
+): MockCodec<Vec<T>> => {
+  if (isCodec<Vec<T>>(items)) {
+    return items as MockCodec<Vec<T>>;
+  }
+
+  const codecItems = items.map(item => {
+    if (isCodec(item)) {
+      return item;
+    }
+
+    if (typeof item === 'string') {
+      return createMockStringCodec(item);
+    }
+
+    if (typeof item === 'number' || item instanceof BigNumber) {
+      return createMockNumberCodec(new BigNumber(item));
+    }
+
+    return createMockCodec(item, !item);
+  });
+
+  const res = createMockCodec(codecItems, !items);
+
+  return res as MockCodec<Vec<T>>;
+};
+
+/**
+ * @hidden
+ */
 export const createMockBTreeMap = <K extends Codec, V extends Codec>(
   items: BTreeMap<K, V> | Map<K, V> = new Map()
 ): MockCodec<BTreeMap<K, V>> => {

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -79,6 +79,7 @@ import {
   ComplianceReport,
   ExtrinsicPermissions,
   Permissions as MeshPermissions,
+  TransferCondition,
 } from 'polymesh-types/polymesh';
 
 import { UnreachableCaseError } from '~/api/procedures/utils';
@@ -3979,7 +3980,7 @@ describe('transferReportToTransferBreakdown', () => {
     const context = dsMockUtils.getContextInstance();
 
     let result = transferReportToTransferBreakdown(
-      [] as unknown as Vec<DispatchError>,
+      undefined,
       undefined,
       dsMockUtils.createMockDispatchResult({
         Ok: dsMockUtils.createMockAssetComplianceReport({
@@ -3988,6 +3989,9 @@ describe('transferReportToTransferBreakdown', () => {
           requirements: [],
         }),
       }) as unknown as Result<ComplianceReport, DispatchError>,
+      dsMockUtils.createMockDispatchResult({
+        Ok: dsMockUtils.createMockVec(),
+      }) as unknown as Result<Vec<TransferCondition>, DispatchError>,
       context
     );
 
@@ -4050,6 +4054,13 @@ describe('transferReportToTransferBreakdown', () => {
           requirements: [],
         }),
       }) as unknown as Result<ComplianceReport, DispatchError>,
+      dsMockUtils.createMockDispatchResult({
+        Ok: dsMockUtils.createMockVec([
+          dsMockUtils.createMockTransferCondition({
+            MaxInvestorCount: dsMockUtils.createMockU64(new BigNumber(100)),
+          }),
+        ]),
+      }) as unknown as Result<Vec<TransferCondition>, DispatchError>,
       context
     );
 
@@ -4059,7 +4070,12 @@ describe('transferReportToTransferBreakdown', () => {
         requirements: [],
         complies: false,
       },
-      restrictions: [],
+      restrictions: [
+        {
+          restriction: { type: TransferRestrictionType.Count, value: new BigNumber(100) },
+          result: true,
+        },
+      ],
       result: false,
     });
   });


### PR DESCRIPTION
### Description

Uses statistics runtime API to get transfer restriction errors in transferring an asset.

### Breaking Changes

NA

### JIRA Link

DA-1315

### Checklist

- [ ] Updated the Readme.md (if required) ?
