### PR TITLE
fix: 🐛 handle createdAt order by for SQ v19+

### DIFF
--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -316,6 +316,7 @@ describe('Account class', () => {
 
       dsMockUtils.createApolloQueryMock(
         extrinsicsByArgs(
+          false,
           {
             blockId: blockNumber1.toString(),
             address,
@@ -370,6 +371,7 @@ describe('Account class', () => {
 
       dsMockUtils.createApolloQueryMock(
         extrinsicsByArgs(
+          false,
           {
             blockId: blockNumber1.toString(),
             address,
@@ -409,6 +411,7 @@ describe('Account class', () => {
 
       dsMockUtils.createApolloQueryMock(
         extrinsicsByArgs(
+          false,
           {
             blockId: undefined,
             address,
@@ -438,6 +441,7 @@ describe('Account class', () => {
 
       dsMockUtils.createApolloQueryMock(
         extrinsicsByArgs(
+          false,
           {
             blockId: undefined,
             address,

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -251,6 +251,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       },
     } = await context.queryMiddleware<Ensured<Query, 'extrinsics'>>(
       extrinsicsByArgs(
+        context.isSqIdPadded,
         {
           blockId: blockNumber ? blockNumber.toString() : undefined,
           address,

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -628,7 +628,7 @@ describe('Identity class', () => {
           .calledWith({ id: assetId }, context)
           .mockReturnValue(assetId)
       );
-      dsMockUtils.createApolloQueryMock(assetHoldersQuery({ identityId: did }), {
+      dsMockUtils.createApolloQueryMock(assetHoldersQuery(false, { identityId: did }), {
         assetHolders: {
           nodes: assetIds.map(assetId => ({ asset: { id: assetId } })),
           totalCount: 2,
@@ -642,6 +642,7 @@ describe('Identity class', () => {
 
       dsMockUtils.createApolloQueryMock(
         assetHoldersQuery(
+          false,
           { identityId: did },
           new BigNumber(1),
           new BigNumber(0),
@@ -679,7 +680,7 @@ describe('Identity class', () => {
           .mockReturnValue(assetId)
       );
 
-      dsMockUtils.createApolloQueryMock(nftHoldersQuery({ identityId: did }), {
+      dsMockUtils.createApolloQueryMock(nftHoldersQuery(false, { identityId: did }), {
         nftHolders: {
           nodes: assetIds.map(assetId => ({ asset: { id: assetId }, nftIds: [] })),
           totalCount: 2,
@@ -693,6 +694,7 @@ describe('Identity class', () => {
 
       dsMockUtils.createApolloQueryMock(
         nftHoldersQuery(
+          false,
           { identityId: did },
           new BigNumber(1),
           new BigNumber(0),

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -404,6 +404,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
       },
     } = await context.queryMiddleware<Ensured<Query, 'assetHolders'>>(
       assetHoldersQuery(
+        context.isSqIdPadded,
         {
           identityId: did,
         },
@@ -451,6 +452,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
       },
     } = await context.queryMiddleware<Ensured<Query, 'nftHolders'>>(
       nftHoldersQuery(
+        context.isSqIdPadded,
         {
           identityId: did,
         },
@@ -755,7 +757,10 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
     let start: BigNumber | undefined;
 
     while (!allFetched) {
-      const { data, next } = await this.getHeldAssets({ size: MAX_PAGE_SIZE, start });
+      const { data, next } = await this.getHeldAssets({
+        size: MAX_PAGE_SIZE,
+        start,
+      });
       start = next ? new BigNumber(next) : undefined;
       allFetched = !next;
       assets = [...assets, ...data];

--- a/src/middleware/__tests__/queries/assets.ts
+++ b/src/middleware/__tests__/queries/assets.ts
@@ -30,12 +30,12 @@ describe('assetHoldersQuery', () => {
       start: 0,
     };
 
-    let result = assetHoldersQuery(variables);
+    let result = assetHoldersQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
-    result = assetHoldersQuery(variables, new BigNumber(1), new BigNumber(0));
+    result = assetHoldersQuery(false, variables, new BigNumber(1), new BigNumber(0));
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({
@@ -54,12 +54,12 @@ describe('nftHoldersQuery', () => {
       start: 0,
     };
 
-    let result = nftHoldersQuery(variables);
+    let result = nftHoldersQuery(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
 
-    result = nftHoldersQuery(variables, new BigNumber(1), new BigNumber(0));
+    result = nftHoldersQuery(false, variables, new BigNumber(1), new BigNumber(0));
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({

--- a/src/middleware/__tests__/queries/extrinsics.ts
+++ b/src/middleware/__tests__/queries/extrinsics.ts
@@ -17,7 +17,7 @@ describe('extrinsicByHash', () => {
 
 describe('extrinsicsByArgs', () => {
   it('should pass the variables to the grapqhl query', () => {
-    let result = extrinsicsByArgs({});
+    let result = extrinsicsByArgs(false, {});
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({ size: DEFAULT_GQL_PAGE_SIZE, start: 0 });
@@ -32,7 +32,7 @@ describe('extrinsicsByArgs', () => {
       start: 0,
     };
 
-    result = extrinsicsByArgs(variables);
+    result = extrinsicsByArgs(false, variables);
 
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);

--- a/src/middleware/queries/assets.ts
+++ b/src/middleware/queries/assets.ts
@@ -50,11 +50,21 @@ export function assetQuery(
  * Get asset held by a DID
  */
 export function assetHoldersQuery(
+  isSqIdPadded: boolean,
   filters: QueryArgs<AssetHolder, 'identityId'>,
   size?: BigNumber,
   start?: BigNumber,
   orderBy = AssetHoldersOrderBy.AssetIdAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<DistributionPayment, 'distributionId'>>> {
+  if (isSqIdPadded) {
+    if (orderBy === AssetHoldersOrderBy.CreatedAtAsc) {
+      orderBy = AssetHoldersOrderBy.CreatedBlockIdAsc;
+    }
+    if (orderBy === AssetHoldersOrderBy.CreatedAtDesc) {
+      orderBy = AssetHoldersOrderBy.CreatedBlockIdDesc;
+    }
+  }
+
   const query = gql`
     query AssetHoldersQuery($identityId: String!, $size: Int, $start: Int) {
       assetHolders(
@@ -89,11 +99,21 @@ export function assetHoldersQuery(
  * Get NFTs held by a DID
  */
 export function nftHoldersQuery(
+  isSqIdPadded: boolean,
   filters: QueryArgs<NftHolder, 'identityId'>,
   size?: BigNumber,
   start?: BigNumber,
   orderBy = NftHoldersOrderBy.AssetIdAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<NftHolder, 'identityId'>>> {
+  if (isSqIdPadded) {
+    if (orderBy === NftHoldersOrderBy.CreatedAtAsc) {
+      orderBy = NftHoldersOrderBy.CreatedBlockIdAsc;
+    }
+    if (orderBy === NftHoldersOrderBy.CreatedAtDesc) {
+      orderBy = NftHoldersOrderBy.CreatedBlockIdDesc;
+    }
+  }
+
   const query = gql`
     query NftHolderQuery($identityId: String!, $size: Int, $start: Int) {
       nftHolders(

--- a/src/middleware/queries/extrinsics.ts
+++ b/src/middleware/queries/extrinsics.ts
@@ -55,6 +55,7 @@ type ExtrinsicArgs = 'blockId' | 'address' | 'moduleId' | 'callId' | 'success';
  * Get transactions
  */
 export function extrinsicsByArgs(
+  isSqIdPadded: boolean,
   filters: QueryArgs<Extrinsic, ExtrinsicArgs>,
   size?: BigNumber,
   start?: BigNumber,
@@ -65,6 +66,16 @@ export function extrinsicsByArgs(
     callId: 'CallIdEnum',
     success: 'Int',
   });
+
+  if (isSqIdPadded) {
+    if (orderBy === ExtrinsicsOrderBy.CreatedAtAsc) {
+      orderBy = ExtrinsicsOrderBy.BlockIdAsc;
+    }
+    if (orderBy === ExtrinsicsOrderBy.CreatedAtDesc) {
+      orderBy = ExtrinsicsOrderBy.BlockIdDesc;
+    }
+  }
+
   const query = gql`
     query TransactionsQuery
       ${args}

--- a/src/middleware/queries/settlements.ts
+++ b/src/middleware/queries/settlements.ts
@@ -210,6 +210,7 @@ type InstructionAffirmationArgs = 'instructionId' | 'status' | 'identity' | 'isM
  * Get a specific instruction within a venue for a specific event
  */
 export function instructionAffirmationsQuery(
+  paddedIds: boolean,
   filters: QueryArgs<InstructionAffirmation, InstructionAffirmationArgs>,
   size?: BigNumber,
   start?: BigNumber
@@ -218,6 +219,11 @@ export function instructionAffirmationsQuery(
     status: 'AffirmStatusEnum',
     isMediator: 'Boolean',
   });
+
+  const orderBy = paddedIds
+    ? `[${InstructionAffirmationsOrderBy.CreatedBlockIdDesc}]`
+    : `[${InstructionAffirmationsOrderBy.CreatedAtAsc}, ${InstructionAffirmationsOrderBy.CreatedBlockIdAsc}]`;
+
   const query = gql`
     query InstructionAffirmationsQuery
       ${args}
@@ -226,7 +232,7 @@ export function instructionAffirmationsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${InstructionAffirmationsOrderBy.CreatedAtAsc}, ${InstructionAffirmationsOrderBy.CreatedBlockIdAsc}]
+        orderBy: ${orderBy}
       ) {
         totalCount
         nodes {
@@ -248,8 +254,13 @@ export function instructionAffirmationsQuery(
  * Get a specific instruction within a venue for a specific event
  */
 export function offChainAffirmationsQuery(
+  paddedIds: boolean,
   filters: QueryArgs<InstructionAffirmation, 'instructionId'>
 ): QueryOptions<QueryArgs<InstructionAffirmation, 'instructionId'>> {
+  const orderBy = paddedIds
+    ? `${InstructionAffirmationsOrderBy.CreatedBlockIdAsc}`
+    : `${InstructionAffirmationsOrderBy.CreatedAtAsc}, ${InstructionAffirmationsOrderBy.CreatedBlockIdAsc}`;
+
   const query = gql`
     query InstructionAffirmationsQuery($instructionId: String!) {
       instructionAffirmations(
@@ -257,7 +268,7 @@ export function offChainAffirmationsQuery(
           instructionId: { equalTo: $instructionId }
           offChainReceiptExists: true
         }
-        orderBy: [${InstructionAffirmationsOrderBy.CreatedAtAsc}, ${InstructionAffirmationsOrderBy.CreatedBlockIdAsc}]
+        orderBy: [${orderBy}]
       ) {
         nodes {
           ${instructionAffirmationAttributes}


### PR DESCRIPTION
### Description

Fix offChainAffirmations, instructionAffirmations order by. Handle CREATED_AT order by in getTransactionHistory, getHeldAssets and getHeldNfts by replacing it with CREATED_BLOCK_ID order instead (which is equivalent in SQv19+). Created at ordering is marked as deprecated and will be removed when SQ v18 is no longer supported

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

DA-1434

### Checklist

- [ ] Updated the Readme.md (if required) ?
