### PR TITLE
fix: 🐛 Correctly return status for failed instructions

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -1461,6 +1461,21 @@ describe('Instruction class', () => {
         {
           query: instructionEventsQuery(
             {
+              event: InstructionEventEnum.FailedToExecuteInstruction,
+              instructionId: id.toString(),
+            },
+            new BigNumber(1),
+            new BigNumber(0)
+          ),
+          returnData: {
+            instructionEvents: {
+              nodes: [],
+            },
+          },
+        },
+        {
+          query: instructionEventsQuery(
+            {
               event: InstructionEventEnum.InstructionRejected,
               instructionId: id.toString(),
             },
@@ -1544,6 +1559,21 @@ describe('Instruction class', () => {
         {
           query: instructionEventsQuery(
             {
+              event: InstructionEventEnum.FailedToExecuteInstruction,
+              instructionId: id.toString(),
+            },
+            new BigNumber(1),
+            new BigNumber(0)
+          ),
+          returnData: {
+            instructionEvents: {
+              nodes: [],
+            },
+          },
+        },
+        {
+          query: instructionEventsQuery(
+            {
               event: InstructionEventEnum.InstructionRejected,
               instructionId: id.toString(),
             },
@@ -1558,7 +1588,76 @@ describe('Instruction class', () => {
         },
       ]);
 
-      const result = await instruction.getStatus();
+      let result = await instruction.getStatus();
+      expect(result).toMatchObject({
+        status: InstructionStatus.Failed,
+        eventIdentifier: fakeEventIdentifierResult,
+      });
+
+      dsMockUtils.createApolloMultipleQueriesMock([
+        {
+          query: instructionEventsQuery(
+            {
+              event: InstructionEventEnum.InstructionExecuted,
+              instructionId: id.toString(),
+            },
+            new BigNumber(1),
+            new BigNumber(0)
+          ),
+          returnData: {
+            instructionEvents: {
+              nodes: [],
+            },
+          },
+        },
+        {
+          query: instructionEventsQuery(
+            {
+              event: InstructionEventEnum.InstructionFailed,
+              instructionId: id.toString(),
+            },
+            new BigNumber(1),
+            new BigNumber(0)
+          ),
+          returnData: {
+            instructionEvents: {
+              nodes: [],
+            },
+          },
+        },
+        {
+          query: instructionEventsQuery(
+            {
+              event: InstructionEventEnum.FailedToExecuteInstruction,
+              instructionId: id.toString(),
+            },
+            new BigNumber(1),
+            new BigNumber(0)
+          ),
+          returnData: {
+            instructionEvents: {
+              nodes: [fakeQueryResult],
+            },
+          },
+        },
+        {
+          query: instructionEventsQuery(
+            {
+              event: InstructionEventEnum.InstructionRejected,
+              instructionId: id.toString(),
+            },
+            new BigNumber(1),
+            new BigNumber(0)
+          ),
+          returnData: {
+            instructionEvents: {
+              nodes: [],
+            },
+          },
+        },
+      ]);
+
+      result = await instruction.getStatus();
       expect(result).toMatchObject({
         status: InstructionStatus.Failed,
         eventIdentifier: fakeEventIdentifierResult,
@@ -1613,6 +1712,21 @@ describe('Instruction class', () => {
           query: instructionEventsQuery(
             {
               event: InstructionEventEnum.InstructionFailed,
+              instructionId: id.toString(),
+            },
+            new BigNumber(1),
+            new BigNumber(0)
+          ),
+          returnData: {
+            instructionEvents: {
+              nodes: [],
+            },
+          },
+        },
+        {
+          query: instructionEventsQuery(
+            {
+              event: InstructionEventEnum.FailedToExecuteInstruction,
               instructionId: id.toString(),
             },
             new BigNumber(1),
@@ -1688,6 +1802,21 @@ describe('Instruction class', () => {
           query: instructionEventsQuery(
             {
               event: InstructionEventEnum.InstructionFailed,
+              instructionId: id.toString(),
+            },
+            new BigNumber(1),
+            new BigNumber(0)
+          ),
+          returnData: {
+            instructionEvents: {
+              nodes: [],
+            },
+          },
+        },
+        {
+          query: instructionEventsQuery(
+            {
+              event: InstructionEventEnum.FailedToExecuteInstruction,
               instructionId: id.toString(),
             },
             new BigNumber(1),

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -744,12 +744,17 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       };
     }
 
-    const [executedEventIdentifier, failedEventIdentifier, rejectedEventIdentifier] =
-      await Promise.all([
-        this.getInstructionEventFromMiddleware(InstructionEventEnum.InstructionExecuted),
-        this.getInstructionEventFromMiddleware(InstructionEventEnum.InstructionFailed),
-        this.getInstructionEventFromMiddleware(InstructionEventEnum.InstructionRejected),
-      ]);
+    const [
+      executedEventIdentifier,
+      failedEventIdentifier,
+      failedToExecuteIdentifier,
+      rejectedEventIdentifier,
+    ] = await Promise.all([
+      this.getInstructionEventFromMiddleware(InstructionEventEnum.InstructionExecuted),
+      this.getInstructionEventFromMiddleware(InstructionEventEnum.InstructionFailed),
+      this.getInstructionEventFromMiddleware(InstructionEventEnum.FailedToExecuteInstruction), // this is the new event triggered for failed to execute instruction
+      this.getInstructionEventFromMiddleware(InstructionEventEnum.InstructionRejected),
+    ]);
 
     if (executedEventIdentifier) {
       return {
@@ -762,6 +767,13 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       return {
         status: InstructionStatus.Failed,
         eventIdentifier: failedEventIdentifier,
+      };
+    }
+
+    if (failedToExecuteIdentifier) {
+      return {
+        status: InstructionStatus.Failed,
+        eventIdentifier: failedToExecuteIdentifier,
       };
     }
 
@@ -830,6 +842,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       | InstructionEventEnum.InstructionExecuted
       | InstructionEventEnum.InstructionFailed
       | InstructionEventEnum.InstructionRejected
+      | InstructionEventEnum.FailedToExecuteInstruction
   ): Promise<EventIdentifier | null> {
     const { id, context } = this;
 


### PR DESCRIPTION
### Description

With new event `FailedToExecuteInstruction` being tracked by SQ for failed events, SDK was not returning the status as failed for failed instructions. 

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

DA-1408

### Checklist

- [ ] Updated the Readme.md (if required) ?
