### PR TITLE
fix: 🐛 Fix logic to check if instruction exists

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -309,15 +309,20 @@ describe('Instruction class', () => {
 
       const instructionCounterMock = dsMockUtils
         .createQueryMock('settlement', 'instructionCounter')
-        .mockResolvedValue(dsMockUtils.createMockU64(new BigNumber(10)));
+        .mockResolvedValue(dsMockUtils.createMockU64(new BigNumber(2)));
 
       let result = await instruction.exists();
 
       expect(result).toBe(true);
 
-      instructionCounterMock.mockResolvedValue(dsMockUtils.createMockU64(new BigNumber(0)));
+      instructionCounterMock.mockResolvedValue(dsMockUtils.createMockU64(new BigNumber(1)));
 
       result = await instruction.exists();
+
+      expect(result).toBe(false);
+
+      const fakeInstruction = new Instruction({ id: new BigNumber(0) }, context);
+      result = await fakeInstruction.exists();
 
       expect(result).toBe(false);
     });

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -1,5 +1,8 @@
-import { StorageKey, u64 } from '@polkadot/types';
-import { PolymeshPrimitivesIdentityIdPortfolioId } from '@polkadot/types/lookup';
+import { Option, StorageKey, u64 } from '@polkadot/types';
+import {
+  PolymeshPrimitivesIdentityIdPortfolioId,
+  PolymeshPrimitivesSettlementLeg,
+} from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -19,7 +22,12 @@ import {
   LegTypeEnum,
 } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
-import { createMockInstructionStatus } from '~/testUtils/mocks/dataSources';
+import {
+  createMockAssetId,
+  createMockInstructionStatus,
+  createMockNfts,
+  createMockU64,
+} from '~/testUtils/mocks/dataSources';
 import { Mocked } from '~/testUtils/types';
 import {
   AffirmationStatus,
@@ -27,7 +35,8 @@ import {
   InstructionAffirmationOperation,
   InstructionStatus,
   InstructionType,
-  Leg,
+  NftLeg,
+  OffChainLeg,
   SignerKeyRingType,
   UnsubCallback,
 } from '~/types';
@@ -955,19 +964,221 @@ describe('Instruction class', () => {
     });
 
     describe('querying from chain', () => {
-      it("should return the instruction's legs", async () => {
-        const mockData = {
-          data: ['leg' as unknown as Leg],
-          next: null,
-          count: new BigNumber(1),
-        };
-        dsMockUtils.configureMocks({
-          contextOptions: { getInstructionLegsFromChain: mockData, middlewareAvailable: false },
+      let instructionStatusMock: jest.Mock;
+
+      let bigNumberToU64Spy: jest.SpyInstance;
+
+      beforeAll(() => {
+        bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+      });
+
+      beforeEach(() => {
+        dsMockUtils.configureMocks({ contextOptions: { middlewareAvailable: false } });
+        dsMockUtils.createQueryMock('settlement', 'instructionCounter', {
+          returnValue: dsMockUtils.createMockU64(new BigNumber(1000)),
         });
+        when(bigNumberToU64Spy).calledWith(id, context).mockReturnValue(rawId);
+        dsMockUtils.createQueryMock('settlement', 'instructionLegs');
+        instructionStatusMock = dsMockUtils.createQueryMock('settlement', 'instructionStatuses');
+      });
 
-        const result = await instruction.getLegs();
+      it("should return the instruction's legs", async () => {
+        const fromDid = 'fromDid';
+        const toDid = 'toDid';
+        const assetId = '0x11111111111181111111111111111111';
+        const assetId2 = '0x22222222222222222222222222222222';
+        const amount = new BigNumber(1000);
 
-        expect(result).toEqual(mockData);
+        entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
+        instructionStatusMock.mockResolvedValue(
+          createMockInstructionStatus(InternalInstructionStatus.Pending)
+        );
+        const mockLeg1 = dsMockUtils.createMockOption(
+          dsMockUtils.createMockInstructionLeg({
+            Fungible: {
+              sender: dsMockUtils.createMockPortfolioId({
+                did: dsMockUtils.createMockIdentityId(fromDid),
+                kind: dsMockUtils.createMockPortfolioKind('Default'),
+              }),
+              receiver: dsMockUtils.createMockPortfolioId({
+                did: dsMockUtils.createMockIdentityId(toDid),
+                kind: dsMockUtils.createMockPortfolioKind('Default'),
+              }),
+              assetId: dsMockUtils.createMockAssetId(assetId),
+              amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
+            },
+          })
+        );
+
+        const mockLeg2 = dsMockUtils.createMockOption(
+          dsMockUtils.createMockInstructionLeg({
+            Fungible: {
+              sender: dsMockUtils.createMockPortfolioId({
+                did: dsMockUtils.createMockIdentityId(fromDid),
+                kind: dsMockUtils.createMockPortfolioKind('Default'),
+              }),
+              receiver: dsMockUtils.createMockPortfolioId({
+                did: dsMockUtils.createMockIdentityId(toDid),
+                kind: dsMockUtils.createMockPortfolioKind('Default'),
+              }),
+              assetId: dsMockUtils.createMockAssetId(assetId2),
+              amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
+            },
+          })
+        );
+        const entries: [StorageKey<[u64, u64]>, Option<PolymeshPrimitivesSettlementLeg>][] = [
+          tuple(
+            {
+              args: [rawId, dsMockUtils.createMockU64(new BigNumber(1))],
+            } as unknown as StorageKey<[u64, u64]>,
+            mockLeg1
+          ),
+          tuple(
+            {
+              args: [rawId, dsMockUtils.createMockU64(new BigNumber(0))],
+            } as unknown as StorageKey<[u64, u64]>,
+            mockLeg2
+          ),
+        ];
+
+        jest
+          .spyOn(utilsInternalModule, 'requestPaginated')
+          .mockClear()
+          .mockImplementation()
+          .mockResolvedValue({ entries, lastKey: null });
+
+        const { data: leg } = await instruction.getLegs();
+
+        const resultLeg1 = leg[0] as FungibleLeg;
+        expect(resultLeg1.amount).toEqual(amount);
+        expect(resultLeg1.asset.id).toBe(hexToUuid(assetId2));
+        expect(resultLeg1.from.owner.did).toBe(fromDid);
+        expect(resultLeg1.to.owner.did).toBe(toDid);
+
+        const resultLeg2 = leg[1] as FungibleLeg;
+        expect(resultLeg2.amount).toEqual(amount);
+        expect(resultLeg2.asset.id).toBe(hexToUuid(assetId));
+        expect(resultLeg2.from.owner.did).toBe(fromDid);
+        expect(resultLeg2.to.owner.did).toBe(toDid);
+      });
+
+      it('should throw an error if the instruction is not pending', () => {
+        instructionStatusMock.mockResolvedValue(createMockInstructionStatus('Success'));
+        return expect(instruction.getLegs()).rejects.toThrow(
+          'Instruction has already been executed/rejected and it was purged from chain'
+        );
+      });
+
+      it('should handle NFT legs', async () => {
+        const fromDid = 'fromDid';
+        const toDid = 'toDid';
+        const assetId = '0x11111111111181111111111111111111';
+
+        entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
+        instructionStatusMock.mockResolvedValue(
+          createMockInstructionStatus(InternalInstructionStatus.Pending)
+        );
+        const mockLeg = dsMockUtils.createMockOption(
+          dsMockUtils.createMockInstructionLeg({
+            NonFungible: {
+              sender: dsMockUtils.createMockPortfolioId({
+                did: dsMockUtils.createMockIdentityId(fromDid),
+                kind: dsMockUtils.createMockPortfolioKind('Default'),
+              }),
+              receiver: dsMockUtils.createMockPortfolioId({
+                did: dsMockUtils.createMockIdentityId(toDid),
+                kind: dsMockUtils.createMockPortfolioKind('Default'),
+              }),
+              nfts: createMockNfts({
+                assetId: createMockAssetId(assetId),
+                ids: [createMockU64(new BigNumber(1))],
+              }),
+            },
+          })
+        );
+        const entries = [
+          tuple({ args: ['instructionId', 'legId'] } as unknown as StorageKey, mockLeg),
+        ];
+
+        jest
+          .spyOn(utilsInternalModule, 'requestPaginated')
+          .mockClear()
+          .mockImplementation()
+          .mockResolvedValue({ entries, lastKey: null });
+
+        const { data: leg } = await instruction.getLegs();
+
+        const resultLeg = leg[0] as NftLeg;
+        expect(resultLeg.nfts).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: new BigNumber(1) })])
+        );
+        expect(resultLeg.asset.id).toBe(hexToUuid(assetId));
+        expect(resultLeg.from.owner.did).toBe(fromDid);
+        expect(resultLeg.to.owner.did).toBe(toDid);
+      });
+
+      it('should handle off chain legs', async () => {
+        const fromDid = 'fromDid';
+        const rawFromId = dsMockUtils.createMockIdentityId(fromDid);
+        const toDid = 'toDid';
+        const rawToId = dsMockUtils.createMockIdentityId(toDid);
+        const offChainAsset = 'SOME_TICKER';
+        const amount = new BigNumber(10);
+
+        instructionStatusMock.mockResolvedValue(
+          createMockInstructionStatus(InternalInstructionStatus.Pending)
+        );
+
+        const identityIdToStringSpy = jest.spyOn(utilsConversionModule, 'identityIdToString');
+
+        when(identityIdToStringSpy).calledWith(rawFromId).mockReturnValue(fromDid);
+        when(identityIdToStringSpy).calledWith(rawToId).mockReturnValue(toDid);
+        const mockLeg = dsMockUtils.createMockOption(
+          dsMockUtils.createMockInstructionLeg({
+            OffChain: {
+              senderIdentity: rawFromId,
+              receiverIdentity: rawToId,
+              ticker: dsMockUtils.createMockTicker(offChainAsset),
+              amount: dsMockUtils.createMockU128(amount.shiftedBy(6)),
+            },
+          })
+        );
+        const entries = [
+          tuple({ args: ['instructionId', 'legId'] } as unknown as StorageKey, mockLeg),
+        ];
+
+        jest
+          .spyOn(utilsInternalModule, 'requestPaginated')
+          .mockClear()
+          .mockImplementation()
+          .mockResolvedValue({ entries, lastKey: null });
+
+        const { data: leg } = await instruction.getLegs();
+
+        const resultLeg = leg[0] as OffChainLeg;
+        expect(resultLeg.offChainAmount).toEqual(amount);
+        expect(resultLeg.asset).toBe(offChainAsset);
+        expect(resultLeg.from.did).toBe(fromDid);
+        expect(resultLeg.to.did).toBe(toDid);
+      });
+
+      it('should throw an error if a leg in None', () => {
+        const assetId = '0x1111';
+
+        entityMockUtils.configureMocks({ fungibleAssetOptions: { assetId } });
+        instructionStatusMock.mockResolvedValue(
+          createMockInstructionStatus(InternalInstructionStatus.Pending)
+        );
+        const mockLeg = dsMockUtils.createMockOption();
+        const entries = [tuple(['instructionId', 'legId'] as unknown as StorageKey, mockLeg)];
+
+        jest
+          .spyOn(utilsInternalModule, 'requestPaginated')
+          .mockClear()
+          .mockImplementation()
+          .mockResolvedValue({ entries, lastKey: null });
+
+        return expect(instruction.getLegs()).rejects.toThrow();
       });
     });
   });

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -1,4 +1,7 @@
-import { PolymeshPrimitivesSettlementInstructionStatus } from '@polkadot/types/lookup';
+import {
+  PolymeshPrimitivesSettlementInstructionStatus,
+  PolymeshPrimitivesSettlementLeg,
+} from '@polkadot/types/lookup';
 import { hexAddPrefix, hexStripPrefix } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 import P from 'bluebird';
@@ -8,8 +11,11 @@ import {
   Account,
   Context,
   Entity,
+  FungibleAsset,
   Identity,
   modifyInstructionAffirmation,
+  Nft,
+  NftCollection,
   PolymeshError,
   Venue,
 } from '~/internal';
@@ -52,12 +58,16 @@ import { InstructionStatus as InternalInstructionStatus } from '~/types/internal
 import { Ensured } from '~/types/utils';
 import { isOffChainLeg } from '~/utils';
 import {
+  balanceToBigNumber,
   bigNumberToU64,
   identityIdToString,
   instructionMemoToString,
   mediatorAffirmationStatusToStatus,
   meshAffirmationStatusToAffirmationStatus,
+  meshAssetToAssetId,
   meshInstructionStatusToInstructionStatus,
+  meshNftToNftId,
+  meshPortfolioIdToPortfolio,
   meshSettlementTypeToEndCondition,
   middlewareAffirmStatusToAffirmationStatus,
   middlewareEventDetailsToEventIdentifier,
@@ -65,6 +75,7 @@ import {
   middlewareInstructionToInstructionEndCondition,
   middlewareLegToLeg,
   momentToDate,
+  tickerToString,
   u64ToBigNumber,
 } from '~/utils/conversion';
 import {
@@ -551,13 +562,107 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
   }
 
   /**
-   * Retrieve all legs of this Instruction from chain
-   * @param paginationOpts
-   *
    * @hidden
+   *
+   * Retrieve all legs of this Instruction from chain
+   *
+   * @note supports pagination
+   *
+   * @throws if the instruction is executed/rejected and was pruned from chain (when querying from chain)
    */
   public async getLegsFromChain(paginationOpts?: PaginationOptions): Promise<ResultSet<Leg>> {
-    return this.context.getInstructionLegsFromChain(this.id, paginationOpts as PaginationOptions);
+    const {
+      context: {
+        polymeshApi: {
+          query: { settlement },
+        },
+      },
+      context,
+      id,
+    } = this;
+    const instruction = new Instruction({ id }, context);
+    const isExecuted = await instruction.isExecuted();
+
+    if (isExecuted) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'Instruction has already been executed/rejected and it was purged from chain',
+      });
+    }
+
+    const { entries: legs, lastKey: next } = await requestPaginated(settlement.instructionLegs, {
+      arg: bigNumberToU64(id, context),
+      paginationOpts: paginationOpts as PaginationOptions,
+    });
+
+    const data = [...legs]
+      .sort((a, b) => u64ToBigNumber(a[0].args[1]).minus(u64ToBigNumber(b[0].args[1])).toNumber())
+      .map(([, leg]) => {
+        if (leg.isSome) {
+          const legValue: PolymeshPrimitivesSettlementLeg = leg.unwrap();
+          if (legValue.isFungible) {
+            const {
+              sender,
+              receiver,
+              amount,
+              ticker: rawTicker,
+              assetId: rawAssetId,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } = legValue.asFungible as any; // NOSONAR
+
+            const assetId = meshAssetToAssetId(rawTicker || rawAssetId, context);
+            const fromPortfolio = meshPortfolioIdToPortfolio(sender, context);
+            const toPortfolio = meshPortfolioIdToPortfolio(receiver, context);
+
+            return {
+              from: fromPortfolio,
+              to: toPortfolio,
+              amount: balanceToBigNumber(amount),
+              asset: new FungibleAsset({ assetId }, context),
+            };
+          } else if (legValue.isNonFungible) {
+            const { sender, receiver, nfts } = legValue.asNonFungible;
+
+            const from = meshPortfolioIdToPortfolio(sender, context);
+            const to = meshPortfolioIdToPortfolio(receiver, context);
+            const { assetId, ids } = meshNftToNftId(nfts, context);
+
+            return {
+              from,
+              to,
+              nfts: ids.map(nftId => new Nft({ assetId, id: nftId }, context)),
+              asset: new NftCollection({ assetId }, context),
+            };
+          } else {
+            const {
+              senderIdentity,
+              receiverIdentity,
+              amount,
+              ticker: rawTicker,
+            } = legValue.asOffChain;
+
+            const ticker = tickerToString(rawTicker);
+            const from = identityIdToString(senderIdentity);
+            const to = identityIdToString(receiverIdentity);
+
+            return {
+              from: new Identity({ did: from }, context),
+              to: new Identity({ did: to }, context),
+              offChainAmount: balanceToBigNumber(amount),
+              asset: ticker,
+            };
+          }
+        } else {
+          throw new Error(
+            'Instruction has already been executed/rejected and it was purged from chain'
+          );
+        }
+      });
+
+    return {
+      data,
+      next,
+    };
   }
 
   /**
@@ -608,7 +713,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       };
     }
 
-    return context.getInstructionLegsFromChain(id, paginationOpts as PaginationOptions);
+    return this.getLegsFromChain(paginationOpts as PaginationOptions);
   }
 
   /**

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -301,7 +301,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
 
     const instructionCounter = await settlement.instructionCounter();
 
-    return id.lte(u64ToBigNumber(instructionCounter));
+    return id.gt(new BigNumber(0)) && id.lt(u64ToBigNumber(instructionCounter));
   }
 
   /**
@@ -548,6 +548,16 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       data,
       next,
     };
+  }
+
+  /**
+   * Retrieve all legs of this Instruction from chain
+   * @param paginationOpts
+   *
+   * @hidden
+   */
+  public async getLegsFromChain(paginationOpts?: PaginationOptions): Promise<ResultSet<Leg>> {
+    return this.context.getInstructionLegsFromChain(this.id, paginationOpts as PaginationOptions);
   }
 
   /**

--- a/src/api/procedures/__tests__/executeManualInstruction.ts
+++ b/src/api/procedures/__tests__/executeManualInstruction.ts
@@ -344,19 +344,15 @@ describe('executeManualInstruction procedure', () => {
       const proc = procedureMockUtils.getInstance<Params, Instruction, Storage>(mockContext);
 
       const boundFunc = prepareStorage.bind(proc);
-      dsMockUtils.configureMocks({
-        contextOptions: {
-          getInstructionLegsFromChain: {
+      entityMockUtils.configureMocks({
+        instructionOptions: {
+          getLegsFromChain: {
             data: [
               { from, to, amount, asset },
               { from: sender, to: receiver, offChainAmount: amount, asset: 'OFF_CHAIN_ASSET' },
             ],
             next: null,
           },
-        },
-      });
-      entityMockUtils.configureMocks({
-        instructionOptions: {
           details: instructionDetails,
         },
       });
@@ -383,14 +379,9 @@ describe('executeManualInstruction procedure', () => {
       from = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });
       to = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: false });
 
-      dsMockUtils.configureMocks({
-        contextOptions: {
-          getInstructionLegsFromChain: { data: [{ from, to, amount, asset }], next: null },
-        },
-      });
-
       entityMockUtils.configureMocks({
         instructionOptions: {
+          getLegsFromChain: { data: [{ from, to, amount, asset }], next: null },
           details: instructionDetails,
         },
       });

--- a/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
@@ -1121,9 +1121,16 @@ describe('modifyInstructionAffirmation procedure', () => {
     const asset = entityMockUtils.getFungibleAssetInstance({ assetId: 'SOME_ASSET' });
 
     it('should return the portfolios for which to modify affirmation status', async () => {
-      dsMockUtils.configureMocks({
-        contextOptions: {
-          getInstructionLegsFromChain: {
+      const proc = procedureMockUtils.getInstance<
+        ModifyInstructionAffirmationParams,
+        Instruction,
+        Storage
+      >(mockContext);
+
+      const boundFunc = prepareStorage.bind(proc);
+      entityMockUtils.configureMocks({
+        instructionOptions: {
+          getLegsFromChain: {
             data: [
               { from: from1, to: to1, amount, asset },
               { from: from2, to: to2, amount, asset },
@@ -1133,13 +1140,6 @@ describe('modifyInstructionAffirmation procedure', () => {
           },
         },
       });
-      const proc = procedureMockUtils.getInstance<
-        ModifyInstructionAffirmationParams,
-        Instruction,
-        Storage
-      >(mockContext);
-
-      const boundFunc = prepareStorage.bind(proc);
 
       let result = await boundFunc({
         id: new BigNumber(1),
@@ -1213,18 +1213,6 @@ describe('modifyInstructionAffirmation procedure', () => {
     });
 
     it('should return the portfolios for which to modify affirmation status when there is no sender legs', async () => {
-      from1 = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });
-      to1 = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: false });
-
-      dsMockUtils.configureMocks({
-        contextOptions: {
-          getInstructionLegsFromChain: {
-            data: [{ from: from1, to: to1, amount, asset }],
-            next: null,
-          },
-        },
-      });
-
       const proc = procedureMockUtils.getInstance<
         ModifyInstructionAffirmationParams,
         Instruction,
@@ -1232,6 +1220,14 @@ describe('modifyInstructionAffirmation procedure', () => {
       >(mockContext);
 
       const boundFunc = prepareStorage.bind(proc);
+      from1 = entityMockUtils.getDefaultPortfolioInstance({ did: fromDid, isCustodiedBy: false });
+      to1 = entityMockUtils.getDefaultPortfolioInstance({ did: toDid, isCustodiedBy: false });
+
+      entityMockUtils.configureMocks({
+        instructionOptions: {
+          getLegsFromChain: { data: [{ from: from1, to: to1, amount, asset }], next: null },
+        },
+      });
 
       const result = await boundFunc({
         id: new BigNumber(1),

--- a/src/api/procedures/executeManualInstruction.ts
+++ b/src/api/procedures/executeManualInstruction.ts
@@ -160,7 +160,7 @@ export async function prepareStorage(
   const instruction = new Instruction({ id }, context);
 
   const [{ data: legs }, { did }, details] = await Promise.all([
-    context.getInstructionLegsFromChain(id),
+    instruction.getLegsFromChain(),
     context.getSigningIdentity(),
     instruction.details(),
   ]);

--- a/src/api/procedures/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/modifyInstructionAffirmation.ts
@@ -654,8 +654,10 @@ export async function prepareStorage(
 
   const portfolioIdParams = portfolioParams.map(portfolioLikeToPortfolioId);
 
+  const instruction = new Instruction({ id }, context);
+
   const [{ data: legs }, signer, executeInstructionInfo] = await Promise.all([
-    context.getInstructionLegsFromChain(id),
+    instruction.getLegsFromChain(),
     context.getSigningIdentity(),
     polymeshApi.call.settlementApi.getExecuteInstructionInfo(rawId),
   ]);

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -186,7 +186,6 @@ import {
   CountryCode as CountryCodeEnum,
   DistributionWithDetails,
   ExtrinsicData,
-  Leg,
   MiddlewareMetadata,
   PermissionedAccount,
   ProtocolFees,
@@ -458,7 +457,6 @@ interface ContextOptions {
   supportsSubscription?: boolean;
   getSignature?: `0x${string}`;
   getNextAssetId?: string;
-  getInstructionLegsFromChain?: ResultSet<Leg>;
 }
 
 interface SigningManagerOptions {
@@ -794,10 +792,6 @@ const defaultContextOptions: ContextOptions = {
   supportsSubscription: true,
   getSignature: '0xsignature',
   getNextAssetId: '0x12341234123412341234123412341234',
-  getInstructionLegsFromChain: {
-    data: [],
-    next: null,
-  },
 };
 let contextOptions: ContextOptions = defaultContextOptions;
 const defaultSigningManagerOptions: SigningManagerOptions = {
@@ -934,7 +928,6 @@ function configureContext(opts: ContextOptions): void {
     assertHasSigningAddress: jest.fn(),
     assertSupportsSubscription: jest.fn(),
     getSignature: jest.fn().mockReturnValue(opts.getSignature),
-    getInstructionLegsFromChain: jest.fn().mockResolvedValue(opts.getInstructionLegsFromChain),
   } as unknown as MockContext;
 
   contextInstance.clone = jest.fn().mockReturnValue(contextInstance);

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -303,6 +303,7 @@ interface InstructionOptions extends EntityOptions {
   id?: BigNumber;
   details?: EntityGetter<InstructionDetails>;
   getLegs?: EntityGetter<ResultSet<Leg>>;
+  getLegsFromChain?: EntityGetter<ResultSet<Leg>>;
   isPending?: EntityGetter<boolean>;
 }
 
@@ -1514,6 +1515,7 @@ const MockInstructionClass = createMockEntityClass<InstructionOptions>(
     id!: BigNumber;
     details!: jest.Mock;
     getLegs!: jest.Mock;
+    getLegsFromChain!: jest.Mock;
     isPending!: jest.Mock;
 
     /**
@@ -1532,6 +1534,7 @@ const MockInstructionClass = createMockEntityClass<InstructionOptions>(
       this.details = createEntityGetterMock(opts.details);
       this.getLegs = createEntityGetterMock(opts.getLegs);
       this.isPending = createEntityGetterMock(opts.isPending);
+      this.getLegsFromChain = createEntityGetterMock(opts.getLegsFromChain);
     }
   },
   () => ({
@@ -1545,6 +1548,17 @@ const MockInstructionClass = createMockEntityClass<InstructionOptions>(
       type: InstructionType.SettleOnAffirmation,
     },
     getLegs: {
+      data: [
+        {
+          from: getNumberedPortfolioInstance({ did: 'someDid', id: new BigNumber(1) }),
+          to: getNumberedPortfolioInstance({ did: 'otherDid', id: new BigNumber(1) }),
+          asset: getFungibleAssetInstance(),
+          amount: new BigNumber(100),
+        },
+      ],
+      next: null,
+    },
+    getLegsFromChain: {
       data: [
         {
           from: getNumberedPortfolioInstance({ did: 'someDid', id: new BigNumber(1) }),


### PR DESCRIPTION
### Description

When an instruction is queried we check that the instruction ID is less than or equal to the instruction counter from the chain. Description in metadata states `InstructionCounter - Number of instructions in the system (It's one more than the actual number)`. As a result if we query an instruction one more than the latest instruction the chain SDK doesn't throw an error when it should. This fixes the same logic

### Breaking Changes

NA

### JIRA Link

DA-1400

### Checklist

- [ ] Updated the Readme.md (if required) ?
