### PR TITLE
fix: 🐛 ignore improper cased permissions

### DIFF
--- a/src/api/entities/Identity/__tests__/AssetPermissions.ts
+++ b/src/api/entities/Identity/__tests__/AssetPermissions.ts
@@ -297,7 +297,7 @@ describe('AssetPermissions class', () => {
       });
 
       const mockExtrinsicNames = dsMockUtils.createMockExtrinsicName({
-        Except: [dsMockUtils.createMockText('createAsset')],
+        Except: [dsMockUtils.createMockText('create_asset')],
       });
 
       const assetTextKey = dsMockUtils.createMockText('asset');

--- a/src/api/entities/__tests__/CustomPermissionGroup.ts
+++ b/src/api/entities/__tests__/CustomPermissionGroup.ts
@@ -123,7 +123,7 @@ describe('CustomPermissionGroup class', () => {
 
       const rawAddClaimPermissions = dsMockUtils.createMockPalletPermissions({
         extrinsics: dsMockUtils.createMockExtrinsicName({
-          These: [dsMockUtils.createMockText('addClaim')],
+          These: [dsMockUtils.createMockText('add_claim')],
         }),
       });
 

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -2195,6 +2195,12 @@ describe('permissionsToMeshPermissions and meshPermissionsToPermissions', () => 
   });
 
   describe('meshPermissionsToPermissionsV2', () => {
+    beforeEach(() => {
+      dsMockUtils.createQueryMock('identity', 'keyAssetPermissions');
+      dsMockUtils.createQueryMock('identity', 'keyExtrinsicPermissions');
+      dsMockUtils.createQueryMock('identity', 'keyPortfolioPermissions');
+    });
+
     it('should convert an Account object to a Permissions', async () => {
       jest.spyOn(utilsInternalModule, 'assertAddressValid').mockImplementation();
       dsMockUtils.createQueryMock('identity', 'keyAssetPermissions');
@@ -2335,6 +2341,44 @@ describe('permissionsToMeshPermissions and meshPermissionsToPermissions', () => 
 
       result = await meshPermissionsToPermissionsV2(entityMockUtils.getAccountInstance(), context);
       expect(result).toEqual(fakeResult);
+    });
+
+    it('should filter out incorrectly cased modules and extrinsics', async () => {
+      const context = dsMockUtils.getContextInstance();
+      const rawIdentityName = dsMockUtils.createMockText('identity');
+      const rawAuthorshipName = dsMockUtils.createMockText('Asset');
+
+      const rawIdentityPermissions = dsMockUtils.createMockPalletPermissions({
+        extrinsics: dsMockUtils.createMockExtrinsicName({
+          These: [dsMockUtils.createMockText('add_claim')],
+        }),
+      });
+
+      const rawAssetPermissions = dsMockUtils.createMockPalletPermissions({
+        extrinsics: dsMockUtils.createMockExtrinsicName({
+          These: [dsMockUtils.createMockText('createAsset')],
+        }),
+      });
+
+      const permissionsMap = new Map();
+      permissionsMap.set(rawIdentityName, rawIdentityPermissions);
+      permissionsMap.set(rawAuthorshipName, rawAssetPermissions);
+
+      dsMockUtils.getQueryMultiMock().mockResolvedValue([
+        dsMockUtils.createMockOption(),
+        dsMockUtils.createMockOption(
+          dsMockUtils.createMockExtrinsicPermissions({
+            These: dsMockUtils.createMockBTreeMap(permissionsMap),
+          })
+        ),
+        dsMockUtils.createMockOption(),
+      ]);
+
+      const result = await meshPermissionsToPermissionsV2(
+        entityMockUtils.getAccountInstance(),
+        context
+      );
+      expect(result.transactions?.values).toEqual([]);
     });
   });
 });

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -66,3 +66,11 @@ export const uuidToHex = (uuid: string): string => {
 
   return `0x${trimmedUuid.replace(/-/g, '')}`;
 };
+
+export const isSnakeCase = (input: string): boolean => {
+  return /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/.test(input);
+};
+
+export const startsWithCapital = (input: string): boolean => {
+  return input[0] === input[0].toUpperCase();
+};


### PR DESCRIPTION
### Description

if a user inputs permissions directly on chain there is no validation of their cases. This updates it so incorrect cased permissions are ignored


### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

✅ Closes: [DA-1397](https://polymesh.atlassian.net/browse/DA-1397)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1397]: https://polymesh.atlassian.net/browse/DA-1397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ