### PR TITLE
feat: 🎸 Retrieve instruction info from middleware(if available) 

### DIFF
--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -90,6 +90,7 @@ export enum AffirmationStatus {
   Unknown = 'Unknown',
   Pending = 'Pending',
   Affirmed = 'Affirmed',
+  Rejected = 'Rejected',
 }
 
 export interface InstructionAffirmation {

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -89,6 +89,11 @@ export interface PaginationOptions {
   start?: string;
 }
 
+export interface MiddlewarePaginationOptions {
+  size: BigNumber;
+  start?: BigNumber;
+}
+
 export type NextKey = string | BigNumber | null;
 
 export interface ResultSet<T> {


### PR DESCRIPTION
### Description

Add option to query information from middleware for instruction related methods.

### Breaking Changes

🧨 Methods in the `Instruction` entity that retrieve information from the
chain were updated to use middleware for fetching data, when available. If middleware is
unavailable, the methods will continue to fetch data directly from the chain.
The following methods were modified with this logic: `details`, `getAffirmations`, `getLegs`,
`getMediators`, `getOffChainAffirmations`, `getOffChainAffirmationForLeg`.
When querying via middleware, these methods will now throw an error in the following cases:
  a. If the instruction does not exist.
  b.If the instruction data has not yet been processed by the middleware.
Also, the pagination options for `getAffirmations` and `getLegs` now supports
`MiddlewarePaginationOptions` as well (when querying via middleware)

### JIRA Link

DA-1369

### Checklist

- [ ] Updated the Readme.md (if required) ?
