### PR TITLE
docs: ✏️ Update interfaces with notes about ticker deprecation

### DIFF
--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -213,6 +213,10 @@ export type MetadataKeyId =
        * @deprecated in favour of `assetId`
        */
       ticker?: string;
+      /**
+       * Unique ID of the Asset
+       * @note For 6.x chain, this value is same as the ticker value
+       */
       assetId: string;
     };
 

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -39,6 +39,10 @@ export type InstructionEndCondition =
 
 export type InstructionDetails = {
   status: InstructionStatus;
+  /**
+   * Date at which the instruction was created
+   * @note From 7.x chain, this value becomes null when instruction has been executed.
+   */
   createdAt: Date | null;
   /**
    * Date at which the trade was agreed upon (optional, for offchain trades)
@@ -48,6 +52,10 @@ export type InstructionDetails = {
    * Date at which the trade was executed (optional, for offchain trades)
    */
   valueDate: Date | null;
+  /**
+   * Venue to which the Instruction belongs to
+   * @note From 7.x chain, an Instruction can be created without specifying a Venue. Hence the null value.
+   */
   venue: Venue | null;
   memo: string | null;
 } & InstructionEndCondition;

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -54,7 +54,7 @@ export type InstructionDetails = {
   valueDate: Date | null;
   /**
    * Venue to which the Instruction belongs to
-   * @note From 7.x chain, an Instruction can be created without specifying a Venue. Hence the null value.
+   * @note From 7.x chain, Instructions can be created without a Venue. Hence the possible null value.
    */
   venue: Venue | null;
   memo: string | null;


### PR DESCRIPTION
### Description

Updates interfaces with notes about ticker deprecation

### Breaking Changes

- Since its not mandatory to specify a ticker while creating an Asset,
  `ticker` field in `BaseAsset` is now optional. `did` field in `BaseAsset` is now also optional.
- Since an instruction can be created without specifying a venue, `venue` field in `InstructionDetails` is now nullable.
- `TickerReservationDetails` optionally returns `assetId` when the status is `TickerReservationStatus.AssetCreated`.
- `ticker` field in `CreateNftCollectionParams` is now optional. Also, a new optional field `assetId` has been added to specify ID of the asset while creating NFT collection.
- `Ticker` value has been marked as deprecated in favour of new `Asset` value for the enums: `ScopeType` and `ClaimScopeTypeEnum`
- `ticker` field has been deprecated in favour of `assetId` field in: a. `HumanReadable` interfaces for these entities: `Checkpoint`, `CheckpointSchedule`, `CorporateAction`, `DividendDistribution`, `CustomPermissionGroup`, `KnownPermissionGroup`, `MetadataEntry`, `Offering` b. `MetadataKeyId` interface

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
