### PR TITLE
feat: 🎸 return `ticker` from `BaseAsset.details` method

### DIFF
--- a/src/api/entities/Asset/__tests__/Fungible/index.ts
+++ b/src/api/entities/Asset/__tests__/Fungible/index.ts
@@ -4,6 +4,7 @@ import {
   PalletAssetAssetDetails,
   PolymeshPrimitivesAssetAssetID,
   PolymeshPrimitivesAssetIdentifier,
+  PolymeshPrimitivesTicker,
 } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
@@ -92,6 +93,7 @@ describe('Fungible class', () => {
 
     let context: Context;
     let asset: FungibleAsset;
+    let rawTicker: Option<PolymeshPrimitivesTicker>;
 
     beforeAll(() => {
       assetId = '0x1234';
@@ -115,6 +117,7 @@ describe('Fungible class', () => {
       );
       rawName = dsMockUtils.createMockOption(dsMockUtils.createMockBytes(name));
       context = dsMockUtils.getContextInstance();
+      rawTicker = dsMockUtils.createMockOption(dsMockUtils.createMockTicker('TICKER'));
       asset = new FungibleAsset({ assetId }, context);
 
       dsMockUtils.createQueryMock('externalAgents', 'groupOfAgent', {
@@ -136,6 +139,10 @@ describe('Fungible class', () => {
       dsMockUtils.createQueryMock('asset', 'assetNames', {
         returnValue: rawName,
       });
+
+      dsMockUtils.createQueryMock('asset', 'assetIDTicker', {
+        returnValue: rawTicker,
+      });
     });
 
     it('should return details for an Asset', async () => {
@@ -154,6 +161,7 @@ describe('Fungible class', () => {
       expect(details.owner.did).toBe(owner);
       expect(details.assetType).toBe(assetType);
       expect(details.fullAgents[0].did).toBe(owner);
+      expect(details.ticker).toEqual('TICKER');
 
       dsMockUtils.createQueryMock('externalAgents', 'groupOfAgent', {
         entries: [
@@ -164,8 +172,13 @@ describe('Fungible class', () => {
         ],
       });
 
+      dsMockUtils.createQueryMock('asset', 'assetIDTicker', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+
       details = await asset.details();
       expect(details.fullAgents[0].did).toEqual(did);
+      expect(details.ticker).toBe(undefined);
 
       tokensMock.mockResolvedValue(
         dsMockUtils.createMockOption(

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -96,6 +96,7 @@ export interface AssetDetails {
   owner: Identity;
   totalSupply: BigNumber;
   fullAgents: Identity[];
+  ticker?: string;
 }
 
 /**


### PR DESCRIPTION
### Description

Return ticker from BaseAsset.details method

### Breaking Changes

`ticker`, `did` has been deprecated in `BaseAsset`. To get the ticker associated with an Asset, use `BaseAsset.details` method which now returns `ticker` along with other Asset details

### JIRA Link

DA-1326

### Checklist

- [ ] Updated the Readme.md (if required) ?
