### PR TITLE
fix: 🐛 Correctly handle scopeToMiddlewareScope for Asset types

### DIFF
--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -5106,7 +5106,7 @@ describe('middlewareScopeToScope and scopeToMiddlewareScope', () => {
       result = await scopeToMiddlewareScope(scope, context);
       expect(result).toEqual({
         type: ClaimScopeTypeEnum.Asset,
-        value: '0x12341234123412341234123412341234',
+        assetId: '0x12341234123412341234123412341234',
       });
 
       scope = { type: ScopeType.Ticker, value: 'SOME_TICKER' }; // NOSONAR
@@ -5114,7 +5114,7 @@ describe('middlewareScopeToScope and scopeToMiddlewareScope', () => {
       result = await scopeToMiddlewareScope(scope, context);
       expect(result).toEqual({
         type: ClaimScopeTypeEnum.Asset,
-        value: '0x12341234123412341234123412341234',
+        assetId: '0x12341234123412341234123412341234',
       });
 
       scope = { type: ScopeType.Custom, value: 'customValue' };

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -2510,7 +2510,7 @@ export async function scopeToMiddlewareScope(
     case ScopeType.Asset:
       return {
         type: ClaimScopeTypeEnum.Asset,
-        value: await getAssetIdForMiddleware(value, context),
+        assetId: await getAssetIdForMiddleware(value, context),
       };
     case ScopeType.Identity:
     case ScopeType.Custom:


### PR DESCRIPTION
### Description

scopeToMiddlewareScope was not correctly modifying the incoming scope in order to filter out data from SQ entities. Old attribute `value` was still used instead of new `assetId` in case of ScopeType.Asset. This correctly now maps the same.

### Breaking Changes

NA

### JIRA Link

DA-1359

### Checklist

- [ ] Updated the Readme.md (if required) ?
