### PR TITLE
fix: 🐛 duplicate entries returned on historicalInstructions

### DIFF
--- a/src/api/client/Settlements.ts
+++ b/src/api/client/Settlements.ts
@@ -10,16 +10,16 @@ import {
   PolymeshError,
   Venue,
 } from '~/internal';
-import { instructionPartiesQuery } from '~/middleware/queries/settlements';
+import { historicalInstructionsQuery } from '~/middleware/queries/settlements';
 import { Query } from '~/middleware/types';
 import {
   AddInstructionWithVenueIdParams,
   CreateVenueParams,
   ErrorCode,
+  HistoricalInstructionFilters,
   HistoricInstruction,
   InstructionAffirmationOperation,
   InstructionIdParams,
-  InstructionPartiesFilters,
   ProcedureMethod,
 } from '~/types';
 import { Ensured } from '~/types/utils';
@@ -134,19 +134,19 @@ export class Settlements {
    *
    */
   public async getHistoricalInstructions(
-    filter: InstructionPartiesFilters
+    filter: HistoricalInstructionFilters
   ): Promise<HistoricInstruction[]> {
     const { context } = this;
 
-    const query = await instructionPartiesQuery(filter, context);
+    const query = await historicalInstructionsQuery(filter, context);
 
     const {
       data: {
-        instructionParties: { nodes: instructionsResult },
+        instructions: { nodes: instructionsResult },
       },
-    } = await context.queryMiddleware<Ensured<Query, 'instructionParties'>>(query);
+    } = await context.queryMiddleware<Ensured<Query, 'instructions'>>(query);
 
-    return instructionsResult.map(({ instruction }) =>
+    return instructionsResult.map(instruction =>
       middlewareInstructionToHistoricInstruction(instruction!, context)
     );
   }

--- a/src/api/client/__tests__/Settlements.ts
+++ b/src/api/client/__tests__/Settlements.ts
@@ -3,7 +3,7 @@ import { when } from 'jest-when';
 
 import { Settlements } from '~/api/client/Settlements';
 import { addInstructionTransformer, Context, PolymeshTransaction, Venue } from '~/internal';
-import { instructionPartiesQuery } from '~/middleware/queries/settlements';
+import { historicalInstructionsQuery } from '~/middleware/queries/settlements';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import {
@@ -195,13 +195,13 @@ describe('Settlements Class', () => {
         'middlewareInstructionToHistoricInstruction'
       );
 
-      const legsResponse = {
+      const instructionsResponse = {
         totalCount: 5,
-        nodes: [{ instruction: 'instruction' }],
+        nodes: [{ id: '1' }],
       };
 
-      dsMockUtils.createApolloQueryMock(await instructionPartiesQuery({}, context), {
-        instructionParties: legsResponse,
+      dsMockUtils.createApolloQueryMock(await historicalInstructionsQuery({}, context), {
+        instructions: instructionsResponse,
       });
 
       const mockHistoricInstruction = 'mockData' as unknown as HistoricInstruction;

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -218,7 +218,7 @@ export type CustomClaimTypeWithDid = CustomClaimType & { did?: string };
  * Filters for instructions
  *
  */
-export interface InstructionPartiesFilters {
+export interface HistoricalInstructionFilters {
   /**
    * The DID of the identity to filter by
    */

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -22,7 +22,7 @@ import {
 } from '~/internal';
 import { assetHoldersQuery, nftHoldersQuery } from '~/middleware/queries/assets';
 import { trustingAssetsQuery } from '~/middleware/queries/claims';
-import { instructionPartiesQuery } from '~/middleware/queries/settlements';
+import { historicalInstructionsQuery } from '~/middleware/queries/settlements';
 import { AssetHoldersOrderBy, NftHoldersOrderBy } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { MockContext } from '~/testUtils/mocks/dataSources';
@@ -1288,15 +1288,15 @@ describe('Identity class', () => {
         'middlewareInstructionToHistoricInstruction'
       );
 
-      const legsResponse = {
+      const instructionsResponse = {
         totalCount: 5,
-        nodes: [{ instruction: 'instruction' }],
+        nodes: [{ id: '1' }],
       };
 
-      const query = await instructionPartiesQuery({ identity: identity.did }, context);
+      const query = await historicalInstructionsQuery({ identity: identity.did }, context);
 
       dsMockUtils.createApolloQueryMock(query, {
-        instructionParties: legsResponse,
+        instructions: instructionsResponse,
       });
 
       const mockHistoricInstruction = 'mockData' as unknown as HistoricInstruction;

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -27,7 +27,7 @@ import {
 } from '~/internal';
 import { assetHoldersQuery, nftHoldersQuery } from '~/middleware/queries/assets';
 import { trustingAssetsQuery } from '~/middleware/queries/claims';
-import { instructionPartiesQuery } from '~/middleware/queries/settlements';
+import { historicalInstructionsQuery } from '~/middleware/queries/settlements';
 import { AssetHoldersOrderBy, NftHoldersOrderBy, Query } from '~/middleware/types';
 import { CddStatus } from '~/polkadot/polymesh';
 import {
@@ -39,8 +39,8 @@ import {
   GroupedInstructions,
   GroupedInvolvedInstructions,
   HeldNfts,
+  HistoricalInstructionFilters,
   HistoricInstruction,
-  InstructionPartiesFilters,
   InstructionsByStatus,
   MultiSigSigners,
   NumberedPortfolio,
@@ -906,21 +906,20 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    *
    */
   public async getHistoricalInstructions(
-    filter?: Omit<InstructionPartiesFilters, 'identity'>
+    filter?: Omit<HistoricalInstructionFilters, 'identity'>
   ): Promise<HistoricInstruction[]> {
     const { context, did } = this;
 
-    const query = await instructionPartiesQuery({ ...filter, identity: did }, context);
+    const query = await historicalInstructionsQuery({ ...filter, identity: did }, context);
 
     const {
       data: {
-        instructionParties: { nodes: instructionsResult },
+        instructions: { nodes: instructionsResult },
       },
-    } = await context.queryMiddleware<Ensured<Query, 'instructionParties'>>(query);
+    } = await context.queryMiddleware<Ensured<Query, 'instructions'>>(query);
 
-    return instructionsResult.map(({ instruction }) =>
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      middlewareInstructionToHistoricInstruction(instruction!, context)
+    return instructionsResult.map(instruction =>
+      middlewareInstructionToHistoricInstruction(instruction, context)
     );
   }
 


### PR DESCRIPTION
### Description

- fixes issue where querying historical instructions would result in duplicate entries being returned

### Breaking Changes

- none

### JIRA Link

https://polymesh.atlassian.net/browse/DA-1446

