### PR TITLE
fix: 🐛 Handle self transfer case when checking asset transfer

### DIFF
--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -359,6 +359,16 @@ export enum TransferError {
    * occurs if some statistics transfer condition would prevent the transfer
    */
   TransferNotAllowed = 'TransferNotAllowed',
+
+  /**
+   * occurs if asset to be check for transfer, no longer exists
+   */
+  AssetDoesNotExists = 'AssetDoesNotExists',
+
+  /**
+   * occurs if receiver balance will overflow on receiving the transfer amount
+   */
+  BalanceOverflow = 'BalanceOverflow',
 }
 
 export interface AssetWithGroup {

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -4025,11 +4025,14 @@ describe('transferReportToTransferBreakdown', () => {
       InvalidTransferFrozenAsset: { is: jest.fn().mockReturnValue(false) },
       InvalidTransferComplianceFailure: { is: jest.fn().mockReturnValue(false) },
       InvalidTransfer: { is: jest.fn().mockReturnValue(false) },
+      NoSuchAsset: { is: jest.fn().mockReturnValue(false) },
+      BalanceOverflow: { is: jest.fn().mockReturnValue(false) },
     } as unknown as DecoratedErrors<'promise'>['asset'];
 
     context.polymeshApi.errors.portfolio = {
       PortfolioDoesNotExist: { is: jest.fn().mockReturnValue(false) },
       InsufficientPortfolioBalance: { is: jest.fn().mockReturnValue(true) },
+      InvalidTransferSenderIdMatchesReceiverId: { is: jest.fn().mockReturnValue(false) },
     } as unknown as DecoratedErrors<'promise'>['portfolio'];
 
     context.polymeshApi.errors.statistics = {
@@ -4106,11 +4109,14 @@ describe('assetDispatchErrorToTransferError', () => {
       InvalidTransferFrozenAsset: { is: jest.fn().mockReturnValue(false) },
       InvalidTransferComplianceFailure: { is: jest.fn().mockReturnValue(false) },
       InvalidTransfer: { is: jest.fn().mockReturnValue(false) },
+      NoSuchAsset: { is: jest.fn().mockReturnValue(false) },
+      BalanceOverflow: { is: jest.fn().mockReturnValue(false) },
     } as unknown as DecoratedErrors<'promise'>['asset'];
 
     context.polymeshApi.errors.portfolio = {
       PortfolioDoesNotExist: { is: jest.fn().mockReturnValue(false) },
       InsufficientPortfolioBalance: { is: jest.fn().mockReturnValue(false) },
+      InvalidTransferSenderIdMatchesReceiverId: { is: jest.fn().mockReturnValue(false) },
     } as unknown as DecoratedErrors<'promise'>['portfolio'];
 
     context.polymeshApi.errors.statistics = {
@@ -4161,6 +4167,22 @@ describe('assetDispatchErrorToTransferError', () => {
 
     expect(result).toEqual(TransferError.InsufficientBalance);
 
+    dsMockUtils.setErrorMock('asset', 'NoSuchAsset', {
+      returnValue: { is: jest.fn().mockReturnValueOnce(true) },
+    });
+
+    result = assetDispatchErrorToTransferError(mockError, context);
+
+    expect(result).toEqual(TransferError.AssetDoesNotExists);
+
+    dsMockUtils.setErrorMock('asset', 'BalanceOverflow', {
+      returnValue: { is: jest.fn().mockReturnValueOnce(true) },
+    });
+
+    result = assetDispatchErrorToTransferError(mockError, context);
+
+    expect(result).toEqual(TransferError.BalanceOverflow);
+
     dsMockUtils.setErrorMock('asset', 'InvalidTransferFrozenAsset', {
       returnValue: { is: jest.fn().mockReturnValueOnce(true) },
     });
@@ -4200,6 +4222,14 @@ describe('assetDispatchErrorToTransferError', () => {
     result = assetDispatchErrorToTransferError(mockError, context);
 
     expect(result).toEqual(TransferError.InsufficientPortfolioBalance);
+
+    dsMockUtils.setErrorMock('portfolio', 'InvalidTransferSenderIdMatchesReceiverId', {
+      returnValue: { is: jest.fn().mockReturnValueOnce(true) },
+    });
+
+    result = assetDispatchErrorToTransferError(mockError, context);
+
+    expect(result).toEqual(TransferError.SelfTransfer);
 
     dsMockUtils.setErrorMock('statistics', 'InvalidTransferStatisticsFailure', {
       returnValue: { is: jest.fn().mockReturnValueOnce(true) },

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -3622,8 +3622,11 @@ export function assetDispatchErrorToTransferError(
   type ErrorCase = [IsError, TransferError];
 
   const record: ErrorCase[] = [
+    [assetErrors.NoSuchAsset, TransferError.AssetDoesNotExists],
     [assetErrors.InvalidGranularity, TransferError.InvalidGranularity],
     [assetErrors.SenderSameAsReceiver, TransferError.SelfTransfer],
+    [portfolioErrors.InvalidTransferSenderIdMatchesReceiverId, TransferError.SelfTransfer],
+    [assetErrors.BalanceOverflow, TransferError.BalanceOverflow],
     [assetErrors.InvalidTransferInvalidReceiverCDD, TransferError.InvalidReceiverCdd],
     [assetErrors.InvalidTransferInvalidSenderCDD, TransferError.InvalidSenderCdd],
     [assetErrors.InsufficientBalance, TransferError.InsufficientBalance],


### PR DESCRIPTION
### Description

Some of the errors handling was missing in `canTransfer` method. This adds those checks

### Breaking Changes

NA

### JIRA Link

DA-1352

### Checklist

- [ ] Updated the Readme.md (if required) ?
