### PR TITLE
fix: 🐛 error when passing Account to register identity

### DIFF
--- a/src/api/procedures/registerIdentity.ts
+++ b/src/api/procedures/registerIdentity.ts
@@ -1,6 +1,6 @@
 import { ISubmittableResult } from '@polkadot/types/types';
 
-import { Account, Context, Identity, PolymeshError, Procedure } from '~/internal';
+import { Context, Identity, PolymeshError, Procedure } from '~/internal';
 import { ErrorCode, RegisterIdentityParams, RoleType, TxTags } from '~/types';
 import { ExtrinsicParams, TransactionSpec } from '~/types/internal';
 import {
@@ -11,7 +11,7 @@ import {
   signerToString,
   stringToAccountId,
 } from '~/utils/conversion';
-import { filterEventRecords, optionize } from '~/utils/internal';
+import { asAccount, filterEventRecords, optionize } from '~/utils/internal';
 
 /**
  * @hidden
@@ -45,7 +45,7 @@ export async function prepareRegisterIdentity(
   } = this;
   const { targetAccount, secondaryAccounts = [], createCdd = false, expiry } = args;
 
-  const account = new Account({ address: targetAccount.toString() }, context);
+  const account = asAccount(targetAccount, context);
 
   const identityExists = await account.getIdentity();
 


### PR DESCRIPTION
### Description

register identity would error when receiving an Account object (address string was fine). This updates it to use the generic input handler

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
