### PR TITLE
fix: 🐛 Fetch legs from chain while instruction affirm/execution

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -1,8 +1,5 @@
-import { Option, StorageKey, u64 } from '@polkadot/types';
-import {
-  PolymeshPrimitivesIdentityIdPortfolioId,
-  PolymeshPrimitivesSettlementLeg,
-} from '@polkadot/types/lookup';
+import { StorageKey, u64 } from '@polkadot/types';
+import { PolymeshPrimitivesIdentityIdPortfolioId } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -22,12 +19,7 @@ import {
   LegTypeEnum,
 } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
-import {
-  createMockAssetId,
-  createMockInstructionStatus,
-  createMockNfts,
-  createMockU64,
-} from '~/testUtils/mocks/dataSources';
+import { createMockInstructionStatus } from '~/testUtils/mocks/dataSources';
 import { Mocked } from '~/testUtils/types';
 import {
   AffirmationStatus,
@@ -35,8 +27,7 @@ import {
   InstructionAffirmationOperation,
   InstructionStatus,
   InstructionType,
-  NftLeg,
-  OffChainLeg,
+  Leg,
   SignerKeyRingType,
   UnsubCallback,
 } from '~/types';
@@ -959,221 +950,19 @@ describe('Instruction class', () => {
     });
 
     describe('querying from chain', () => {
-      let instructionStatusMock: jest.Mock;
-
-      let bigNumberToU64Spy: jest.SpyInstance;
-
-      beforeAll(() => {
-        bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
-      });
-
-      beforeEach(() => {
-        dsMockUtils.configureMocks({ contextOptions: { middlewareAvailable: false } });
-        dsMockUtils.createQueryMock('settlement', 'instructionCounter', {
-          returnValue: dsMockUtils.createMockU64(new BigNumber(1000)),
-        });
-        when(bigNumberToU64Spy).calledWith(id, context).mockReturnValue(rawId);
-        dsMockUtils.createQueryMock('settlement', 'instructionLegs');
-        instructionStatusMock = dsMockUtils.createQueryMock('settlement', 'instructionStatuses');
-      });
-
       it("should return the instruction's legs", async () => {
-        const fromDid = 'fromDid';
-        const toDid = 'toDid';
-        const assetId = '0x11111111111181111111111111111111';
-        const assetId2 = '0x22222222222222222222222222222222';
-        const amount = new BigNumber(1000);
+        const mockData = {
+          data: ['leg' as unknown as Leg],
+          next: null,
+          count: new BigNumber(1),
+        };
+        dsMockUtils.configureMocks({
+          contextOptions: { getInstructionLegsFromChain: mockData, middlewareAvailable: false },
+        });
 
-        entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
-        instructionStatusMock.mockResolvedValue(
-          createMockInstructionStatus(InternalInstructionStatus.Pending)
-        );
-        const mockLeg1 = dsMockUtils.createMockOption(
-          dsMockUtils.createMockInstructionLeg({
-            Fungible: {
-              sender: dsMockUtils.createMockPortfolioId({
-                did: dsMockUtils.createMockIdentityId(fromDid),
-                kind: dsMockUtils.createMockPortfolioKind('Default'),
-              }),
-              receiver: dsMockUtils.createMockPortfolioId({
-                did: dsMockUtils.createMockIdentityId(toDid),
-                kind: dsMockUtils.createMockPortfolioKind('Default'),
-              }),
-              assetId: dsMockUtils.createMockAssetId(assetId),
-              amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
-            },
-          })
-        );
+        const result = await instruction.getLegs();
 
-        const mockLeg2 = dsMockUtils.createMockOption(
-          dsMockUtils.createMockInstructionLeg({
-            Fungible: {
-              sender: dsMockUtils.createMockPortfolioId({
-                did: dsMockUtils.createMockIdentityId(fromDid),
-                kind: dsMockUtils.createMockPortfolioKind('Default'),
-              }),
-              receiver: dsMockUtils.createMockPortfolioId({
-                did: dsMockUtils.createMockIdentityId(toDid),
-                kind: dsMockUtils.createMockPortfolioKind('Default'),
-              }),
-              assetId: dsMockUtils.createMockAssetId(assetId2),
-              amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
-            },
-          })
-        );
-        const entries: [StorageKey<[u64, u64]>, Option<PolymeshPrimitivesSettlementLeg>][] = [
-          tuple(
-            {
-              args: [rawId, dsMockUtils.createMockU64(new BigNumber(1))],
-            } as unknown as StorageKey<[u64, u64]>,
-            mockLeg1
-          ),
-          tuple(
-            {
-              args: [rawId, dsMockUtils.createMockU64(new BigNumber(0))],
-            } as unknown as StorageKey<[u64, u64]>,
-            mockLeg2
-          ),
-        ];
-
-        jest
-          .spyOn(utilsInternalModule, 'requestPaginated')
-          .mockClear()
-          .mockImplementation()
-          .mockResolvedValue({ entries, lastKey: null });
-
-        const { data: leg } = await instruction.getLegs();
-
-        const resultLeg1 = leg[0] as FungibleLeg;
-        expect(resultLeg1.amount).toEqual(amount);
-        expect(resultLeg1.asset.id).toBe(hexToUuid(assetId2));
-        expect(resultLeg1.from.owner.did).toBe(fromDid);
-        expect(resultLeg1.to.owner.did).toBe(toDid);
-
-        const resultLeg2 = leg[1] as FungibleLeg;
-        expect(resultLeg2.amount).toEqual(amount);
-        expect(resultLeg2.asset.id).toBe(hexToUuid(assetId));
-        expect(resultLeg2.from.owner.did).toBe(fromDid);
-        expect(resultLeg2.to.owner.did).toBe(toDid);
-      });
-
-      it('should throw an error if the instruction is not pending', () => {
-        instructionStatusMock.mockResolvedValue(createMockInstructionStatus('Success'));
-        return expect(instruction.getLegs()).rejects.toThrow(
-          'Instruction has already been executed/rejected and it was purged from chain'
-        );
-      });
-
-      it('should handle NFT legs', async () => {
-        const fromDid = 'fromDid';
-        const toDid = 'toDid';
-        const assetId = '0x11111111111181111111111111111111';
-
-        entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
-        instructionStatusMock.mockResolvedValue(
-          createMockInstructionStatus(InternalInstructionStatus.Pending)
-        );
-        const mockLeg = dsMockUtils.createMockOption(
-          dsMockUtils.createMockInstructionLeg({
-            NonFungible: {
-              sender: dsMockUtils.createMockPortfolioId({
-                did: dsMockUtils.createMockIdentityId(fromDid),
-                kind: dsMockUtils.createMockPortfolioKind('Default'),
-              }),
-              receiver: dsMockUtils.createMockPortfolioId({
-                did: dsMockUtils.createMockIdentityId(toDid),
-                kind: dsMockUtils.createMockPortfolioKind('Default'),
-              }),
-              nfts: createMockNfts({
-                assetId: createMockAssetId(assetId),
-                ids: [createMockU64(new BigNumber(1))],
-              }),
-            },
-          })
-        );
-        const entries = [
-          tuple({ args: ['instructionId', 'legId'] } as unknown as StorageKey, mockLeg),
-        ];
-
-        jest
-          .spyOn(utilsInternalModule, 'requestPaginated')
-          .mockClear()
-          .mockImplementation()
-          .mockResolvedValue({ entries, lastKey: null });
-
-        const { data: leg } = await instruction.getLegs();
-
-        const resultLeg = leg[0] as NftLeg;
-        expect(resultLeg.nfts).toEqual(
-          expect.arrayContaining([expect.objectContaining({ id: new BigNumber(1) })])
-        );
-        expect(resultLeg.asset.id).toBe(hexToUuid(assetId));
-        expect(resultLeg.from.owner.did).toBe(fromDid);
-        expect(resultLeg.to.owner.did).toBe(toDid);
-      });
-
-      it('should handle off chain legs', async () => {
-        const fromDid = 'fromDid';
-        const rawFromId = dsMockUtils.createMockIdentityId(fromDid);
-        const toDid = 'toDid';
-        const rawToId = dsMockUtils.createMockIdentityId(toDid);
-        const offChainAsset = 'SOME_TICKER';
-        const amount = new BigNumber(10);
-
-        instructionStatusMock.mockResolvedValue(
-          createMockInstructionStatus(InternalInstructionStatus.Pending)
-        );
-
-        const identityIdToStringSpy = jest.spyOn(utilsConversionModule, 'identityIdToString');
-
-        when(identityIdToStringSpy).calledWith(rawFromId).mockReturnValue(fromDid);
-        when(identityIdToStringSpy).calledWith(rawToId).mockReturnValue(toDid);
-        const mockLeg = dsMockUtils.createMockOption(
-          dsMockUtils.createMockInstructionLeg({
-            OffChain: {
-              senderIdentity: rawFromId,
-              receiverIdentity: rawToId,
-              ticker: dsMockUtils.createMockTicker(offChainAsset),
-              amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
-            },
-          })
-        );
-        const entries = [
-          tuple({ args: ['instructionId', 'legId'] } as unknown as StorageKey, mockLeg),
-        ];
-
-        jest
-          .spyOn(utilsInternalModule, 'requestPaginated')
-          .mockClear()
-          .mockImplementation()
-          .mockResolvedValue({ entries, lastKey: null });
-
-        const { data: leg } = await instruction.getLegs();
-
-        const resultLeg = leg[0] as OffChainLeg;
-        expect(resultLeg.offChainAmount).toEqual(amount);
-        expect(resultLeg.asset).toBe(offChainAsset);
-        expect(resultLeg.from.did).toBe(fromDid);
-        expect(resultLeg.to.did).toBe(toDid);
-      });
-
-      it('should throw an error if a leg in None', () => {
-        const assetId = '0x1111';
-
-        entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
-        instructionStatusMock.mockResolvedValue(
-          createMockInstructionStatus(InternalInstructionStatus.Pending)
-        );
-        const mockLeg = dsMockUtils.createMockOption();
-        const entries = [tuple(['instructionId', 'legId'] as unknown as StorageKey, mockLeg)];
-
-        jest
-          .spyOn(utilsInternalModule, 'requestPaginated')
-          .mockClear()
-          .mockImplementation()
-          .mockResolvedValue({ entries, lastKey: null });
-
-        return expect(instruction.getLegs()).rejects.toThrow();
+        expect(result).toEqual(mockData);
       });
     });
   });

--- a/src/api/procedures/__tests__/executeManualInstruction.ts
+++ b/src/api/procedures/__tests__/executeManualInstruction.ts
@@ -344,15 +344,19 @@ describe('executeManualInstruction procedure', () => {
       const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext);
 
       const boundFunc = prepareStorage.bind(proc);
-      entityMockUtils.configureMocks({
-        instructionOptions: {
-          getLegs: {
+      dsMockUtils.configureMocks({
+        contextOptions: {
+          getInstructionLegsFromChain: {
             data: [
               { from, to, amount, asset },
               { from: sender, to: receiver, offChainAmount: amount, asset: 'OFF_CHAIN_ASSET' },
             ],
             next: null,
           },
+        },
+      });
+      entityMockUtils.configureMocks({
+        instructionOptions: {
           details: instructionDetails,
         },
       });
@@ -379,9 +383,14 @@ describe('executeManualInstruction procedure', () => {
       from = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });
       to = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: false });
 
+      dsMockUtils.configureMocks({
+        contextOptions: {
+          getInstructionLegsFromChain: { data: [{ from, to, amount, asset }], next: null },
+        },
+      });
+
       entityMockUtils.configureMocks({
         instructionOptions: {
-          getLegs: { data: [{ from, to, amount, asset }], next: null },
           details: instructionDetails,
         },
       });

--- a/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
@@ -1121,16 +1121,9 @@ describe('modifyInstructionAffirmation procedure', () => {
     const asset = entityMockUtils.getFungibleAssetInstance({ assetId: 'SOME_ASSET' });
 
     it('should return the portfolios for which to modify affirmation status', async () => {
-      const proc = procedureMockUtils.getInstance<
-        ModifyInstructionAffirmationParams,
-        Instruction,
-        Storage
-      >(mockContext);
-
-      const boundFunc = prepareStorage.bind(proc);
-      entityMockUtils.configureMocks({
-        instructionOptions: {
-          getLegs: {
+      dsMockUtils.configureMocks({
+        contextOptions: {
+          getInstructionLegsFromChain: {
             data: [
               { from: from1, to: to1, amount, asset },
               { from: from2, to: to2, amount, asset },
@@ -1140,6 +1133,13 @@ describe('modifyInstructionAffirmation procedure', () => {
           },
         },
       });
+      const proc = procedureMockUtils.getInstance<
+        ModifyInstructionAffirmationParams,
+        Instruction,
+        Storage
+      >(mockContext);
+
+      const boundFunc = prepareStorage.bind(proc);
 
       let result = await boundFunc({
         id: new BigNumber(1),
@@ -1213,6 +1213,18 @@ describe('modifyInstructionAffirmation procedure', () => {
     });
 
     it('should return the portfolios for which to modify affirmation status when there is no sender legs', async () => {
+      from1 = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });
+      to1 = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: false });
+
+      dsMockUtils.configureMocks({
+        contextOptions: {
+          getInstructionLegsFromChain: {
+            data: [{ from: from1, to: to1, amount, asset }],
+            next: null,
+          },
+        },
+      });
+
       const proc = procedureMockUtils.getInstance<
         ModifyInstructionAffirmationParams,
         Instruction,
@@ -1220,14 +1232,6 @@ describe('modifyInstructionAffirmation procedure', () => {
       >(mockContext);
 
       const boundFunc = prepareStorage.bind(proc);
-      from1 = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });
-      to1 = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: false });
-
-      entityMockUtils.configureMocks({
-        instructionOptions: {
-          getLegs: { data: [{ from: from1, to: to1, amount, asset }], next: null },
-        },
-      });
 
       const result = await boundFunc({
         id: new BigNumber(1),

--- a/src/api/procedures/executeManualInstruction.ts
+++ b/src/api/procedures/executeManualInstruction.ts
@@ -160,7 +160,7 @@ export async function prepareStorage(
   const instruction = new Instruction({ id }, context);
 
   const [{ data: legs }, { did }, details] = await Promise.all([
-    instruction.getLegs(),
+    context.getInstructionLegsFromChain(id),
     context.getSigningIdentity(),
     instruction.details(),
   ]);

--- a/src/api/procedures/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/modifyInstructionAffirmation.ts
@@ -654,10 +654,8 @@ export async function prepareStorage(
 
   const portfolioIdParams = portfolioParams.map(portfolioLikeToPortfolioId);
 
-  const instruction = new Instruction({ id }, context);
-
   const [{ data: legs }, signer, executeInstructionInfo] = await Promise.all([
-    instruction.getLegs(),
+    context.getInstructionLegsFromChain(id),
     context.getSigningIdentity(),
     polymeshApi.call.settlementApi.getExecuteInstructionInfo(rawId),
   ]);

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -14,6 +14,7 @@ import {
   PalletCorporateActionsDistribution,
   PalletRelayerSubsidy,
   PolymeshCommonUtilitiesProtocolFeeProtocolOp,
+  PolymeshPrimitivesSettlementLeg,
 } from '@polkadot/types/lookup';
 import { CallFunction, Codec, DetectCodec, Signer as PolkadotSigner } from '@polkadot/types/types';
 import { SigningManager } from '@polymeshassociation/signing-manager-types';
@@ -28,6 +29,9 @@ import {
   DividendDistribution,
   FungibleAsset,
   Identity,
+  Instruction,
+  Nft,
+  NftCollection,
   PolymeshError,
   Subsidy,
 } from '~/internal';
@@ -42,8 +46,10 @@ import {
   CorporateActionParams,
   DistributionWithDetails,
   ErrorCode,
+  Leg,
   MiddlewareMetadata,
   ModuleName,
+  PaginationOptions,
   PolkadotConfig,
   ProtocolFees,
   ResultSet,
@@ -60,6 +66,7 @@ import {
   assetToMeshAssetId,
   balanceToBigNumber,
   bigNumberToU32,
+  bigNumberToU64,
   boolToBoolean,
   claimTypeToMeshClaimType,
   corporateActionIdentifierToCaId,
@@ -68,6 +75,8 @@ import {
   meshAssetToAssetId,
   meshClaimToClaim,
   meshCorporateActionToCorporateActionParams,
+  meshNftToNftId,
+  meshPortfolioIdToPortfolio,
   middlewareClaimToClaimData,
   middlewareEventDetailsToEventIdentifier,
   momentToDate,
@@ -77,9 +86,11 @@ import {
   stringToHash,
   stringToIdentityId,
   textToString,
+  tickerToString,
   txTagToProtocolOp,
   u16ToBigNumber,
   u32ToBigNumber,
+  u64ToBigNumber,
 } from '~/utils/conversion';
 import {
   asAccount,
@@ -90,6 +101,7 @@ import {
   getApiAtBlock,
   getLatestSqVersion,
   isV6Spec,
+  requestPaginated,
 } from '~/utils/internal';
 
 import { processType } from './utils';
@@ -1421,5 +1433,105 @@ export class Context {
     });
 
     return result.signature;
+  }
+
+  /**
+   * Retrieves legs for an instruction ID from chain
+   * @param instructionId whose legs needs to be fetched
+   * @param paginationOpts pagination options if given
+   * @returns Legs of the instruction
+   */
+  public async getInstructionLegsFromChain(
+    instructionId: BigNumber,
+    paginationOpts?: PaginationOptions
+  ): Promise<ResultSet<Leg>> {
+    const {
+      polymeshApi: {
+        query: { settlement },
+      },
+    } = this;
+    const instruction = new Instruction({ id: instructionId }, this);
+    const isExecuted = await instruction.isExecuted();
+
+    if (isExecuted) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'Instruction has already been executed/rejected and it was purged from chain',
+      });
+    }
+
+    const { entries: legs, lastKey: next } = await requestPaginated(settlement.instructionLegs, {
+      arg: bigNumberToU64(instructionId, this),
+      paginationOpts: paginationOpts as PaginationOptions,
+    });
+
+    const data = [...legs]
+      .sort((a, b) => u64ToBigNumber(a[0].args[1]).minus(u64ToBigNumber(b[0].args[1])).toNumber())
+      .map(([, leg]) => {
+        if (leg.isSome) {
+          const legValue: PolymeshPrimitivesSettlementLeg = leg.unwrap();
+          if (legValue.isFungible) {
+            const {
+              sender,
+              receiver,
+              amount,
+              ticker: rawTicker,
+              assetId: rawAssetId,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } = legValue.asFungible as any; // NOSONAR
+
+            const assetId = meshAssetToAssetId(rawTicker || rawAssetId, this);
+            const fromPortfolio = meshPortfolioIdToPortfolio(sender, this);
+            const toPortfolio = meshPortfolioIdToPortfolio(receiver, this);
+
+            return {
+              from: fromPortfolio,
+              to: toPortfolio,
+              amount: balanceToBigNumber(amount),
+              asset: new FungibleAsset({ assetId }, this),
+            };
+          } else if (legValue.isNonFungible) {
+            const { sender, receiver, nfts } = legValue.asNonFungible;
+
+            const from = meshPortfolioIdToPortfolio(sender, this);
+            const to = meshPortfolioIdToPortfolio(receiver, this);
+            const { assetId, ids } = meshNftToNftId(nfts, this);
+
+            return {
+              from,
+              to,
+              nfts: ids.map(nftId => new Nft({ assetId, id: nftId }, this)),
+              asset: new NftCollection({ assetId }, this),
+            };
+          } else {
+            const {
+              senderIdentity,
+              receiverIdentity,
+              amount,
+              ticker: rawTicker,
+            } = legValue.asOffChain;
+
+            const ticker = tickerToString(rawTicker);
+            const from = identityIdToString(senderIdentity);
+            const to = identityIdToString(receiverIdentity);
+
+            return {
+              from: new Identity({ did: from }, this),
+              to: new Identity({ did: to }, this),
+              offChainAmount: balanceToBigNumber(amount),
+              asset: ticker,
+            };
+          }
+        } else {
+          throw new Error(
+            'Instruction has already been executed/rejected and it was purged from chain'
+          );
+        }
+      });
+
+    return {
+      data,
+      next,
+    };
   }
 }

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -1,5 +1,7 @@
 import { QueryOptions } from '@apollo/client/core';
 import { ApiPromise } from '@polkadot/api';
+import { Option, StorageKey, u64 } from '@polkadot/types';
+import { PolymeshPrimitivesSettlementLeg } from '@polkadot/types/lookup';
 import { Signer as PolkadotSigner } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 import P from 'bluebird';
@@ -18,16 +20,28 @@ import {
   ModuleIdEnum,
 } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
-import { createMockAccountId, getAtMock } from '~/testUtils/mocks/dataSources';
+import {
+  createMockAccountId,
+  createMockAssetId,
+  createMockInstructionStatus,
+  createMockNfts,
+  createMockU64,
+  getAtMock,
+} from '~/testUtils/mocks/dataSources';
 import {
   ClaimType,
   CorporateActionKind,
   ErrorCode,
+  FungibleLeg,
+  NftLeg,
+  OffChainLeg,
   TargetTreatment,
   TransactionArgumentType,
   TxTags,
 } from '~/types';
+import { InstructionStatus as InternalInstructionStatus } from '~/types/internal';
 import { tuple } from '~/types/utils';
+import { hexToUuid } from '~/utils';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as utilsInternalModule from '~/utils/internal';
 
@@ -2525,6 +2539,250 @@ describe('Context class', () => {
       expect(signer.signRaw).toHaveBeenCalledTimes(2);
 
       expect(result).toEqual('0xsignature');
+    });
+  });
+
+  describe('getInstructionLegsFromChain', () => {
+    let instructionStatusMock: jest.Mock;
+    let id: BigNumber;
+    let rawId: u64;
+
+    let bigNumberToU64Spy: jest.SpyInstance;
+
+    beforeAll(() => {
+      bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+
+      id = new BigNumber(1);
+      rawId = dsMockUtils.createMockU64(id);
+    });
+
+    beforeEach(() => {
+      dsMockUtils.createQueryMock('settlement', 'instructionCounter', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(1000)),
+      });
+      bigNumberToU64Spy.mockReturnValue(rawId);
+      dsMockUtils.createQueryMock('settlement', 'instructionLegs');
+      instructionStatusMock = dsMockUtils.createQueryMock('settlement', 'instructionStatuses');
+    });
+
+    it("should return the instruction's legs", async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+      const fromDid = 'fromDid';
+      const toDid = 'toDid';
+      const assetId = '0x11111111111181111111111111111111';
+      const assetId2 = '0x22222222222222222222222222222222';
+      const amount = new BigNumber(1000);
+
+      entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
+      instructionStatusMock.mockResolvedValue(
+        createMockInstructionStatus(InternalInstructionStatus.Pending)
+      );
+      const mockLeg1 = dsMockUtils.createMockOption(
+        dsMockUtils.createMockInstructionLeg({
+          Fungible: {
+            sender: dsMockUtils.createMockPortfolioId({
+              did: dsMockUtils.createMockIdentityId(fromDid),
+              kind: dsMockUtils.createMockPortfolioKind('Default'),
+            }),
+            receiver: dsMockUtils.createMockPortfolioId({
+              did: dsMockUtils.createMockIdentityId(toDid),
+              kind: dsMockUtils.createMockPortfolioKind('Default'),
+            }),
+            assetId: dsMockUtils.createMockAssetId(assetId),
+            amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
+          },
+        })
+      );
+
+      const mockLeg2 = dsMockUtils.createMockOption(
+        dsMockUtils.createMockInstructionLeg({
+          Fungible: {
+            sender: dsMockUtils.createMockPortfolioId({
+              did: dsMockUtils.createMockIdentityId(fromDid),
+              kind: dsMockUtils.createMockPortfolioKind('Default'),
+            }),
+            receiver: dsMockUtils.createMockPortfolioId({
+              did: dsMockUtils.createMockIdentityId(toDid),
+              kind: dsMockUtils.createMockPortfolioKind('Default'),
+            }),
+            assetId: dsMockUtils.createMockAssetId(assetId2),
+            amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
+          },
+        })
+      );
+      const entries: [StorageKey<[u64, u64]>, Option<PolymeshPrimitivesSettlementLeg>][] = [
+        tuple(
+          {
+            args: [rawId, dsMockUtils.createMockU64(new BigNumber(1))],
+          } as unknown as StorageKey<[u64, u64]>,
+          mockLeg1
+        ),
+        tuple(
+          {
+            args: [rawId, dsMockUtils.createMockU64(new BigNumber(0))],
+          } as unknown as StorageKey<[u64, u64]>,
+          mockLeg2
+        ),
+      ];
+
+      jest
+        .spyOn(utilsInternalModule, 'requestPaginated')
+        .mockClear()
+        .mockImplementation()
+        .mockResolvedValue({ entries, lastKey: null });
+
+      const { data: leg } = await context.getInstructionLegsFromChain(id);
+
+      const resultLeg1 = leg[0] as FungibleLeg;
+      expect(resultLeg1.amount).toEqual(amount);
+      expect(resultLeg1.asset.id).toBe(hexToUuid(assetId2));
+      expect(resultLeg1.from.owner.did).toBe(fromDid);
+      expect(resultLeg1.to.owner.did).toBe(toDid);
+
+      const resultLeg2 = leg[1] as FungibleLeg;
+      expect(resultLeg2.amount).toEqual(amount);
+      expect(resultLeg2.asset.id).toBe(hexToUuid(assetId));
+      expect(resultLeg2.from.owner.did).toBe(fromDid);
+      expect(resultLeg2.to.owner.did).toBe(toDid);
+    });
+
+    it('should throw an error if the instruction is not pending', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+      instructionStatusMock.mockResolvedValue(createMockInstructionStatus('Success'));
+      await expect(context.getInstructionLegsFromChain(id)).rejects.toThrow(
+        'Instruction has already been executed/rejected and it was purged from chain'
+      );
+    });
+
+    it('should handle NFT legs', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      const fromDid = 'fromDid';
+      const toDid = 'toDid';
+      const assetId = '0x11111111111181111111111111111111';
+
+      entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
+      instructionStatusMock.mockResolvedValue(
+        createMockInstructionStatus(InternalInstructionStatus.Pending)
+      );
+      const mockLeg = dsMockUtils.createMockOption(
+        dsMockUtils.createMockInstructionLeg({
+          NonFungible: {
+            sender: dsMockUtils.createMockPortfolioId({
+              did: dsMockUtils.createMockIdentityId(fromDid),
+              kind: dsMockUtils.createMockPortfolioKind('Default'),
+            }),
+            receiver: dsMockUtils.createMockPortfolioId({
+              did: dsMockUtils.createMockIdentityId(toDid),
+              kind: dsMockUtils.createMockPortfolioKind('Default'),
+            }),
+            nfts: createMockNfts({
+              assetId: createMockAssetId(assetId),
+              ids: [createMockU64(new BigNumber(1))],
+            }),
+          },
+        })
+      );
+      const entries = [
+        tuple({ args: ['instructionId', 'legId'] } as unknown as StorageKey, mockLeg),
+      ];
+
+      jest
+        .spyOn(utilsInternalModule, 'requestPaginated')
+        .mockClear()
+        .mockImplementation()
+        .mockResolvedValue({ entries, lastKey: null });
+
+      const { data: leg } = await context.getInstructionLegsFromChain(id);
+
+      const resultLeg = leg[0] as NftLeg;
+      expect(resultLeg.nfts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: new BigNumber(1) })])
+      );
+      expect(resultLeg.asset.id).toBe(hexToUuid(assetId));
+      expect(resultLeg.from.owner.did).toBe(fromDid);
+      expect(resultLeg.to.owner.did).toBe(toDid);
+    });
+
+    it('should handle off chain legs', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+      const fromDid = 'fromDid';
+      const rawFromId = dsMockUtils.createMockIdentityId(fromDid);
+      const toDid = 'toDid';
+      const rawToId = dsMockUtils.createMockIdentityId(toDid);
+      const offChainAsset = 'SOME_TICKER';
+      const amount = new BigNumber(10);
+
+      instructionStatusMock.mockResolvedValue(
+        createMockInstructionStatus(InternalInstructionStatus.Pending)
+      );
+
+      const identityIdToStringSpy = jest.spyOn(utilsConversionModule, 'identityIdToString');
+
+      when(identityIdToStringSpy).calledWith(rawFromId).mockReturnValue(fromDid);
+      when(identityIdToStringSpy).calledWith(rawToId).mockReturnValue(toDid);
+      const mockLeg = dsMockUtils.createMockOption(
+        dsMockUtils.createMockInstructionLeg({
+          OffChain: {
+            senderIdentity: rawFromId,
+            receiverIdentity: rawToId,
+            ticker: dsMockUtils.createMockTicker(offChainAsset),
+            amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
+          },
+        })
+      );
+      const entries = [
+        tuple({ args: ['instructionId', 'legId'] } as unknown as StorageKey, mockLeg),
+      ];
+
+      jest
+        .spyOn(utilsInternalModule, 'requestPaginated')
+        .mockClear()
+        .mockImplementation()
+        .mockResolvedValue({ entries, lastKey: null });
+
+      const { data: leg } = await context.getInstructionLegsFromChain(id);
+
+      const resultLeg = leg[0] as OffChainLeg;
+      expect(resultLeg.offChainAmount).toEqual(amount);
+      expect(resultLeg.asset).toBe(offChainAsset);
+      expect(resultLeg.from.did).toBe(fromDid);
+      expect(resultLeg.to.did).toBe(toDid);
+    });
+
+    it('should throw an error if a leg in None', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+      const assetId = '0x1111';
+
+      entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
+      instructionStatusMock.mockResolvedValue(
+        createMockInstructionStatus(InternalInstructionStatus.Pending)
+      );
+      const mockLeg = dsMockUtils.createMockOption();
+      const entries = [tuple(['instructionId', 'legId'] as unknown as StorageKey, mockLeg)];
+
+      jest
+        .spyOn(utilsInternalModule, 'requestPaginated')
+        .mockClear()
+        .mockImplementation()
+        .mockResolvedValue({ entries, lastKey: null });
+
+      await expect(context.getInstructionLegsFromChain(id)).rejects.toThrow();
     });
   });
 });

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -186,6 +186,7 @@ import {
   CountryCode as CountryCodeEnum,
   DistributionWithDetails,
   ExtrinsicData,
+  Leg,
   MiddlewareMetadata,
   PermissionedAccount,
   ProtocolFees,
@@ -457,6 +458,7 @@ interface ContextOptions {
   supportsSubscription?: boolean;
   getSignature?: `0x${string}`;
   getNextAssetId?: string;
+  getInstructionLegsFromChain?: ResultSet<Leg>;
 }
 
 interface SigningManagerOptions {
@@ -792,6 +794,10 @@ const defaultContextOptions: ContextOptions = {
   supportsSubscription: true,
   getSignature: '0xsignature',
   getNextAssetId: '0x12341234123412341234123412341234',
+  getInstructionLegsFromChain: {
+    data: [],
+    next: null,
+  },
 };
 let contextOptions: ContextOptions = defaultContextOptions;
 const defaultSigningManagerOptions: SigningManagerOptions = {
@@ -928,6 +934,7 @@ function configureContext(opts: ContextOptions): void {
     assertHasSigningAddress: jest.fn(),
     assertSupportsSubscription: jest.fn(),
     getSignature: jest.fn().mockReturnValue(opts.getSignature),
+    getInstructionLegsFromChain: jest.fn().mockResolvedValue(opts.getInstructionLegsFromChain),
   } as unknown as MockContext;
 
   contextInstance.clone = jest.fn().mockReturnValue(contextInstance);


### PR DESCRIPTION
### Description

`Instruction.getLegs` was modified to use middleware to fetch the leg information. This caused the affirm/execution procedure to wait for the instruction to be synced via middleware before affirming/executing (when middleware was available).

### Breaking Changes

NA

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
