### PR TITLE
Fix type for `tradeDate` and `valueDate` in instruction details when queried from middleware

### DIFF
--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -474,8 +474,8 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       return {
         status: middlewareInstructionStatusToInstructionStatus(status),
         createdAt: new Date(createdBlock!.datetime),
-        tradeDate,
-        valueDate,
+        tradeDate: new Date(tradeDate),
+        valueDate: new Date(valueDate),
         venue: venueId ? new Venue({ id: new BigNumber(venueId) }, context) : null,
         memo: memo ?? null,
         ...endCondition,


### PR DESCRIPTION
### Description

Convert `tradeDate` and `valueDate` middleware date/times to `Date`

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
