### PR TITLE
feat: 🎸 Add more info about historical proposal

### DIFF
--- a/src/api/entities/Account/MultiSig/types.ts
+++ b/src/api/entities/Account/MultiSig/types.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 
-import { Account, MultiSig } from '~/internal';
+import { Account, MultiSig, MultiSigProposal } from '~/internal';
+import { AnyJson, ProposalStatus, TxTag } from '~/types';
 
 export interface MultiSigDetails {
   signers: Account[];
@@ -12,4 +13,14 @@ export interface MultiSigSigners {
   signers: Account[];
   isAdmin: boolean;
   isPayer: boolean;
+}
+
+export interface HistoricalMultiSigProposal {
+  proposal: MultiSigProposal;
+  status: ProposalStatus;
+  approvalAmount: BigNumber;
+  rejectionAmount: BigNumber;
+  expiry: Date | null;
+  txTag: TxTag;
+  args: AnyJson;
 }

--- a/src/middleware/queries/multisigs.ts
+++ b/src/middleware/queries/multisigs.ts
@@ -119,6 +119,10 @@ export function multiSigProposalsQuery(
           id
           proposalId
           multisigId
+          status
+          approvalCount
+          rejectionCount
+          params
         }
         totalCount
       }

--- a/src/middleware/typesV1.ts
+++ b/src/middleware/typesV1.ts
@@ -13,3 +13,12 @@ export enum SettlementDirectionEnum {
   Incoming = 'Incoming',
   Outgoing = 'Outgoing',
 }
+
+export enum MultiSigProposalStatusEnum {
+  Active = 'Active',
+  Approved = 'Approved',
+  Success = 'Success',
+  Failed = 'Failed',
+  Rejected = 'Rejected',
+  Deleted = 'Deleted',
+}

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -104,7 +104,7 @@ import {
   ModuleIdEnum,
   Portfolio as MiddlewarePortfolio,
 } from '~/middleware/types';
-import { ClaimScopeTypeEnum } from '~/middleware/typesV1';
+import { ClaimScopeTypeEnum, MultiSigProposalStatusEnum } from '~/middleware/typesV1';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
 import {
   createMockAssetId,
@@ -291,6 +291,7 @@ import {
   middlewarePermissionsDataToPermissions,
   middlewarePortfolioDataToPortfolio,
   middlewarePortfolioToPortfolio,
+  middlewareProposalStateToProposalStatus,
   middlewareScopeToScope,
   moduleAddressToString,
   momentToDate,
@@ -11229,5 +11230,34 @@ describe('childKeysWithAuthToCreateChildIdentitiesWithAuth', () => {
     const result = childKeysWithAuthToCreateChildIdentitiesWithAuth(childKeyAuths, context);
 
     expect(result).toEqual(fakeResult);
+  });
+});
+
+describe('middlewareProposalStateToProposalStatus', () => {
+  test('should convert a MultiSigProposalStatusEnum to ProposalStatus ', () => {
+    expect(middlewareProposalStateToProposalStatus(MultiSigProposalStatusEnum.Active)).toEqual(
+      ProposalStatus.Active
+    );
+    expect(middlewareProposalStateToProposalStatus(MultiSigProposalStatusEnum.Deleted)).toEqual(
+      ProposalStatus.Expired
+    );
+    expect(middlewareProposalStateToProposalStatus(MultiSigProposalStatusEnum.Failed)).toEqual(
+      ProposalStatus.Failed
+    );
+    expect(middlewareProposalStateToProposalStatus(MultiSigProposalStatusEnum.Success)).toEqual(
+      ProposalStatus.Successful
+    );
+    expect(middlewareProposalStateToProposalStatus(MultiSigProposalStatusEnum.Rejected)).toEqual(
+      ProposalStatus.Rejected
+    );
+    expect(middlewareProposalStateToProposalStatus(MultiSigProposalStatusEnum.Approved)).toEqual(
+      ProposalStatus.Active
+    );
+
+    expect(
+      middlewareProposalStateToProposalStatus(
+        'Random state' as unknown as MultiSigProposalStatusEnum
+      )
+    ).toEqual(ProposalStatus.Invalid);
   });
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -146,7 +146,12 @@ import {
   Portfolio as MiddlewarePortfolio,
   PortfolioMovement as MiddlewarePortfolioMovement,
 } from '~/middleware/types';
-import { ClaimScopeTypeEnum, MiddlewareScope, SettlementDirectionEnum } from '~/middleware/typesV1';
+import {
+  ClaimScopeTypeEnum,
+  MiddlewareScope,
+  MultiSigProposalStatusEnum,
+  SettlementDirectionEnum,
+} from '~/middleware/typesV1';
 import {
   AssetComplianceResult,
   AuthorizationType as MeshAuthorizationType,
@@ -5455,4 +5460,22 @@ export function childKeysWithAuthToCreateChildIdentitiesWithAuth(
     'Vec<PolymeshCommonUtilitiesIdentityCreateChildIdentityWithAuth>',
     keyWithAuths
   );
+}
+
+/**
+ * @hidden
+ */
+export function middlewareProposalStateToProposalStatus(
+  state: MultiSigProposalStatusEnum
+): ProposalStatus {
+  const stateToStatusMap = {
+    [MultiSigProposalStatusEnum.Active]: ProposalStatus.Active,
+    [MultiSigProposalStatusEnum.Deleted]: ProposalStatus.Expired,
+    [MultiSigProposalStatusEnum.Failed]: ProposalStatus.Failed,
+    [MultiSigProposalStatusEnum.Success]: ProposalStatus.Successful,
+    [MultiSigProposalStatusEnum.Rejected]: ProposalStatus.Rejected,
+    [MultiSigProposalStatusEnum.Approved]: ProposalStatus.Active,
+  };
+
+  return stateToStatusMap[state] || ProposalStatus.Invalid;
 }


### PR DESCRIPTION
### Description

`MultiSig.getHistoricalProposals` used to return just the entity object of MultiSigProposal expecting users to fetch details on their own. But while fetching the details, pruned proposal data could not be fetch and SDK throws error on the same. 

This PR introduces new interface `HistoricalMultiSigProposal` which will fetch all the info from middleware and return the same. 

### Breaking Changes

BREAKING CHANGE: 🧨 Return type of `MultiSig.getHistoricalProposals` is now changed to `ResultSet<HistoricalMultiSigProposal>` to provide more info about the proposal. This will allow get know information about prunded proposals as well

### JIRA Link

DA-1391

### Checklist

- [ ] Updated the Readme.md (if required) ?
