### PR TITLE
feat: 🎸 add support for padded IDs in subquery

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=polymeshassociation
 sonar.projectKey=PolymeshAssociation_polymesh-sdk
 sonar.sources=src
-sonar.coverage.exclusions=**/testUtils/**,**/polkadot/**,**/__tests__/**,**/generated/**,src/utils/typeguards.ts,src/types/internal.ts,src/middleware/enums.ts
+sonar.coverage.exclusions=**/testUtils/**,**/polkadot/**,**/__tests__/**,**/generated/**,src/utils/typeguards.ts,src/types/internal.ts,src/middleware/enums.ts,src/middleware/queries/*.ts
 sonar.cpd.exclusions=**/__tests__/**,**/polkadot/**
 sonar.exclusions=**/polkadot/augment-**
 sonar.javascript.environments=node

--- a/src/api/client/Claims.ts
+++ b/src/api/client/Claims.ts
@@ -255,7 +255,7 @@ export class Claims {
         claims: { nodes },
       },
     } = await context.queryMiddleware<Ensured<Query, 'claims'>>(
-      claimsQuery({
+      claimsQuery(context.isSqIdPadded, {
         dids: targetIssuers,
         ...filters,
       })
@@ -555,7 +555,7 @@ export class Claims {
           claims: { nodes },
         },
       } = await context.queryMiddleware<Ensured<Query, 'claims'>>(
-        claimsQuery({
+        claimsQuery(context.isSqIdPadded, {
           trustedClaimIssuers: claimIssuers,
           ...filters,
         })

--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -179,6 +179,7 @@ export class Network {
       },
     } = await context.queryMiddleware<Ensured<Query, 'events'>>(
       eventsByArgs(
+        context.isSqIdPadded,
         {
           moduleId,
           eventId,
@@ -338,6 +339,7 @@ export class Network {
       },
     } = await context.queryMiddleware<Ensured<Query, 'events'>>(
       eventsByArgs(
+        context.isSqIdPadded,
         {
           moduleId,
           eventId,

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -15,6 +15,7 @@ import {
   CreateTransactionBatchProcedureMethod,
   ErrorCode,
   MiddlewareConfig,
+  MiddlewareMetadata,
   PolkadotConfig,
   UnsubCallback,
 } from '~/types';
@@ -194,7 +195,7 @@ export class Polymesh {
     }
 
     if (middlewareV2) {
-      let middlewareMetadata = null;
+      let middlewareMetadata: MiddlewareMetadata | null = null;
 
       const checkMiddleware = async (): Promise<void> => {
         try {
@@ -215,6 +216,8 @@ export class Polymesh {
             message: 'Middleware V2 URL is for a different chain than the given node URL',
           });
         }
+
+        context.isSqIdPadded = middlewareMetadata.paddedIds;
       };
 
       await Promise.all([checkMiddleware(), warnUnexpectedSqVersion(context)]);

--- a/src/api/client/__tests__/Claims.ts
+++ b/src/api/client/__tests__/Claims.ts
@@ -167,7 +167,7 @@ describe('Claims Class', () => {
       dsMockUtils.configureMocks({ contextOptions: { withSigningManager: true } });
 
       dsMockUtils.createApolloQueryMock(
-        claimsQuery({
+        claimsQuery(false, {
           dids: [targetDid],
           scope: undefined,
           trustedClaimIssuers: [issuerDid],
@@ -211,7 +211,7 @@ describe('Claims Class', () => {
           },
         },
         {
-          query: claimsQuery({
+          query: claimsQuery(false, {
             dids: [targetDid],
             scope: undefined,
             trustedClaimIssuers: undefined,
@@ -304,7 +304,7 @@ describe('Claims Class', () => {
       dsMockUtils.configureMocks({ contextOptions: { withSigningManager: true } });
 
       dsMockUtils.createApolloQueryMock(
-        claimsQuery({
+        claimsQuery(false, {
           dids: [targetDid],
           scope: { type: 'Asset', value: '0x12341234123412341234123412341234' },
           trustedClaimIssuers: [issuerDid],
@@ -801,7 +801,7 @@ describe('Claims Class', () => {
         .mockReturnValue(fakeClaims);
 
       dsMockUtils.createApolloQueryMock(
-        claimsQuery({
+        claimsQuery(false, {
           dids: [did],
           scope,
           trustedClaimIssuers: [issuerDid],
@@ -847,7 +847,7 @@ describe('Claims Class', () => {
           },
         },
         {
-          query: claimsQuery({
+          query: claimsQuery(false, {
             dids: ['someDid'],
             scope: undefined,
             trustedClaimIssuers: [issuerDid],

--- a/src/api/client/__tests__/Network.ts
+++ b/src/api/client/__tests__/Network.ts
@@ -213,6 +213,7 @@ describe('Network Class', () => {
       dsMockUtils.configureMocks({ contextOptions: { withSigningManager: true } });
       dsMockUtils.createApolloQueryMock(
         eventsByArgs(
+          false,
           {
             ...variables,
             eventArg0: undefined,
@@ -244,6 +245,7 @@ describe('Network Class', () => {
     it('should return null if the query result is empty', async () => {
       dsMockUtils.createApolloQueryMock(
         eventsByArgs(
+          false,
           {
             ...variables,
             eventArg0: 'someDid',
@@ -282,6 +284,7 @@ describe('Network Class', () => {
 
       dsMockUtils.createApolloQueryMock(
         eventsByArgs(
+          false,
           {
             ...variables,
             eventArg0: undefined,
@@ -317,7 +320,7 @@ describe('Network Class', () => {
 
     it('should return null if the query result is empty', async () => {
       dsMockUtils.createApolloQueryMock(
-        eventsByArgs({
+        eventsByArgs(false, {
           ...variables,
           eventArg0: 'someDid',
           eventArg1: undefined,

--- a/src/api/client/__tests__/Polymesh.ts
+++ b/src/api/client/__tests__/Polymesh.ts
@@ -396,6 +396,7 @@ describe('Polymesh Class', () => {
         },
       });
       const context = dsMockUtils.getContextInstance();
+      context.isSqIdPadded = false;
 
       const expectedTransaction = 'someTransaction' as unknown as PolymeshTransactionBatch<
         [void, void]

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -44,6 +44,7 @@ export interface MiddlewareMetadata {
   specName: string;
   targetHeight: BigNumber;
   sqVersion: string;
+  paddedIds: boolean;
 }
 
 export interface SubmissionDetails {

--- a/src/api/entities/Asset/Fungible/index.ts
+++ b/src/api/entities/Asset/Fungible/index.ts
@@ -155,7 +155,7 @@ export class FungibleAsset extends BaseAsset {
         tickerExternalAgentHistories: { nodes },
       },
     } = await context.queryMiddleware<Ensured<Query, 'tickerExternalAgentHistories'>>(
-      tickerExternalAgentHistoryQuery({
+      tickerExternalAgentHistoryQuery(context.isSqIdPadded, {
         assetId: middlewareAssetId,
       })
     );
@@ -191,6 +191,7 @@ export class FungibleAsset extends BaseAsset {
       },
     } = await context.queryMiddleware<Ensured<Query, 'assetTransactions'>>(
       assetTransactionQuery(
+        context.isSqIdPadded,
         {
           assetId: middlewareAssetId,
         },

--- a/src/api/entities/Asset/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/NonFungible/NftCollection.ts
@@ -345,6 +345,7 @@ export class NftCollection extends BaseAsset {
       },
     } = await context.queryMiddleware<Ensured<Query, 'assetTransactions'>>(
       assetTransactionQuery(
+        context.isSqIdPadded,
         {
           assetId: id,
         },

--- a/src/api/entities/Asset/__tests__/Fungible/index.ts
+++ b/src/api/entities/Asset/__tests__/Fungible/index.ts
@@ -742,7 +742,7 @@ describe('Fungible class', () => {
       const datetime = '2020-10-10';
 
       dsMockUtils.createApolloQueryMock(
-        tickerExternalAgentHistoryQuery({
+        tickerExternalAgentHistoryQuery(false, {
           assetId,
         }),
         {
@@ -775,7 +775,7 @@ describe('Fungible class', () => {
       });
 
       dsMockUtils.createApolloQueryMock(
-        tickerExternalAgentHistoryQuery({
+        tickerExternalAgentHistoryQuery(false, {
           assetId,
         }),
         {
@@ -857,7 +857,7 @@ describe('Fungible class', () => {
         .mockReturnValue(assetId);
 
       dsMockUtils.createApolloQueryMock(
-        assetTransactionQuery({ assetId }, new BigNumber(3), new BigNumber(0)),
+        assetTransactionQuery(false, { assetId }, new BigNumber(3), new BigNumber(0)),
         {
           assetTransactions: transactionResponse,
         }

--- a/src/api/entities/Asset/__tests__/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/NftCollection.ts
@@ -631,7 +631,7 @@ describe('NftCollection class', () => {
       };
 
       dsMockUtils.createApolloQueryMock(
-        assetTransactionQuery({ assetId }, new BigNumber(3), new BigNumber(0)),
+        assetTransactionQuery(false, { assetId }, new BigNumber(3), new BigNumber(0)),
         {
           assetTransactions: transactionResponse,
         }

--- a/src/api/entities/DefaultTrustedClaimIssuer.ts
+++ b/src/api/entities/DefaultTrustedClaimIssuer.ts
@@ -66,7 +66,7 @@ export class DefaultTrustedClaimIssuer extends Identity {
         },
       },
     } = await context.queryMiddleware<Ensured<Query, 'trustedClaimIssuers'>>(
-      trustedClaimIssuerQuery({
+      trustedClaimIssuerQuery(context.isSqIdPadded, {
         assetId: middlewareAssetId,
         issuer,
       })

--- a/src/api/entities/Identity/AssetPermissions.ts
+++ b/src/api/entities/Identity/AssetPermissions.ts
@@ -333,7 +333,7 @@ export class AssetPermissions extends Namespace<Identity> {
         },
       },
     } = await context.queryMiddleware<Ensured<Query, 'tickerExternalAgents'>>(
-      tickerExternalAgentsQuery({
+      tickerExternalAgentsQuery(context.isSqIdPadded, {
         assetId: middlewareAssetId,
       })
     );
@@ -387,6 +387,7 @@ export class AssetPermissions extends Namespace<Identity> {
       },
     } = await context.queryMiddleware<Ensured<Query, 'tickerExternalAgentActions'>>(
       tickerExternalAgentActionsQuery(
+        context.isSqIdPadded,
         {
           assetId: middlewareAssetId,
           callerId: did,

--- a/src/api/entities/Identity/Portfolios.ts
+++ b/src/api/entities/Identity/Portfolios.ts
@@ -241,7 +241,7 @@ export class Portfolios extends Namespace<Identity> {
     }
 
     const settlementsPromise = context.queryMiddleware<Ensured<Query, 'legs'>>(
-      settlementsForAllPortfoliosQuery({
+      settlementsForAllPortfoliosQuery(context.isSqIdPadded, {
         identityId,
         address: account,
         assetId: middlewareAssetId,
@@ -249,7 +249,7 @@ export class Portfolios extends Namespace<Identity> {
     );
 
     const portfolioMovementsPromise = context.queryMiddleware<Ensured<Query, 'portfolioMovements'>>(
-      portfoliosMovementsQuery({
+      portfoliosMovementsQuery(context.isSqIdPadded, {
         identityId,
         address: account,
         assetId: middlewareAssetId,

--- a/src/api/entities/Identity/__tests__/Portfolios.ts
+++ b/src/api/entities/Identity/__tests__/Portfolios.ts
@@ -70,7 +70,7 @@ describe('Portfolios class', () => {
   });
 
   it('should extend namespace', () => {
-    expect(Portfolios.prototype instanceof Namespace).toBe(true);
+    expect(Portfolios.prototype).toBeInstanceOf(Namespace);
   });
 
   describe('method: getPortfolios', () => {
@@ -380,7 +380,7 @@ describe('Portfolios class', () => {
 
       dsMockUtils.createApolloMultipleQueriesMock([
         {
-          query: settlementsForAllPortfoliosQuery({
+          query: settlementsForAllPortfoliosQuery(false, {
             identityId: did,
             address: account,
             assetId: '0x12341234123412341234123412341234',
@@ -390,7 +390,7 @@ describe('Portfolios class', () => {
           },
         },
         {
-          query: portfoliosMovementsQuery({
+          query: portfoliosMovementsQuery(false, {
             identityId: did,
             address: account,
             assetId: '0x12341234123412341234123412341234',
@@ -432,7 +432,7 @@ describe('Portfolios class', () => {
 
       dsMockUtils.createApolloMultipleQueriesMock([
         {
-          query: settlementsForAllPortfoliosQuery({
+          query: settlementsForAllPortfoliosQuery(false, {
             identityId: did,
             address: undefined,
             assetId: '0x12341234123412341234123412341234',
@@ -444,7 +444,7 @@ describe('Portfolios class', () => {
           },
         },
         {
-          query: portfoliosMovementsQuery({
+          query: portfoliosMovementsQuery(false, {
             identityId: did,
             address: undefined,
             assetId: '0x12341234123412341234123412341234',
@@ -498,7 +498,7 @@ describe('Portfolios class', () => {
 
       dsMockUtils.createApolloMultipleQueriesMock([
         {
-          query: settlementsForAllPortfoliosQuery({
+          query: settlementsForAllPortfoliosQuery(false, {
             identityId: did,
             address: undefined,
             assetId: undefined,
@@ -510,7 +510,7 @@ describe('Portfolios class', () => {
           },
         },
         {
-          query: portfoliosMovementsQuery({
+          query: portfoliosMovementsQuery(false, {
             identityId: did,
             address: undefined,
             assetId: undefined,

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -398,7 +398,7 @@ describe('Instruction class', () => {
           memo,
         };
         dsMockUtils.createApolloQueryMock(
-          instructionsQuery({
+          instructionsQuery(false, {
             id: id.toString(),
           }),
           {
@@ -424,7 +424,7 @@ describe('Instruction class', () => {
         expect(result).toEqual(expect.objectContaining(expectedDetails));
 
         dsMockUtils.createApolloQueryMock(
-          instructionsQuery({
+          instructionsQuery(false, {
             id: id.toString(),
           }),
           {
@@ -450,7 +450,7 @@ describe('Instruction class', () => {
         );
 
         dsMockUtils.createApolloQueryMock(
-          instructionsQuery({
+          instructionsQuery(false, {
             id: id.toString(),
           }),
           {
@@ -477,7 +477,7 @@ describe('Instruction class', () => {
         );
 
         dsMockUtils.createApolloQueryMock(
-          instructionsQuery({
+          instructionsQuery(false, {
             id: id.toString(),
           }),
           {
@@ -502,7 +502,7 @@ describe('Instruction class', () => {
         );
 
         dsMockUtils.createApolloQueryMock(
-          instructionsQuery({
+          instructionsQuery(false, {
             id: id.toString(),
           }),
           {
@@ -524,7 +524,7 @@ describe('Instruction class', () => {
       });
 
       it('should throw an error if an Instruction is not yet processed by middleware', () => {
-        dsMockUtils.createApolloQueryMock(instructionsQuery({ id: id.toString() }), {
+        dsMockUtils.createApolloQueryMock(instructionsQuery(false, { id: id.toString() }), {
           instructions: { nodes: [] },
         });
 
@@ -1430,6 +1430,7 @@ describe('Instruction class', () => {
       dsMockUtils.createApolloMultipleQueriesMock([
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionExecuted,
               instructionId: id.toString(),
@@ -1445,6 +1446,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionFailed,
               instructionId: id.toString(),
@@ -1460,6 +1462,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.FailedToExecuteInstruction,
               instructionId: id.toString(),
@@ -1475,6 +1478,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionRejected,
               instructionId: id.toString(),
@@ -1528,6 +1532,7 @@ describe('Instruction class', () => {
       dsMockUtils.createApolloMultipleQueriesMock([
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionExecuted,
               instructionId: id.toString(),
@@ -1543,6 +1548,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionFailed,
               instructionId: id.toString(),
@@ -1558,6 +1564,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.FailedToExecuteInstruction,
               instructionId: id.toString(),
@@ -1573,6 +1580,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionRejected,
               instructionId: id.toString(),
@@ -1597,6 +1605,7 @@ describe('Instruction class', () => {
       dsMockUtils.createApolloMultipleQueriesMock([
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionExecuted,
               instructionId: id.toString(),
@@ -1612,6 +1621,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionFailed,
               instructionId: id.toString(),
@@ -1627,6 +1637,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.FailedToExecuteInstruction,
               instructionId: id.toString(),
@@ -1642,6 +1653,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionRejected,
               instructionId: id.toString(),
@@ -1695,6 +1707,7 @@ describe('Instruction class', () => {
       dsMockUtils.createApolloMultipleQueriesMock([
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionExecuted,
               instructionId: id.toString(),
@@ -1710,6 +1723,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionFailed,
               instructionId: id.toString(),
@@ -1725,6 +1739,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.FailedToExecuteInstruction,
               instructionId: id.toString(),
@@ -1740,6 +1755,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionRejected,
               instructionId: id.toString(),
@@ -1785,6 +1801,7 @@ describe('Instruction class', () => {
       dsMockUtils.createApolloMultipleQueriesMock([
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionExecuted,
               instructionId: id.toString(),
@@ -1800,6 +1817,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionFailed,
               instructionId: id.toString(),
@@ -1815,6 +1833,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.FailedToExecuteInstruction,
               instructionId: id.toString(),
@@ -1830,6 +1849,7 @@ describe('Instruction class', () => {
         },
         {
           query: instructionEventsQuery(
+            false,
             {
               event: InstructionEventEnum.InstructionRejected,
               instructionId: id.toString(),
@@ -1919,7 +1939,7 @@ describe('Instruction class', () => {
     describe('querying the middleware', () => {
       it('should return the instruction mediators', async () => {
         dsMockUtils.createApolloQueryMock(
-          instructionsQuery({
+          instructionsQuery(false, {
             id: id.toString(),
           }),
           {

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -355,7 +355,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
         },
       },
     } = await context.queryMiddleware<Ensured<Query, 'instructions'>>(
-      instructionsQuery({
+      instructionsQuery(false, {
         id: id.toString(),
       })
     );
@@ -854,6 +854,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       },
     } = await context.queryMiddleware<Ensured<Query, 'instructionEvents'>>(
       instructionEventsQuery(
+        context.isSqIdPadded,
         {
           event,
           instructionId: id.toString(),

--- a/src/api/entities/MultiSigProposal/__tests__/index.ts
+++ b/src/api/entities/MultiSigProposal/__tests__/index.ts
@@ -223,7 +223,7 @@ describe('MultiSigProposal class', () => {
       const action = MultiSigProposalVoteActionEnum.Approved;
 
       dsMockUtils.createApolloQueryMock(
-        multiSigProposalVotesQuery({
+        multiSigProposalVotesQuery(false, {
           proposalId: `${address}/${id.toString()}`,
         }),
         {
@@ -270,7 +270,7 @@ describe('MultiSigProposal class', () => {
       jest.spyOn(utilsConversionModule, 'addressToKey').mockImplementation();
 
       dsMockUtils.createApolloQueryMock(
-        multiSigProposalQuery({
+        multiSigProposalQuery(false, {
           multisigId: address,
           proposalId: id.toNumber(),
         }),
@@ -298,7 +298,7 @@ describe('MultiSigProposal class', () => {
         expect(result).toEqual({ blockNumber, blockHash, blockDate, eventIndex: eventIdx });
 
         dsMockUtils.createApolloQueryMock(
-          multiSigProposalQuery({
+          multiSigProposalQuery(false, {
             multisigId: address,
             proposalId: id.toNumber(),
           }),
@@ -324,7 +324,7 @@ describe('MultiSigProposal class', () => {
         );
 
         dsMockUtils.createApolloQueryMock(
-          multiSigProposalQuery({
+          multiSigProposalQuery(false, {
             multisigId: address,
             proposalId: id.toNumber(),
           }),

--- a/src/api/entities/MultiSigProposal/index.ts
+++ b/src/api/entities/MultiSigProposal/index.ts
@@ -285,7 +285,7 @@ export class MultiSigProposal extends Entity<UniqueIdentifiers, HumanReadable> {
         multiSigProposalVotes: { nodes: signerVotes },
       },
     } = await context.queryMiddleware<Ensured<Query, 'multiSigProposalVotes'>>(
-      multiSigProposalVotesQuery({
+      multiSigProposalVotesQuery(context.isSqIdPadded, {
         proposalId: `${address}/${id.toString()}`,
       })
     );
@@ -323,7 +323,7 @@ export class MultiSigProposal extends Entity<UniqueIdentifiers, HumanReadable> {
         },
       },
     } = await context.queryMiddleware<Ensured<Query, 'multiSigProposals'>>(
-      multiSigProposalQuery({
+      multiSigProposalQuery(context.isSqIdPadded, {
         multisigId: address,
         proposalId: id.toNumber(),
       })

--- a/src/api/entities/Offering/__tests__/index.ts
+++ b/src/api/entities/Offering/__tests__/index.ts
@@ -302,6 +302,7 @@ describe('Offering class', () => {
 
       dsMockUtils.createApolloQueryMock(
         investmentsQuery(
+          false,
           {
             stoId: id.toNumber(),
             offeringToken: assetId,
@@ -326,7 +327,7 @@ describe('Offering class', () => {
       expect(data[0].investedAmount).toEqual(raiseTokenAmount.div(Math.pow(10, 6)));
 
       dsMockUtils.createApolloQueryMock(
-        investmentsQuery({
+        investmentsQuery(false, {
           stoId: id.toNumber(),
           offeringToken: assetId,
         }),

--- a/src/api/entities/Offering/index.ts
+++ b/src/api/entities/Offering/index.ts
@@ -233,6 +233,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
       },
     } = await context.queryMiddleware<Ensured<Query, 'investments'>>(
       investmentsQuery(
+        context.isSqIdPadded,
         {
           stoId: id.toNumber(),
           offeringToken: middlewareAssetId,

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -87,7 +87,7 @@ describe('Portfolio class', () => {
   });
 
   it('should extend Entity', () => {
-    expect(Portfolio.prototype instanceof Entity).toBe(true);
+    expect(Portfolio.prototype).toBeInstanceOf(Entity);
   });
 
   describe('constructor', () => {
@@ -669,7 +669,7 @@ describe('Portfolio class', () => {
 
       dsMockUtils.createApolloMultipleQueriesMock([
         {
-          query: settlementsQuery({
+          query: settlementsQuery(false, {
             identityId: did,
             portfolioId: id,
             address: account,
@@ -680,7 +680,7 @@ describe('Portfolio class', () => {
           },
         },
         {
-          query: portfolioMovementsQuery({
+          query: portfolioMovementsQuery(false, {
             identityId: did,
             portfolioId: id,
             address: account,
@@ -721,7 +721,7 @@ describe('Portfolio class', () => {
 
       dsMockUtils.createApolloMultipleQueriesMock([
         {
-          query: settlementsQuery({
+          query: settlementsQuery(false, {
             identityId: did,
             portfolioId: undefined,
             address: undefined,
@@ -734,7 +734,7 @@ describe('Portfolio class', () => {
           },
         },
         {
-          query: portfolioMovementsQuery({
+          query: portfolioMovementsQuery(false, {
             identityId: did,
             portfolioId: undefined,
             address: undefined,
@@ -795,7 +795,7 @@ describe('Portfolio class', () => {
 
       dsMockUtils.createApolloMultipleQueriesMock([
         {
-          query: settlementsQuery({
+          query: settlementsQuery(false, {
             identityId: did,
             portfolioId: id,
             address: undefined,
@@ -808,7 +808,7 @@ describe('Portfolio class', () => {
           },
         },
         {
-          query: portfolioMovementsQuery({
+          query: portfolioMovementsQuery(false, {
             identityId: did,
             portfolioId: id,
             address: undefined,

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -419,7 +419,7 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
     }
 
     const settlementsPromise = context.queryMiddleware<Ensured<Query, 'legs'>>(
-      settlementsQuery({
+      settlementsQuery(context.isSqIdPadded, {
         identityId,
         portfolioId,
         address: account,
@@ -428,7 +428,7 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
     );
 
     const portfolioMovementsPromise = context.queryMiddleware<Ensured<Query, 'portfolioMovements'>>(
-      portfolioMovementsQuery({
+      portfolioMovementsQuery(context.isSqIdPadded, {
         identityId,
         portfolioId,
         address: account,

--- a/src/api/entities/Venue/__tests__/index.ts
+++ b/src/api/entities/Venue/__tests__/index.ts
@@ -175,6 +175,7 @@ describe('Venue class', () => {
 
       dsMockUtils.createApolloQueryMock(
         instructionsQuery(
+          false,
           {
             venueId: venueId.toString(),
           },
@@ -202,7 +203,7 @@ describe('Venue class', () => {
       expect(data).toEqual([mockHistoricInstruction]);
 
       dsMockUtils.createApolloQueryMock(
-        instructionsQuery({
+        instructionsQuery(false, {
           venueId: venueId.toString(),
         }),
         {

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -251,6 +251,7 @@ export class Venue extends Entity<UniqueIdentifiers, string> {
       },
     } = await context.queryMiddleware<Ensured<Query, 'instructions'>>(
       instructionsQuery(
+        context.isSqIdPadded,
         {
           venueId: id.toString(),
         },

--- a/src/api/entities/__tests__/DefaultTrustedClaimIssuer.ts
+++ b/src/api/entities/__tests__/DefaultTrustedClaimIssuer.ts
@@ -81,7 +81,7 @@ describe('DefaultTrustedClaimIssuer class', () => {
 
       when(getAssetIdForMiddlewareSpy).calledWith(assetId, context).mockResolvedValue(assetId);
 
-      dsMockUtils.createApolloQueryMock(trustedClaimIssuerQuery(variables), {
+      dsMockUtils.createApolloQueryMock(trustedClaimIssuerQuery(false, variables), {
         trustedClaimIssuers: {
           nodes: [
             {
@@ -104,7 +104,7 @@ describe('DefaultTrustedClaimIssuer class', () => {
     it('should return null if the query result is empty', async () => {
       const trustedClaimIssuer = new DefaultTrustedClaimIssuer({ did, assetId }, context);
 
-      dsMockUtils.createApolloQueryMock(trustedClaimIssuerQuery(variables), {
+      dsMockUtils.createApolloQueryMock(trustedClaimIssuerQuery(false, variables), {
         trustedClaimIssuers: {
           nodes: [],
         },

--- a/src/api/entities/common/namespaces/Authorizations.ts
+++ b/src/api/entities/common/namespaces/Authorizations.ts
@@ -173,7 +173,7 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
         authorizations: { totalCount, nodes: authorizationResult },
       },
     } = await context.queryMiddleware<Ensured<Query, 'authorizations'>>(
-      authorizationsQuery(filters, size, start)
+      authorizationsQuery(context.isSqIdPadded, filters, size, start)
     );
 
     const data = authorizationResult.map(middlewareAuthorization => {

--- a/src/api/entities/common/namespaces/__tests__/Authorizations.ts
+++ b/src/api/entities/common/namespaces/__tests__/Authorizations.ts
@@ -254,7 +254,7 @@ describe('Authorizations class', () => {
         toId: did,
       }));
 
-      dsMockUtils.createApolloQueryMock(authorizationsQuery({ toId: did }), {
+      dsMockUtils.createApolloQueryMock(authorizationsQuery(false, { toId: did }), {
         authorizations: {
           nodes: fakeAuths,
           totalCount: new BigNumber(10),
@@ -291,6 +291,7 @@ describe('Authorizations class', () => {
       };
       dsMockUtils.createApolloQueryMock(
         authorizationsQuery(
+          false,
           {
             type: AuthTypeEnum.RotatePrimaryKey,
             status: AuthorizationStatusEnum.Consumed,

--- a/src/api/procedures/__tests__/modifyClaims.ts
+++ b/src/api/procedures/__tests__/modifyClaims.ts
@@ -236,7 +236,7 @@ describe('modifyClaims procedure', () => {
     jest.clearAllMocks();
 
     dsMockUtils.createApolloQueryMock(
-      claimsQuery({
+      claimsQuery(false, {
         dids: [someDid, otherDid],
         trustedClaimIssuers: [issuer.did],
         includeExpired,
@@ -348,7 +348,7 @@ describe('modifyClaims procedure', () => {
     const { did } = await mockContext.getSigningIdentity();
 
     dsMockUtils.createApolloQueryMock(
-      claimsQuery({
+      claimsQuery(false, {
         trustedClaimIssuers: [did],
         dids: [someDid, otherDid],
         includeExpired,
@@ -426,7 +426,7 @@ describe('modifyClaims procedure', () => {
     const proc = procedureMockUtils.getInstance<ModifyClaimsParams, void>(mockContext);
 
     dsMockUtils.createApolloQueryMock(
-      claimsQuery({
+      claimsQuery(false, {
         trustedClaimIssuers: [issuer.did],
         dids: [someDid, otherDid],
         includeExpired,
@@ -439,7 +439,7 @@ describe('modifyClaims procedure', () => {
     );
 
     dsMockUtils.createApolloQueryMock(
-      claimsQuery({
+      claimsQuery(false, {
         dids: [someDid, otherDid],
         trustedClaimIssuers: [issuer.did],
         includeExpired,
@@ -491,7 +491,7 @@ describe('modifyClaims procedure', () => {
     const { did } = await mockContext.getSigningIdentity();
 
     dsMockUtils.createApolloQueryMock(
-      claimsQuery({
+      claimsQuery(false, {
         trustedClaimIssuers: [did],
         dids: [someDid, otherDid],
         includeExpired,

--- a/src/api/procedures/modifyClaims.ts
+++ b/src/api/procedures/modifyClaims.ts
@@ -163,7 +163,7 @@ export async function prepareModifyClaims(
     const { did: currentDid } = await context.getSigningIdentity();
 
     const result = await context.queryMiddleware<Ensured<Query, 'claims'>>(
-      claimsQuery({
+      claimsQuery(context.isSqIdPadded, {
         dids: allTargets,
         trustedClaimIssuers: [currentDid],
         includeExpired: true,

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -1315,6 +1315,7 @@ describe('Context class', () => {
 
       dsMockUtils.createApolloQueryMock(
         claimsQuery(
+          false,
           {
             dids: [targetDid],
             trustedClaimIssuers: [targetDid],
@@ -1344,6 +1345,7 @@ describe('Context class', () => {
 
       dsMockUtils.createApolloQueryMock(
         claimsQuery(
+          false,
           {
             dids: undefined,
             trustedClaimIssuers: undefined,
@@ -2174,7 +2176,40 @@ describe('Context class', () => {
       jest.spyOn(utilsInternalModule, 'getLatestSqVersion').mockResolvedValue(sqVersion);
 
       const result = await context.getMiddlewareMetadata();
-      expect(result).toEqual(metadata);
+      expect(result).toEqual({ paddedIds: false, ...metadata });
+    });
+
+    it('should return paddedId if sq version is greater than 19', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      const sqVersion = '19.0.1';
+      const metadata = {
+        chain: 'Polymesh Testnet Develop',
+        specName: 'polymesh_testnet',
+        genesisHash: '0x3c3183f6d701500766ff7d147b79c4f10014a095eaaa98e960dcef6b3ead50ee',
+        lastProcessedHeight: new BigNumber(6120220),
+        lastProcessedTimestamp: new Date('01/06/2023'),
+        targetHeight: new BigNumber(6120219),
+        indexerHealthy: true,
+        sqVersion,
+      };
+
+      dsMockUtils.createApolloQueryMock(metadataQuery(), {
+        _metadata: {
+          ...metadata,
+          lastProcessedTimestamp: metadata.lastProcessedTimestamp.getTime().toString(),
+          lastProcessedHeight: metadata.lastProcessedHeight.toString(),
+          targetHeight: metadata.targetHeight.toString(),
+        },
+      });
+
+      jest.spyOn(utilsInternalModule, 'getLatestSqVersion').mockResolvedValue(sqVersion);
+
+      const result = await context.getMiddlewareMetadata();
+      expect(result).toEqual({ paddedIds: true, ...metadata });
     });
 
     it('should return null if middleware V2 is disabled', async () => {
@@ -2282,6 +2317,7 @@ describe('Context class', () => {
 
       dsMockUtils.createApolloQueryMock(
         polyxTransactionsQuery(
+          false,
           {
             identityId: 'someDid',
             addresses: ['someAddress'],
@@ -2308,6 +2344,7 @@ describe('Context class', () => {
 
       dsMockUtils.createApolloQueryMock(
         polyxTransactionsQuery(
+          false,
           {
             identityId: undefined,
             addresses: undefined,

--- a/src/middleware/__tests__/queries/assets.ts
+++ b/src/middleware/__tests__/queries/assets.ts
@@ -78,12 +78,12 @@ describe('assetTransactionQuery', () => {
       start: 0,
     };
 
-    let result = assetTransactionQuery(variables);
+    let result = assetTransactionQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
-    result = assetTransactionQuery(variables, new BigNumber(1), new BigNumber(0));
+    result = assetTransactionQuery(false, variables, new BigNumber(1), new BigNumber(0));
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/__tests__/queries/authorizations.ts
+++ b/src/middleware/__tests__/queries/authorizations.ts
@@ -6,7 +6,7 @@ import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 
 describe('authorizationsQuery', () => {
   it('should pass the variables to the grapqhl query', () => {
-    let result = authorizationsQuery({});
+    let result = authorizationsQuery(false, {});
 
     expect(result.query).toBeDefined();
 
@@ -20,12 +20,12 @@ describe('authorizationsQuery', () => {
       start: 0,
     };
 
-    result = authorizationsQuery(variables);
+    result = authorizationsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
-    result = authorizationsQuery(variables, new BigNumber(1), new BigNumber(0));
+    result = authorizationsQuery(false, variables, new BigNumber(1), new BigNumber(0));
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/__tests__/queries/claims.ts
+++ b/src/middleware/__tests__/queries/claims.ts
@@ -41,12 +41,13 @@ describe('claimsQuery', () => {
       start: 0,
     };
 
-    let result = claimsQuery(variables);
+    let result = claimsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
     result = claimsQuery(
+      false,
       { ...variables, includeExpired: false },
       new BigNumber(1),
       new BigNumber(0)
@@ -63,7 +64,7 @@ describe('claimsQuery', () => {
   });
 
   it('should not include undefined values in the variables', () => {
-    const result = claimsQuery({ includeExpired: true });
+    const result = claimsQuery(false, { includeExpired: true });
     expect(result.variables).toEqual({
       includeExpired: true,
       size: DEFAULT_GQL_PAGE_SIZE,
@@ -79,7 +80,7 @@ describe('trustedClaimIssuerQuery', () => {
       assetId: 'SOME_TICKER',
     };
 
-    const result = trustedClaimIssuerQuery(variables);
+    const result = trustedClaimIssuerQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);

--- a/src/middleware/__tests__/queries/events.ts
+++ b/src/middleware/__tests__/queries/events.ts
@@ -6,7 +6,7 @@ import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 
 describe('eventsByArgs', () => {
   it('should pass the variables to the grapqhl query', () => {
-    let result = eventsByArgs({});
+    let result = eventsByArgs(false, {});
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({ size: DEFAULT_GQL_PAGE_SIZE, start: 0 });
@@ -19,12 +19,12 @@ describe('eventsByArgs', () => {
       start: 0,
     };
 
-    result = eventsByArgs(variables);
+    result = eventsByArgs(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
-    result = eventsByArgs(variables, new BigNumber(1), new BigNumber(0));
+    result = eventsByArgs(false, variables, new BigNumber(1), new BigNumber(0));
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/__tests__/queries/externalAgents.ts
+++ b/src/middleware/__tests__/queries/externalAgents.ts
@@ -14,7 +14,7 @@ describe('tickerExternalAgentsQuery', () => {
       assetId: 'SOME_TICKER',
     };
 
-    const result = tickerExternalAgentsQuery(variables);
+    const result = tickerExternalAgentsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
@@ -27,7 +27,7 @@ describe('tickerExternalAgentHistoryQuery', () => {
       assetId: 'SOME_TICKER',
     };
 
-    const result = tickerExternalAgentHistoryQuery(variables);
+    const result = tickerExternalAgentHistoryQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
@@ -36,7 +36,7 @@ describe('tickerExternalAgentHistoryQuery', () => {
 
 describe('tickerExternalAgentActionsQuery', () => {
   it('should pass the variables to the grapqhl query', () => {
-    let result = tickerExternalAgentActionsQuery({});
+    let result = tickerExternalAgentActionsQuery(false, {});
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({ size: DEFAULT_GQL_PAGE_SIZE, start: 0 });
@@ -50,12 +50,12 @@ describe('tickerExternalAgentActionsQuery', () => {
       start: 0,
     };
 
-    result = tickerExternalAgentActionsQuery(variables);
+    result = tickerExternalAgentActionsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
-    result = tickerExternalAgentActionsQuery(variables, new BigNumber(1), new BigNumber(0));
+    result = tickerExternalAgentActionsQuery(false, variables, new BigNumber(1), new BigNumber(0));
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/__tests__/queries/multisigs.ts
+++ b/src/middleware/__tests__/queries/multisigs.ts
@@ -14,7 +14,7 @@ describe('multiSigProposalQuery', () => {
       proposalId: 1,
     };
 
-    const result = multiSigProposalQuery(variables);
+    const result = multiSigProposalQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
@@ -27,7 +27,7 @@ describe('multiSigProposalVotesQuery', () => {
       proposalId: 'multiSigAddress/1',
     };
 
-    const result = multiSigProposalVotesQuery(variables);
+    const result = multiSigProposalVotesQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);

--- a/src/middleware/__tests__/queries/polyxTransactions.ts
+++ b/src/middleware/__tests__/queries/polyxTransactions.ts
@@ -12,12 +12,12 @@ describe('polyxTransactionsQuery', () => {
       start: 0,
     };
 
-    let result = polyxTransactionsQuery(variables);
+    let result = polyxTransactionsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
-    result = polyxTransactionsQuery({}, new BigNumber(10), new BigNumber(2));
+    result = polyxTransactionsQuery(false, {}, new BigNumber(10), new BigNumber(2));
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/__tests__/queries/portfolios.ts
+++ b/src/middleware/__tests__/queries/portfolios.ts
@@ -25,7 +25,7 @@ describe('portfolioMovementsQuery', () => {
       address: 'someAddress',
     };
 
-    const result = portfolioMovementsQuery(variables);
+    const result = portfolioMovementsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/__tests__/queries/settlements.ts
+++ b/src/middleware/__tests__/queries/settlements.ts
@@ -23,12 +23,13 @@ describe('instructionsQuery', () => {
       start: 0,
     };
 
-    let result = instructionsQuery(variables);
+    let result = instructionsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
     result = instructionsQuery(
+      true,
       {
         venueId: '2',
       },
@@ -201,11 +202,12 @@ describe('instructionEventsQuery', () => {
       size: DEFAULT_GQL_PAGE_SIZE,
       start: 0,
     };
-    let result = instructionEventsQuery(variables);
+    let result = instructionEventsQuery(false, variables);
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
     result = instructionEventsQuery(
+      true,
       {
         event: InstructionEventEnum.InstructionFailed,
       },
@@ -231,7 +233,7 @@ describe('settlementsQuery', () => {
       address: 'someAddress',
     };
 
-    const result = settlementsQuery(variables);
+    const result = settlementsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({
@@ -253,7 +255,7 @@ describe('settlementsForAllPortfoliosQuery', () => {
       address: 'someAddress',
     };
 
-    const result = settlementsForAllPortfoliosQuery(variables);
+    const result = settlementsForAllPortfoliosQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/__tests__/queries/stos.ts
+++ b/src/middleware/__tests__/queries/stos.ts
@@ -10,7 +10,7 @@ describe('investmentsQuery', () => {
       start: 0,
     };
 
-    const result = investmentsQuery(variables);
+    const result = investmentsQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);

--- a/src/middleware/queries/assets.ts
+++ b/src/middleware/queries/assets.ts
@@ -126,15 +126,20 @@ export function nftHoldersQuery(
  * Get the balance history for an Asset
  */
 export function assetTransactionQuery(
+  paddedIds: boolean,
   filters: QueryArgs<AssetTransaction, 'assetId'>,
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<AssetTransaction, 'assetId'>>> {
+  const orderBy = paddedIds
+    ? `${AssetTransactionsOrderBy.CreatedBlockIdAsc}`
+    : `${AssetTransactionsOrderBy.CreatedAtAsc}, ${AssetTransactionsOrderBy.CreatedBlockIdAsc}`;
+
   const query = gql`
     query AssetTransactionQuery($assetId: String!) {
       assetTransactions(
         filter: { assetId: { equalTo: $assetId } }
-        orderBy: [${AssetTransactionsOrderBy.CreatedAtAsc}, ${AssetTransactionsOrderBy.CreatedBlockIdAsc}]
+        orderBy:  [${orderBy}]
       ) {
         totalCount
         nodes {

--- a/src/middleware/queries/authorizations.ts
+++ b/src/middleware/queries/authorizations.ts
@@ -52,11 +52,17 @@ function createAuthorizationFilters(variables: QueryArgs<Authorization, Authoriz
  * Get all authorizations with specified filters
  */
 export function authorizationsQuery(
+  paddedIds: boolean,
   filters: QueryArgs<Authorization, AuthorizationArgs>,
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Authorization, AuthorizationArgs>>> {
   const { args, filter } = createAuthorizationFilters(filters);
+
+  const idField = paddedIds ? 'id' : 'authId: id';
+  const orderBy = paddedIds
+    ? `${AuthorizationsOrderBy.CreatedBlockIdAsc}`
+    : `${AuthorizationsOrderBy.CreatedAtAsc}, ${AuthorizationsOrderBy.CreatedBlockIdAsc}`;
 
   const query = gql`
     query AuthorizationsQuery
@@ -66,11 +72,11 @@ export function authorizationsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${AuthorizationsOrderBy.CreatedAtAsc}, ${AuthorizationsOrderBy.CreatedBlockIdAsc}]
+        orderBy: [${orderBy}]
       ) {
         totalCount
         nodes {
-          id
+          ${idField}
           type
           fromId
           toId

--- a/src/middleware/queries/claims.ts
+++ b/src/middleware/queries/claims.ts
@@ -99,11 +99,16 @@ export function claimsGroupingQuery(
  * Get all claims that a given target DID has, with a given scope and from one of the given trustedClaimIssuers
  */
 export function claimsQuery(
+  paddedIds: boolean,
   filters: ClaimsQueryFilter,
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<ClaimsQueryFilter>> {
   const { args, filter } = createClaimsFilters(filters);
+
+  const orderBy = paddedIds
+    ? `${ClaimsOrderBy.TargetIdAsc}, ${ClaimsOrderBy.CreatedBlockIdAsc}, ${ClaimsOrderBy.EventIdxAsc}`
+    : `${ClaimsOrderBy.TargetIdAsc}, ${ClaimsOrderBy.CreatedAtAsc}, ${ClaimsOrderBy.CreatedBlockIdAsc}, ${ClaimsOrderBy.EventIdxAsc}`;
 
   const query = gql`
     query ClaimsQuery
@@ -111,7 +116,7 @@ export function claimsQuery(
       {
         claims(
           ${filter}
-          orderBy: [${ClaimsOrderBy.TargetIdAsc}, ${ClaimsOrderBy.CreatedAtAsc}, ${ClaimsOrderBy.CreatedBlockIdAsc}, ${ClaimsOrderBy.EventIdxAsc}]
+          orderBy: [${orderBy}]
           first: $size
           offset: $start
         ) {
@@ -148,13 +153,18 @@ export function claimsQuery(
  * Get an trusted claim issuer event for an asset and an issuer
  */
 export function trustedClaimIssuerQuery(
+  paddedIds: boolean,
   variables: QueryArgs<TrustedClaimIssuer, 'issuer' | 'assetId'>
 ): QueryOptions<QueryArgs<TrustedClaimIssuer, 'issuer' | 'assetId'>> {
+  const orderBy = paddedIds
+    ? `${TrustedClaimIssuersOrderBy.CreatedBlockIdDesc}`
+    : `${TrustedClaimIssuersOrderBy.CreatedAtDesc}, ${TrustedClaimIssuersOrderBy.CreatedBlockIdDesc}`;
+
   const query = gql`
     query TrustedClaimIssuerQuery($assetId: String!, $issuer: String!) {
       trustedClaimIssuers(
-        filter: { assetId: { equalTo: $assetId }, issuer: { equalTo: $issuer } },
-        orderBy: [${TrustedClaimIssuersOrderBy.CreatedAtDesc}, ${TrustedClaimIssuersOrderBy.CreatedBlockIdDesc}]
+        filter: { assetId: { equalTo: $assetId }, issuer: { equalTo: $issuer } }
+        orderBy: [${orderBy}]
       ) {
         nodes {
           eventIdx

--- a/src/middleware/queries/common.ts
+++ b/src/middleware/queries/common.ts
@@ -86,11 +86,10 @@ export function metadataQuery(): QueryOptions {
 export function latestSqVersionQuery(): QueryOptions {
   const query = gql`
     query SubqueryVersions {
-      subqueryVersions(orderBy: [${SubqueryVersionsOrderBy.CreatedAtDesc}], first: 1) {
+      subqueryVersions(orderBy: [${SubqueryVersionsOrderBy.IdDesc}], first: 1) {
         nodes {
           id
           version
-          createdAt
         }
       }
     }
@@ -163,4 +162,13 @@ export function removeUndefinedValues(
   variables: Record<string | number | symbol, unknown>
 ): Record<string | number | symbol, unknown> {
   return Object.fromEntries(Object.entries(variables).filter(([, value]) => value !== undefined));
+}
+
+/**
+ * Pad ID for subquery
+ *
+ * @hidden
+ */
+export function padSqId(id: string): string {
+  return id.padStart(10, '0');
 }

--- a/src/middleware/queries/events.ts
+++ b/src/middleware/queries/events.ts
@@ -14,6 +14,7 @@ type EventArgs = 'moduleId' | 'eventId' | 'eventArg0' | 'eventArg1' | 'eventArg2
  * Get a single event by any of its indexed arguments
  */
 export function eventsByArgs(
+  paddedIds: boolean,
   filters: QueryArgs<Event, EventArgs>,
   size?: BigNumber,
   start?: BigNumber
@@ -22,13 +23,18 @@ export function eventsByArgs(
     moduleId: 'ModuleIdEnum',
     eventId: 'EventIdEnum',
   });
+
+  const orderBy = paddedIds
+    ? `${EventsOrderBy.BlockIdAsc}`
+    : `${EventsOrderBy.CreatedAtAsc}, ${EventsOrderBy.BlockIdAsc}`;
+
   const query = gql`
     query EventsQuery
       ${args}
      {
       events(
         ${filter}
-        orderBy: [${EventsOrderBy.CreatedAtAsc}, ${EventsOrderBy.BlockIdAsc}]
+        orderBy: [${orderBy}]
         first: $size
         offset: $start
       ) {

--- a/src/middleware/queries/externalAgents.ts
+++ b/src/middleware/queries/externalAgents.ts
@@ -19,13 +19,18 @@ import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
  * Get the event details when external agent added for a ticker
  */
 export function tickerExternalAgentsQuery(
+  paddedIds: boolean,
   variables: QueryArgs<TickerExternalAgent, 'assetId'>
 ): QueryOptions<QueryArgs<TickerExternalAgent, 'assetId'>> {
+  const orderBy = paddedIds
+    ? `${TickerExternalAgentsOrderBy.CreatedBlockIdDesc}`
+    : `${TickerExternalAgentsOrderBy.CreatedAtDesc}, ${TickerExternalAgentsOrderBy.CreatedBlockIdDesc}`;
+
   const query = gql`
     query TickerExternalAgentQuery($assetId: String!) {
       tickerExternalAgents(
         filter: { assetId: { equalTo: $assetId } }
-        orderBy: [${TickerExternalAgentsOrderBy.CreatedAtDesc}, ${TickerExternalAgentsOrderBy.CreatedBlockIdDesc}]
+        orderBy: [${orderBy}]
         first: 1
       ) {
         nodes {
@@ -52,13 +57,18 @@ export function tickerExternalAgentsQuery(
  * Get the transaction history of each external agent of an Asset
  */
 export function tickerExternalAgentHistoryQuery(
+  paddedIds: boolean,
   variables: QueryArgs<TickerExternalAgentHistory, 'assetId'>
 ): QueryOptions<QueryArgs<TickerExternalAgentHistory, 'assetId'>> {
+  const orderBy = paddedIds
+    ? `${TickerExternalAgentHistoriesOrderBy.CreatedBlockIdAsc}`
+    : `${TickerExternalAgentHistoriesOrderBy.CreatedAtAsc}, ${TickerExternalAgentHistoriesOrderBy.CreatedBlockIdAsc}`;
+
   const query = gql`
     query TickerExternalAgentHistoryQuery($assetId: String!) {
       tickerExternalAgentHistories(
         filter: { assetId: { equalTo: $assetId } }
-        orderBy: [${TickerExternalAgentHistoriesOrderBy.CreatedAtAsc}, ${TickerExternalAgentHistoriesOrderBy.CreatedBlockIdAsc}]
+        orderBy: [${orderBy}]
       ) {
         nodes {
           identityId
@@ -87,6 +97,7 @@ type TickerExternalAgentActionArgs = 'assetId' | 'callerId' | 'palletName' | 'ev
  * Get list of Events triggered by actions (from the set of actions that can only be performed by external agents) that have been performed on a specific Asset
  */
 export function tickerExternalAgentActionsQuery(
+  paddedIds: boolean,
   filters: QueryArgs<TickerExternalAgentAction, TickerExternalAgentActionArgs>,
   size?: BigNumber,
   start?: BigNumber
@@ -94,6 +105,9 @@ export function tickerExternalAgentActionsQuery(
   PaginatedQueryArgs<QueryArgs<TickerExternalAgentAction, TickerExternalAgentActionArgs>>
 > {
   const { args, filter } = createArgsAndFilters(filters, { eventId: 'EventIdEnum' });
+  const orderBy = paddedIds
+    ? `${TickerExternalAgentActionsOrderBy.CreatedBlockIdDesc}`
+    : `${TickerExternalAgentActionsOrderBy.CreatedAtDesc}, ${TickerExternalAgentActionsOrderBy.CreatedBlockIdDesc}`;
   const query = gql`
     query TickerExternalAgentActionsQuery
       ${args}
@@ -102,7 +116,7 @@ export function tickerExternalAgentActionsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${TickerExternalAgentActionsOrderBy.CreatedAtDesc}, ${TickerExternalAgentActionsOrderBy.CreatedBlockIdDesc}]
+        orderBy: [${orderBy}]
       ) {
         totalCount
         nodes {

--- a/src/middleware/queries/multisigs.ts
+++ b/src/middleware/queries/multisigs.ts
@@ -16,8 +16,13 @@ import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
  * Get MultiSig proposal details for a given MultiSig address and portfolio ID
  */
 export function multiSigProposalQuery(
+  paddedIds: boolean,
   variables: QueryArgs<MultiSigProposal, 'multisigId' | 'proposalId'>
 ): QueryOptions<QueryArgs<MultiSigProposal, 'multisigId' | 'proposalId'>> {
+  const orderBy = paddedIds
+    ? `${MultiSigProposalVotesOrderBy.CreatedBlockIdAsc}, ${MultiSigProposalVotesOrderBy.EventIdxAsc}`
+    : `${MultiSigProposalVotesOrderBy.CreatedAtAsc}, ${MultiSigProposalVotesOrderBy.CreatedBlockIdAsc}, ${MultiSigProposalVotesOrderBy.EventIdxAsc}`;
+
   const query = gql`
     query MultiSigProposalQuery($multisigId: String!, $proposalId: Int!) {
       multiSigProposals(
@@ -32,7 +37,7 @@ export function multiSigProposalQuery(
             hash
             datetime
           }
-          votes(orderBy: [${MultiSigProposalVotesOrderBy.CreatedAtAsc}, ${MultiSigProposalVotesOrderBy.CreatedBlockIdAsc}, ${MultiSigProposalVotesOrderBy.EventIdxAsc}]) {
+          votes(orderBy: [${orderBy}]) {
             nodes {
               action
               signer {
@@ -63,13 +68,18 @@ export function multiSigProposalQuery(
  * Get MultiSig proposal votes for a given proposalId ({multiSigAddress}/{proposalId})
  */
 export function multiSigProposalVotesQuery(
+  paddedIds: boolean,
   variables: QueryArgs<MultiSigProposalVote, 'proposalId'>
 ): QueryOptions<QueryArgs<MultiSigProposalVote, 'proposalId'>> {
+  const orderBy = paddedIds
+    ? `${MultiSigProposalVotesOrderBy.CreatedBlockIdAsc}, ${MultiSigProposalVotesOrderBy.EventIdxAsc}`
+    : `${MultiSigProposalVotesOrderBy.CreatedAtAsc}, ${MultiSigProposalVotesOrderBy.CreatedBlockIdAsc}, ${MultiSigProposalVotesOrderBy.EventIdxAsc}`;
+
   const query = gql`
     query MultiSigProposalVotesQuery($proposalId: String!) {
       multiSigProposalVotes(
         filter: { proposalId: { equalTo: $proposalId } }
-        orderBy: [${MultiSigProposalVotesOrderBy.CreatedAtAsc}, ${MultiSigProposalVotesOrderBy.CreatedBlockIdAsc}, ${MultiSigProposalVotesOrderBy.EventIdxAsc}]
+        orderBy: [${orderBy}]
       ) {
         nodes {
           signer {

--- a/src/middleware/queries/polyxTransactions.ts
+++ b/src/middleware/queries/polyxTransactions.ts
@@ -54,11 +54,17 @@ function createPolyxTransactionFilters({ identityId, addresses }: QueryPolyxTran
  * Get POLYX transactions where an Account or an Identity is involved
  */
 export function polyxTransactionsQuery(
+  paddedIds: boolean,
   filters: QueryPolyxTransactionFilters,
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<QueryPolyxTransactionFilters>> {
   const { args, filter, variables } = createPolyxTransactionFilters(filters);
+
+  const orderBy = paddedIds
+    ? `${PolyxTransactionsOrderBy.CreatedBlockIdAsc}`
+    : `${PolyxTransactionsOrderBy.CreatedAtAsc}, ${PolyxTransactionsOrderBy.CreatedBlockIdAsc}`;
+
   const query = gql`
     query PolyxTransactionsQuery
       ${args}
@@ -67,7 +73,7 @@ export function polyxTransactionsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${PolyxTransactionsOrderBy.CreatedAtAsc}, ${PolyxTransactionsOrderBy.CreatedBlockIdAsc}]
+        orderBy: [${orderBy}]
       ) {
         nodes {
           id

--- a/src/middleware/queries/portfolios.ts
+++ b/src/middleware/queries/portfolios.ts
@@ -84,14 +84,22 @@ function createPortfolioMovementFilters(
 /**
  * @hidden
  */
-function buildPortfolioMovementsQuery(args: string, filter: string): DocumentNode {
+function buildPortfolioMovementsQuery(
+  paddedIds: boolean,
+  args: string,
+  filter: string
+): DocumentNode {
+  const orderBy = paddedIds
+    ? `${PortfolioMovementsOrderBy.CreatedBlockIdAsc}`
+    : `${PortfolioMovementsOrderBy.CreatedAtAsc}, ${PortfolioMovementsOrderBy.CreatedBlockIdAsc}`;
+
   return gql`
   query PortfolioMovementsQuery
     ${args}
    {
     portfolioMovements(
       ${filter}
-      orderBy: [${PortfolioMovementsOrderBy.CreatedAtAsc}, ${PortfolioMovementsOrderBy.CreatedBlockIdAsc}]
+      orderBy: [${orderBy}]
     ) {
       nodes {
         id
@@ -120,10 +128,11 @@ function buildPortfolioMovementsQuery(args: string, filter: string): DocumentNod
  * Get Settlements where a Portfolio is involved
  */
 export function portfolioMovementsQuery(
+  paddedIds: boolean,
   filters: QuerySettlementFilters
 ): QueryOptions<QueryArgs<PortfolioMovement, 'fromId' | 'toId' | 'assetId' | 'address'>> {
   const { args, filter, variables } = createPortfolioMovementFilters(filters);
-  const query = buildPortfolioMovementsQuery(args, filter);
+  const query = buildPortfolioMovementsQuery(paddedIds, args, filter);
 
   return {
     query,
@@ -137,10 +146,11 @@ export function portfolioMovementsQuery(
  * Get Settlements for all portfolios
  */
 export function portfoliosMovementsQuery(
+  paddedIds: boolean,
   filters: Omit<QuerySettlementFilters, 'portfolioId'>
 ): QueryOptions<QueryArgs<PortfolioMovement, 'fromId' | 'toId' | 'assetId' | 'address'>> {
   const { args, filter, variables } = createPortfolioMovementFilters(filters, true);
-  const query = buildPortfolioMovementsQuery(args, filter);
+  const query = buildPortfolioMovementsQuery(paddedIds, args, filter);
 
   return {
     query,

--- a/src/middleware/queries/stos.ts
+++ b/src/middleware/queries/stos.ts
@@ -12,17 +12,22 @@ import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
  * Get all investments for a given offering
  */
 export function investmentsQuery(
+  paddedIds: boolean,
   filters: QueryArgs<Investment, 'stoId' | 'offeringToken'>,
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Investment, 'stoId' | 'offeringToken'>>> {
+  const orderBy = paddedIds
+    ? `${InvestmentsOrderBy.CreatedBlockIdAsc}`
+    : `${InvestmentsOrderBy.CreatedAtAsc}, ${InvestmentsOrderBy.CreatedBlockIdAsc}`;
+
   const query = gql`
     query InvestmentsQuery($stoId: Int!, $offeringToken: String!, $size: Int, $start: Int) {
       investments(
         filter: { stoId: { equalTo: $stoId }, offeringToken: { equalTo: $offeringToken } }
         first: $size
         offset: $start
-        orderBy: [${InvestmentsOrderBy.CreatedAtAsc}, ${InvestmentsOrderBy.CreatedBlockIdAsc}]
+        orderBy: [${orderBy}]
       ) {
         totalCount
         nodes {

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -771,6 +771,7 @@ const defaultContextOptions: ContextOptions = {
     targetHeight: new BigNumber(10000),
     indexerHealthy: true,
     sqVersion: '1.0.0',
+    paddedIds: false,
   },
   sentAuthorizations: {
     data: [{} as AuthorizationRequest],

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -153,6 +153,11 @@ export const DEFAULT_CDD_ID = '0x00000000000000000000000000000000000000000000000
 export const MINIMUM_SQ_VERSION = '16.1.0';
 
 /**
+ * The first version of Subquery that pads IDs for proper lexical order
+ */
+export const MINIMUM_SQ_PADDED_ID_VERSION = '19.0.0';
+
+/**
  * Global metadata key used to conventionally register an NFT image
  */
 export const GLOBAL_IMAGE_URI_NAME = 'imageUri';


### PR DESCRIPTION
### Description

Add dual version SubQuery support. v19+ SQ instance will pad block ID values so ordering by created block is such that the lexical order is equivalent to numerical order. Also created_at column has been removed as the padding makes it redundant (it was the time of sync, not the time on chain).

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

[DA-1371](https://polymesh.atlassian.net/browse/DA-1371)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1371]: https://polymesh.atlassian.net/browse/DA-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ