### PR TITLE
fix: 🐛 Use unique portfolios while creating BtreeSet

### DIFF
--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -9110,20 +9110,17 @@ describe('portfolioIdsToBtreeSet', () => {
   it('should convert BTreeSet<PolymeshPrimitivesIdentityIdPortfolioId>', () => {
     const context = dsMockUtils.getContextInstance();
 
-    const rawPortfolioIds = [
-      dsMockUtils.createMockPortfolioId({
-        did: dsMockUtils.createMockIdentityId('someDid'),
-        kind: 'Default',
-      }),
-    ];
-
-    const mockPortfolioIdsSet = dsMockUtils.createMockBTreeSet(rawPortfolioIds);
+    const rawPortfolioId = dsMockUtils.createMockPortfolioId({
+      did: dsMockUtils.createMockIdentityId('someDid'),
+      kind: 'Default',
+    });
+    const mockPortfolioIdsSet = dsMockUtils.createMockBTreeSet([rawPortfolioId]);
 
     when(context.createType)
-      .calledWith('BTreeSet<PolymeshPrimitivesIdentityIdPortfolioId>', rawPortfolioIds)
+      .calledWith('BTreeSet<PolymeshPrimitivesIdentityIdPortfolioId>', [rawPortfolioId])
       .mockReturnValue(mockPortfolioIdsSet);
 
-    const result = portfolioIdsToBtreeSet(rawPortfolioIds, context);
+    const result = portfolioIdsToBtreeSet([rawPortfolioId, rawPortfolioId], context);
     expect(result).toEqual(mockPortfolioIdsSet);
   });
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -101,11 +101,13 @@ import {
   forEach,
   groupBy,
   includes,
+  isEqual,
   map,
   range,
   rangeRight,
   snakeCase,
   uniq,
+  uniqWith,
   values,
 } from 'lodash';
 
@@ -3577,7 +3579,10 @@ export function portfolioIdsToBtreeSet(
   rawPortfolioIds: PolymeshPrimitivesIdentityIdPortfolioId[],
   context: Context
 ): BTreeSet<PolymeshPrimitivesIdentityIdPortfolioId> {
-  return context.createType('BTreeSet<PolymeshPrimitivesIdentityIdPortfolioId>', rawPortfolioIds);
+  return context.createType(
+    'BTreeSet<PolymeshPrimitivesIdentityIdPortfolioId>',
+    uniqWith(rawPortfolioIds, isEqual)
+  );
 }
 
 /**


### PR DESCRIPTION
### Description

When an instruction had two or more legs with sender portfolio as same, the creation of BtreeSet of portfolioIds was failing because of duplicate items in the list. This fixes the issue by only using unique items in the list.

### Breaking Changes

NA

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
