### PR TITLE
feat: 🎸 add  pagination, filters to getHistoricalInstructions

### DIFF
--- a/src/api/client/Settlements.ts
+++ b/src/api/client/Settlements.ts
@@ -10,10 +10,7 @@ import {
   PolymeshError,
   Venue,
 } from '~/internal';
-import {
-  InstructionPartiesFilters,
-  instructionPartiesQuery,
-} from '~/middleware/queries/settlements';
+import { instructionPartiesQuery } from '~/middleware/queries/settlements';
 import { Query } from '~/middleware/types';
 import {
   AddInstructionWithVenueIdParams,
@@ -22,6 +19,7 @@ import {
   HistoricInstruction,
   InstructionAffirmationOperation,
   InstructionIdParams,
+  InstructionPartiesFilters,
   ProcedureMethod,
 } from '~/types';
 import { Ensured } from '~/types/utils';
@@ -136,24 +134,17 @@ export class Settlements {
    *
    */
   public async getHistoricalInstructions(
-    filter: InstructionPartiesFilters,
-    {
-      size,
-      start,
-    }: {
-      size?: BigNumber;
-      start?: BigNumber;
-    } = {}
+    filter: InstructionPartiesFilters
   ): Promise<HistoricInstruction[]> {
     const { context } = this;
+
+    const query = await instructionPartiesQuery(filter, context);
 
     const {
       data: {
         instructionParties: { nodes: instructionsResult },
       },
-    } = await context.queryMiddleware<Ensured<Query, 'instructionParties'>>(
-      instructionPartiesQuery(filter, size, start)
-    );
+    } = await context.queryMiddleware<Ensured<Query, 'instructionParties'>>(query);
 
     return instructionsResult.map(({ instruction }) =>
       middlewareInstructionToHistoricInstruction(instruction!, context)

--- a/src/api/client/__tests__/Settlements.ts
+++ b/src/api/client/__tests__/Settlements.ts
@@ -200,7 +200,7 @@ describe('Settlements Class', () => {
         nodes: [{ instruction: 'instruction' }],
       };
 
-      dsMockUtils.createApolloQueryMock(instructionPartiesQuery({}), {
+      dsMockUtils.createApolloQueryMock(await instructionPartiesQuery({}, context), {
         instructionParties: legsResponse,
       });
 

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -2,7 +2,9 @@ import { ApiOptions } from '@polkadot/api/types';
 import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
-import { TxTag } from '~/types';
+import { Asset, Identity, InstructionStatusEnum, TxTag } from '~/types';
+
+export { InstructionStatusEnum };
 
 export interface ExtrinsicData {
   blockHash: string;
@@ -210,3 +212,46 @@ export type CustomClaimType = {
  * CustomClaimType with DID that registered the CustomClaimType
  */
 export type CustomClaimTypeWithDid = CustomClaimType & { did?: string };
+
+/**
+ * Filters for instructions
+ *
+ */
+export interface InstructionPartiesFilters {
+  /**
+   * The DID of the identity to filter by
+   */
+  identity?: string | Identity;
+  /**
+   * The asset ID to filter by
+   */
+  asset?: string | Asset;
+  /**
+   * The status to filter by
+   */
+  status?: InstructionStatusEnum;
+  /**
+   * The sender did to filter by
+   */
+  sender?: string | Identity;
+  /**
+   * The receiver did to filter by
+   */
+  receiver?: string | Identity;
+  /**
+   * The mediator did to filter by
+   */
+  mediator?: string | Identity;
+  /**
+   * The party did to filter by
+   */
+  party?: string | Identity;
+  /**
+   * The number of results to return
+   */
+  size?: BigNumber;
+  /**
+   * The number of results to skip
+   */
+  start?: BigNumber;
+}

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -1296,7 +1296,9 @@ describe('Identity class', () => {
         nodes: [{ instruction: 'instruction' }],
       };
 
-      dsMockUtils.createApolloQueryMock(instructionPartiesQuery({ identity: identity.did }), {
+      const query = await instructionPartiesQuery({ identity: identity.did }, context);
+
+      dsMockUtils.createApolloQueryMock(query, {
         instructionParties: legsResponse,
       });
 

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -1296,7 +1296,7 @@ describe('Identity class', () => {
         nodes: [{ instruction: 'instruction' }],
       };
 
-      dsMockUtils.createApolloQueryMock(instructionPartiesQuery(identity.did), {
+      dsMockUtils.createApolloQueryMock(instructionPartiesQuery({ identity: identity.did }), {
         instructionParties: legsResponse,
       });
 

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -28,7 +28,10 @@ import {
 } from '~/internal';
 import { assetHoldersQuery, nftHoldersQuery } from '~/middleware/queries/assets';
 import { trustingAssetsQuery } from '~/middleware/queries/claims';
-import { instructionPartiesQuery } from '~/middleware/queries/settlements';
+import {
+  InstructionPartiesFilters,
+  instructionPartiesQuery,
+} from '~/middleware/queries/settlements';
 import { AssetHoldersOrderBy, NftHoldersOrderBy, Query } from '~/middleware/types';
 import { CddStatus } from '~/polkadot/polymesh';
 import {
@@ -911,8 +914,19 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    * Retrieve all Instructions that have been associated with this Identity's DID
    *
    * @note uses the middleware V2
+   * @note supports pagination
+   *
    */
-  public async getHistoricalInstructions(): Promise<HistoricInstruction[]> {
+  public async getHistoricalInstructions(
+    filter?: Omit<InstructionPartiesFilters, 'identity'>,
+    {
+      size,
+      start,
+    }: {
+      size?: BigNumber;
+      start?: BigNumber;
+    } = {}
+  ): Promise<HistoricInstruction[]> {
     const { context, did } = this;
 
     const {
@@ -920,7 +934,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
         instructionParties: { nodes: instructionsResult },
       },
     } = await context.queryMiddleware<Ensured<Query, 'instructionParties'>>(
-      instructionPartiesQuery(did)
+      instructionPartiesQuery({ ...filter, identity: did }, size, start)
     );
 
     return instructionsResult.map(({ instruction }) =>

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -28,10 +28,7 @@ import {
 } from '~/internal';
 import { assetHoldersQuery, nftHoldersQuery } from '~/middleware/queries/assets';
 import { trustingAssetsQuery } from '~/middleware/queries/claims';
-import {
-  InstructionPartiesFilters,
-  instructionPartiesQuery,
-} from '~/middleware/queries/settlements';
+import { instructionPartiesQuery } from '~/middleware/queries/settlements';
 import { AssetHoldersOrderBy, NftHoldersOrderBy, Query } from '~/middleware/types';
 import { CddStatus } from '~/polkadot/polymesh';
 import {
@@ -44,6 +41,7 @@ import {
   GroupedInvolvedInstructions,
   HeldNfts,
   HistoricInstruction,
+  InstructionPartiesFilters,
   InstructionsByStatus,
   MultiSigSigners,
   NumberedPortfolio,
@@ -918,24 +916,17 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    *
    */
   public async getHistoricalInstructions(
-    filter?: Omit<InstructionPartiesFilters, 'identity'>,
-    {
-      size,
-      start,
-    }: {
-      size?: BigNumber;
-      start?: BigNumber;
-    } = {}
+    filter?: Omit<InstructionPartiesFilters, 'identity'>
   ): Promise<HistoricInstruction[]> {
     const { context, did } = this;
+
+    const query = await instructionPartiesQuery({ ...filter, identity: did }, context);
 
     const {
       data: {
         instructionParties: { nodes: instructionsResult },
       },
-    } = await context.queryMiddleware<Ensured<Query, 'instructionParties'>>(
-      instructionPartiesQuery({ ...filter, identity: did }, size, start)
-    );
+    } = await context.queryMiddleware<Ensured<Query, 'instructionParties'>>(query);
 
     return instructionsResult.map(({ instruction }) =>
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/middleware/__tests__/queries/settlements.ts
+++ b/src/middleware/__tests__/queries/settlements.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import {
+  buildInstructionPartiesFilter,
   instructionEventsQuery,
   instructionPartiesQuery,
   instructionsQuery,
@@ -38,11 +39,108 @@ describe('instructionsQuery', () => {
   });
 });
 
+describe('buildInstructionPartiesFilter', () => {
+  it('should create the correct graphql filter with identity', () => {
+    const result = buildInstructionPartiesFilter({ identity: 'someDid' });
+
+    expect(result.args).toBe('($identity: String!)');
+    expect(result.filter).toBe('filter: { identity: { equalTo: $identity } }');
+  });
+
+  it('should create the correct graphql filter with status', () => {
+    const result = buildInstructionPartiesFilter({ status: InstructionStatusEnum.Executed });
+
+    expect(result.args).toBe('($status: InstructionStatusEnum!)');
+    expect(result.filter).toBe('filter: { instruction: { status: { equalTo: $status } } }');
+  });
+
+  it('should create the correct graphql filter with mediator', () => {
+    const result = buildInstructionPartiesFilter({ mediator: 'someMediator' });
+
+    expect(result.args).toBe('($mediator: String!)');
+    expect(result.filter).toBe(
+      'filter: { instruction: { mediators: { containsKey: $mediator } } }'
+    );
+  });
+
+  it('should create the correct graphql filter with party', () => {
+    const result = buildInstructionPartiesFilter({ party: 'someParty' });
+
+    expect(result.args).toBe('($party: String!)');
+    expect(result.filter).toBe(
+      'filter: { instruction: { parties: { some: { identity: { equalTo: $party } } } } }'
+    );
+  });
+
+  it('should create the correct graphql filter with assetId', () => {
+    const result = buildInstructionPartiesFilter({ assetId: 'someAssetId' });
+
+    expect(result.args).toBe('($assetId: String!)');
+    expect(result.filter).toBe(
+      'filter: { instruction: { legs: { assetId: { equalTo: $assetId } } } }'
+    );
+  });
+
+  it('should create the correct graphql filter with ticker', () => {
+    const result = buildInstructionPartiesFilter({ ticker: 'someTicker' });
+
+    expect(result.args).toBe('($ticker: String!)');
+    expect(result.filter).toBe(
+      'filter: { instruction: { legs: { ticker: { equalTo: $ticker } } } }'
+    );
+  });
+
+  it('should create the correct graphql filter with sender', () => {
+    const result = buildInstructionPartiesFilter({ sender: 'someSender' });
+
+    expect(result.args).toBe('($sender: String!)');
+    expect(result.filter).toBe('filter: { instruction: { legs: { from: { equalTo: $sender } } } }');
+  });
+
+  it('should create the correct graphql filter with receiver', () => {
+    const result = buildInstructionPartiesFilter({ receiver: 'someReceiver' });
+
+    expect(result.args).toBe('($receiver: String!)');
+    expect(result.filter).toBe('filter: { instruction: { legs: { to: { equalTo: $receiver } } } }');
+  });
+
+  it('should create the correct graphql filter with multiple parameters', () => {
+    const result = buildInstructionPartiesFilter({
+      identity: 'someDid',
+      status: InstructionStatusEnum.Executed,
+      assetId: 'someAssetId',
+      sender: 'someSender',
+    });
+
+    expect(result.args).toBe(
+      '($identity: String!,$status: InstructionStatusEnum!,$assetId: String!,$sender: String!)'
+    );
+    expect(result.filter).toBe(
+      'filter: { identity: { equalTo: $identity }, instruction: { status: { equalTo: $status }, legs: { assetId: { equalTo: $assetId }, from: { equalTo: $sender } } } }'
+    );
+  });
+
+  it('should return empty filter when no parameters are provided', () => {
+    const result = buildInstructionPartiesFilter({});
+
+    expect(result.args).toBe('');
+    expect(result.filter).toBe('');
+  });
+});
+
 describe('instructionPartiesQuery', () => {
   it('should pass the variables to the grapqhl query', () => {
-    const result = instructionPartiesQuery('someDid');
+    const result = instructionPartiesQuery(
+      { identity: 'someDid' },
+      new BigNumber(10),
+      new BigNumber(2)
+    );
     expect(result.query).toBeDefined();
-    expect(result.variables).toEqual({ identity: 'someDid' });
+    expect(result.variables).toEqual({
+      identity: 'someDid',
+      size: 10,
+      start: 2,
+    });
   });
 });
 

--- a/src/middleware/__tests__/queries/settlements.ts
+++ b/src/middleware/__tests__/queries/settlements.ts
@@ -11,6 +11,7 @@ import {
 } from '~/middleware/queries/settlements';
 import { InstructionEventEnum, InstructionStatusEnum } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
+import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 import * as utilsInternalModule from '~/utils/internal';
 
 describe('instructionsQuery', () => {
@@ -155,11 +156,13 @@ describe('buildInstructionPartiesFilter', () => {
     );
   });
 
-  it('should return empty filter when no parameters are provided', async () => {
+  it('should return empty filter with default pagination when no parameters are provided', async () => {
     const result = await buildInstructionPartiesFilter({}, context);
 
     expect(result.args).toBe('($start: Int,$size: Int)');
     expect(result.filter).toBe('');
+    expect(result.variables.size).toBe(DEFAULT_GQL_PAGE_SIZE);
+    expect(result.variables.start).toBe(0);
   });
 });
 

--- a/src/middleware/__tests__/queries/settlements.ts
+++ b/src/middleware/__tests__/queries/settlements.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 
+import { Context } from '~/internal';
 import {
   buildInstructionPartiesFilter,
   instructionEventsQuery,
@@ -9,6 +10,8 @@ import {
   settlementsQuery,
 } from '~/middleware/queries/settlements';
 import { InstructionEventEnum, InstructionStatusEnum } from '~/middleware/types';
+import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
+import * as utilsInternalModule from '~/utils/internal';
 
 describe('instructionsQuery', () => {
   it('should pass the variables to the grapqhl query', () => {
@@ -40,100 +43,141 @@ describe('instructionsQuery', () => {
 });
 
 describe('buildInstructionPartiesFilter', () => {
-  it('should create the correct graphql filter with identity', () => {
-    const result = buildInstructionPartiesFilter({ identity: 'someDid' });
+  let context: Context;
 
-    expect(result.args).toBe('($identity: String!)');
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+    jest.spyOn(utilsInternalModule, 'asAssetId').mockImplementation((a): Promise<string> => {
+      return Promise.resolve(typeof a === 'string' ? a : a.id);
+    });
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should create the correct graphql filter with identity', async () => {
+    const result = await buildInstructionPartiesFilter({ identity: 'someDid' }, context);
+
+    expect(result.args).toBe('($start: Int,$size: Int,$identity: String!)');
     expect(result.filter).toBe('filter: { identity: { equalTo: $identity } }');
   });
 
-  it('should create the correct graphql filter with status', () => {
-    const result = buildInstructionPartiesFilter({ status: InstructionStatusEnum.Executed });
+  it('should create the correct graphql filter with identity as Identity object', async () => {
+    const did = 'someDid';
+    const mockIdentity = entityMockUtils.getIdentityInstance({ did });
+    const result = await buildInstructionPartiesFilter({ identity: mockIdentity }, context);
 
-    expect(result.args).toBe('($status: InstructionStatusEnum!)');
+    expect(result.args).toBe('($start: Int,$size: Int,$identity: String!)');
+    expect(result.filter).toBe('filter: { identity: { equalTo: $identity } }');
+    expect(result.variables.identity).toBe(did);
+  });
+
+  it('should create the correct graphql filter with status', async () => {
+    const result = await buildInstructionPartiesFilter(
+      { status: InstructionStatusEnum.Executed },
+      context
+    );
+
+    expect(result.args).toBe('($start: Int,$size: Int,$status: InstructionStatusEnum!)');
     expect(result.filter).toBe('filter: { instruction: { status: { equalTo: $status } } }');
   });
 
-  it('should create the correct graphql filter with mediator', () => {
-    const result = buildInstructionPartiesFilter({ mediator: 'someMediator' });
+  it('should create the correct graphql filter with mediator', async () => {
+    const result = await buildInstructionPartiesFilter({ mediator: 'someMediator' }, context);
 
-    expect(result.args).toBe('($mediator: String!)');
+    expect(result.args).toBe('($start: Int,$size: Int,$mediator: String!)');
     expect(result.filter).toBe(
       'filter: { instruction: { mediators: { containsKey: $mediator } } }'
     );
   });
 
-  it('should create the correct graphql filter with party', () => {
-    const result = buildInstructionPartiesFilter({ party: 'someParty' });
+  it('should create the correct graphql filter with party', async () => {
+    const result = await buildInstructionPartiesFilter({ party: 'someParty' }, context);
 
-    expect(result.args).toBe('($party: String!)');
+    expect(result.args).toBe('($start: Int,$size: Int,$party: String!)');
     expect(result.filter).toBe(
       'filter: { instruction: { parties: { some: { identity: { equalTo: $party } } } } }'
     );
   });
 
-  it('should create the correct graphql filter with assetId', () => {
-    const result = buildInstructionPartiesFilter({ assetId: 'someAssetId' });
+  it('should create the correct graphql filter with assetId', async () => {
+    const result = await buildInstructionPartiesFilter({ asset: 'TICKER' }, context);
 
-    expect(result.args).toBe('($assetId: String!)');
+    expect(result.args).toBe('($start: Int,$size: Int,$asset: String!)');
     expect(result.filter).toBe(
-      'filter: { instruction: { legs: { assetId: { equalTo: $assetId } } } }'
+      'filter: { instruction: { legs: { assetId: { equalTo: $asset } } } }'
     );
   });
 
-  it('should create the correct graphql filter with ticker', () => {
-    const result = buildInstructionPartiesFilter({ ticker: 'someTicker' });
+  it('should create the correct graphql filter with asset as Asset object', async () => {
+    const assetId = 'TICKE';
+    const mockAsset = entityMockUtils.getFungibleAssetInstance({ assetId });
+    const result = await buildInstructionPartiesFilter({ asset: mockAsset }, context);
 
-    expect(result.args).toBe('($ticker: String!)');
+    expect(result.args).toBe('($start: Int,$size: Int,$asset: String!)');
     expect(result.filter).toBe(
-      'filter: { instruction: { legs: { ticker: { equalTo: $ticker } } } }'
+      'filter: { instruction: { legs: { assetId: { equalTo: $asset } } } }'
     );
+    expect(result.variables.asset).toBe(assetId);
   });
 
-  it('should create the correct graphql filter with sender', () => {
-    const result = buildInstructionPartiesFilter({ sender: 'someSender' });
+  it('should create the correct graphql filter with sender', async () => {
+    const result = await buildInstructionPartiesFilter({ sender: 'someSender' }, context);
 
-    expect(result.args).toBe('($sender: String!)');
+    expect(result.args).toBe('($start: Int,$size: Int,$sender: String!)');
     expect(result.filter).toBe('filter: { instruction: { legs: { from: { equalTo: $sender } } } }');
   });
 
-  it('should create the correct graphql filter with receiver', () => {
-    const result = buildInstructionPartiesFilter({ receiver: 'someReceiver' });
+  it('should create the correct graphql filter with receiver', async () => {
+    const result = await buildInstructionPartiesFilter({ receiver: 'someReceiver' }, context);
 
-    expect(result.args).toBe('($receiver: String!)');
+    expect(result.args).toBe('($start: Int,$size: Int,$receiver: String!)');
     expect(result.filter).toBe('filter: { instruction: { legs: { to: { equalTo: $receiver } } } }');
   });
 
-  it('should create the correct graphql filter with multiple parameters', () => {
-    const result = buildInstructionPartiesFilter({
-      identity: 'someDid',
-      status: InstructionStatusEnum.Executed,
-      assetId: 'someAssetId',
-      sender: 'someSender',
-    });
+  it('should create the correct graphql filter with multiple parameters', async () => {
+    const result = await buildInstructionPartiesFilter(
+      {
+        identity: 'someDid',
+        status: InstructionStatusEnum.Executed,
+        asset: 'TICKER',
+        sender: 'someSender',
+      },
+      context
+    );
 
     expect(result.args).toBe(
-      '($identity: String!,$status: InstructionStatusEnum!,$assetId: String!,$sender: String!)'
+      '($start: Int,$size: Int,$identity: String!,$status: InstructionStatusEnum!,$asset: String!,$sender: String!)'
     );
     expect(result.filter).toBe(
-      'filter: { identity: { equalTo: $identity }, instruction: { status: { equalTo: $status }, legs: { assetId: { equalTo: $assetId }, from: { equalTo: $sender } } } }'
+      'filter: { identity: { equalTo: $identity }, instruction: { status: { equalTo: $status }, legs: { assetId: { equalTo: $asset }, from: { equalTo: $sender } } } }'
     );
   });
 
-  it('should return empty filter when no parameters are provided', () => {
-    const result = buildInstructionPartiesFilter({});
+  it('should return empty filter when no parameters are provided', async () => {
+    const result = await buildInstructionPartiesFilter({}, context);
 
-    expect(result.args).toBe('');
+    expect(result.args).toBe('($start: Int,$size: Int)');
     expect(result.filter).toBe('');
   });
 });
 
 describe('instructionPartiesQuery', () => {
-  it('should pass the variables to the grapqhl query', () => {
-    const result = instructionPartiesQuery(
-      { identity: 'someDid' },
-      new BigNumber(10),
-      new BigNumber(2)
+  let context: Context;
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+  });
+
+  it('should pass the variables to the grapqhl query', async () => {
+    const result = await instructionPartiesQuery(
+      {
+        identity: 'someDid',
+        size: new BigNumber(10),
+        start: new BigNumber(2),
+      },
+      context
     );
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/queries/settlements.ts
+++ b/src/middleware/queries/settlements.ts
@@ -15,6 +15,7 @@ import {
 } from '~/middleware/types';
 import { InstructionPartiesFilters } from '~/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
+import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 import { asAssetId, asDid } from '~/utils/internal';
 
 const instructionAttributes = `
@@ -168,7 +169,17 @@ export const buildInstructionPartiesFilter = async (
   filter: string;
   variables: InstructionPartiesVariables;
 }> => {
-  const { identity, asset, status, sender, receiver, mediator, party, size, start } = filters;
+  const {
+    identity,
+    asset,
+    status,
+    sender,
+    receiver,
+    mediator,
+    party,
+    size = new BigNumber(DEFAULT_GQL_PAGE_SIZE),
+    start = new BigNumber(0),
+  } = filters;
 
   const args = ['$start: Int', '$size: Int'];
   const baseFilter = [];


### PR DESCRIPTION
### Description

 - enables pagination on Identity.getHistoricalInstuctions
 - adds filter by  assetId, ticker, status, sender,  receiver,  mediator,  party to Identity.getHistoricalInstuction
 - adds getHistoricalInstuctions to Settlements class

### JIRA Link

https://polymesh.atlassian.net/browse/DA-1340

### Checklist

- [ ] Updated the Readme.md (if required) ?
