### PR TITLE
Move unreleased staking tx methods

### DIFF
--- a/src/api/client/__tests__/Staking.ts
+++ b/src/api/client/__tests__/Staking.ts
@@ -9,6 +9,7 @@ import { Account, Context } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { createMockBool, createMockU128 } from '~/testUtils/mocks/dataSources';
 import { Mocked } from '~/testUtils/types';
+import { PolymeshTransaction } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(
@@ -21,10 +22,10 @@ jest.mock(
 );
 
 describe('Staking Class', () => {
-  let context: Mocked<Context>;
+  let mockContext: Mocked<Context>;
   let staking: Staking;
 
-  let address: string;
+  let account: Account;
   let rawAddress: AccountId;
 
   let accountIdToStringSpy: jest.SpyInstance;
@@ -36,12 +37,14 @@ describe('Staking Class', () => {
   });
 
   beforeEach(() => {
-    context = dsMockUtils.getContextInstance();
+    mockContext = dsMockUtils.getContextInstance();
+    rawAddress = dsMockUtils.createMockAccountId();
 
-    staking = new Staking(context);
+    account = entityMockUtils.getAccountInstance();
+    staking = new Staking(mockContext);
     accountIdToStringSpy = jest.spyOn(utilsConversionModule, 'accountIdToString');
 
-    when(accountIdToStringSpy).calledWith(rawAddress).mockReturnValue(address);
+    when(accountIdToStringSpy).calledWith(rawAddress).mockReturnValue(account.address);
   });
 
   afterEach(() => {
@@ -53,6 +56,137 @@ describe('Staking Class', () => {
   afterAll(() => {
     dsMockUtils.cleanup();
     procedureMockUtils.cleanup();
+  });
+
+  describe('method: bond', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const amount = new BigNumber(3);
+
+      const args = {
+        payee: account,
+        controller: account,
+        rewardDestination: account,
+        autoStake: false,
+        amount,
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.bond(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: unbond', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const amount = new BigNumber(3);
+
+      const args = {
+        amount,
+        type: 'unbond',
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.unbond(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: bondExtra', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const amount = new BigNumber(3);
+
+      const args = {
+        amount,
+        type: 'bondExtra',
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.bondExtra(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: withdraw', () => {
+    it('should prepare the procedure with the correct context, and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args: undefined, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.withdraw();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: nominate', () => {
+    it('should prepare the procedure with the correct context, and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args: { validators: [] }, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.nominate({ validators: [] });
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: setController', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const args = {
+        controller: 'someAccount',
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.setController(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: setPayee', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const args = {
+        payee: 'someAccount',
+        autoStake: false,
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.setPayee(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
   });
 
   describe('method: getValidators', () => {

--- a/src/api/entities/Account/Staking/index.ts
+++ b/src/api/entities/Account/Staking/index.ts
@@ -2,31 +2,14 @@ import { Option } from '@polkadot/types';
 import { AccountId, RewardDestination } from '@polkadot/types/interfaces';
 import { PalletStakingNominations } from '@polkadot/types/lookup';
 
+import { Account, Namespace } from '~/internal';
 import {
-  Account,
-  bondPolyx,
-  Context,
-  Namespace,
-  nominateValidators,
-  setStakingController,
-  setStakingPayee,
-  updateBondedPolyx,
-  withdrawUnbondedPolyx,
-} from '~/internal';
-import {
-  BondPolyxParams,
-  NoArgsProcedureMethod,
-  NominateValidatorsParams,
-  ProcedureMethod,
-  SetStakingControllerParams,
-  SetStakingPayeeParams,
   StakingCommission,
   StakingLedger,
   StakingNomination,
   StakingPayee,
   SubCallback,
   UnsubCallback,
-  UpdatePolyxBondParams,
 } from '~/types';
 import {
   accountIdToString,
@@ -36,116 +19,11 @@ import {
   rewardDestinationToPayee,
   stringToAccountId,
 } from '~/utils/conversion';
-import { createProcedureMethod } from '~/utils/internal';
 
 /**
- * Handles all Staking related functionality
+ * Handles Account staking related functionality
  */
 export class Staking extends Namespace<Account> {
-  /**
-   * @hidden
-   */
-  constructor(parent: Account, context: Context) {
-    super(parent, context);
-
-    this.bond = createProcedureMethod(
-      {
-        getProcedureAndArgs: args => [bondPolyx, { ...args }],
-      },
-      context
-    );
-
-    this.unbond = createProcedureMethod(
-      {
-        getProcedureAndArgs: args => [updateBondedPolyx, { ...args, type: 'unbond' } as const],
-      },
-      context
-    );
-
-    this.bondExtra = createProcedureMethod(
-      {
-        getProcedureAndArgs: args => [updateBondedPolyx, { ...args, type: 'bondExtra' } as const],
-      },
-      context
-    );
-
-    this.withdraw = createProcedureMethod(
-      {
-        getProcedureAndArgs: () => [withdrawUnbondedPolyx, undefined],
-        voidArgs: true,
-      },
-      context
-    );
-
-    this.nominate = createProcedureMethod(
-      {
-        getProcedureAndArgs: args => [nominateValidators, { ...args } as const],
-      },
-      context
-    );
-
-    this.setController = createProcedureMethod(
-      {
-        getProcedureAndArgs: args => [setStakingController, args],
-      },
-      context
-    );
-
-    this.setPayee = createProcedureMethod(
-      {
-        getProcedureAndArgs: args => [setStakingPayee, args],
-      },
-      context
-    );
-  }
-
-  /**
-   * Bond POLYX for staking
-   *
-   * @note the signing account cannot be a stash
-   */
-  public bond: ProcedureMethod<BondPolyxParams, void>;
-
-  /**
-   * Bond extra POLYX for staking
-   *
-   * @note this transaction must be signed by a stash
-   */
-  public bondExtra: ProcedureMethod<UpdatePolyxBondParams, void>;
-
-  /**
-   * Unbond POLYX for staking. The unbonded amount can be withdrawn after the lockup period
-   */
-  public unbond: ProcedureMethod<UpdatePolyxBondParams, void>;
-
-  /**
-   * Withdraw unbonded POLYX to free it for the stash account
-   *
-   * @note this transaction must be signed by a controller
-   */
-  public withdraw: NoArgsProcedureMethod<void>;
-
-  /**
-   * Nominate validators for the bonded POLYX
-   *
-   * @note this transaction must be signed by a controller
-   */
-  public nominate: ProcedureMethod<NominateValidatorsParams, void>;
-
-  /**
-   * Allow for a stash account to update its controller
-   *
-   * @note the transaction must be signed by a stash account
-   */
-  public setController: ProcedureMethod<SetStakingControllerParams, void>;
-
-  /**
-   * Allow for a stash account to update where it's staking rewards are deposited
-   *
-   * @note the transaction must be signed by a controller account
-   */
-  public setPayee: ProcedureMethod<SetStakingPayeeParams, void>;
-
   /**
    * Fetch the ledger information for a stash account
    *

--- a/src/api/entities/Account/__tests__/Staking.ts
+++ b/src/api/entities/Account/__tests__/Staking.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
-import { Account, Context, Namespace, PolymeshTransaction } from '~/internal';
+import { Account, Context, Namespace } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import * as utilsConversionModule from '~/utils/conversion';
 
@@ -60,137 +60,6 @@ describe('Staking namespace', () => {
     accountIdToStringSpy = jest.spyOn(utilsConversionModule, 'accountIdToString');
 
     when(stringToAccountIdSpy).calledWith(account.address, mockContext).mockReturnValue(rawAddress);
-  });
-
-  describe('method: bond', () => {
-    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
-      const amount = new BigNumber(3);
-
-      const args = {
-        payee: account,
-        controller: account,
-        rewardDestination: account,
-        autoStake: false,
-        amount,
-      };
-
-      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
-
-      when(procedureMockUtils.getPrepareMock())
-        .calledWith({ args, transformer: undefined }, mockContext, {})
-        .mockResolvedValue(expectedTransaction);
-
-      const tx = await staking.bond(args);
-
-      expect(tx).toBe(expectedTransaction);
-    });
-  });
-
-  describe('method: unbond', () => {
-    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
-      const amount = new BigNumber(3);
-
-      const args = {
-        amount,
-        type: 'unbond',
-      };
-
-      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
-
-      when(procedureMockUtils.getPrepareMock())
-        .calledWith({ args, transformer: undefined }, mockContext, {})
-        .mockResolvedValue(expectedTransaction);
-
-      const tx = await staking.unbond(args);
-
-      expect(tx).toBe(expectedTransaction);
-    });
-  });
-
-  describe('method: bondExtra', () => {
-    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
-      const amount = new BigNumber(3);
-
-      const args = {
-        amount,
-        type: 'bondExtra',
-      };
-
-      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
-
-      when(procedureMockUtils.getPrepareMock())
-        .calledWith({ args, transformer: undefined }, mockContext, {})
-        .mockResolvedValue(expectedTransaction);
-
-      const tx = await staking.bondExtra(args);
-
-      expect(tx).toBe(expectedTransaction);
-    });
-  });
-
-  describe('method: withdraw', () => {
-    it('should prepare the procedure with the correct context, and return the resulting transaction', async () => {
-      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
-
-      when(procedureMockUtils.getPrepareMock())
-        .calledWith({ args: undefined, transformer: undefined }, mockContext, {})
-        .mockResolvedValue(expectedTransaction);
-
-      const tx = await staking.withdraw();
-
-      expect(tx).toBe(expectedTransaction);
-    });
-  });
-
-  describe('method: nominate', () => {
-    it('should prepare the procedure with the correct context, and return the resulting transaction', async () => {
-      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
-
-      when(procedureMockUtils.getPrepareMock())
-        .calledWith({ args: { validators: [] }, transformer: undefined }, mockContext, {})
-        .mockResolvedValue(expectedTransaction);
-
-      const tx = await staking.nominate({ validators: [] });
-
-      expect(tx).toBe(expectedTransaction);
-    });
-  });
-
-  describe('method: setController', () => {
-    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
-      const args = {
-        controller: 'someAccount',
-      };
-
-      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
-
-      when(procedureMockUtils.getPrepareMock())
-        .calledWith({ args, transformer: undefined }, mockContext, {})
-        .mockResolvedValue(expectedTransaction);
-
-      const tx = await staking.setController(args);
-
-      expect(tx).toBe(expectedTransaction);
-    });
-  });
-
-  describe('method: setPayee', () => {
-    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
-      const args = {
-        payee: 'someAccount',
-        autoStake: false,
-      };
-
-      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
-
-      when(procedureMockUtils.getPrepareMock())
-        .calledWith({ args, transformer: undefined }, mockContext, {})
-        .mockResolvedValue(expectedTransaction);
-
-      const tx = await staking.setPayee(args);
-
-      expect(tx).toBe(expectedTransaction);
-    });
   });
 
   describe('method: getLedger', () => {


### PR DESCRIPTION
### Description

remove staking methods from the `Account` namespace and attach them to the SDK staking namespace. `account.staking.bond` -> `sdk.staking.bond`. The signing account was always the acting account and the parent account was not relevant

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
