### PR TITLE
feat: 🎸 add field to expose unmatched permissions

### DIFF
--- a/src/api/entities/CustomPermissionGroup.ts
+++ b/src/api/entities/CustomPermissionGroup.ts
@@ -79,12 +79,14 @@ export class CustomPermissionGroup extends PermissionGroup {
 
     const rawGroupPermissions = await externalAgents.groupPermissions(rawAssetId, rawAgId);
 
-    const transactions = extrinsicPermissionsToTransactionPermissions(rawGroupPermissions.unwrap());
+    const { permissions } = extrinsicPermissionsToTransactionPermissions(
+      rawGroupPermissions.unwrap()
+    );
 
-    const transactionGroups = transactionPermissionsToTxGroups(transactions);
+    const transactionGroups = transactionPermissionsToTxGroups(permissions);
 
     return {
-      transactions,
+      transactions: permissions,
       transactionGroups,
     };
   }

--- a/src/api/entities/Identity/AssetPermissions.ts
+++ b/src/api/entities/Identity/AssetPermissions.ts
@@ -182,7 +182,7 @@ export class AssetPermissions extends Namespace<Identity> {
 
       const groupPermissionsOption = await externalAgents.groupPermissions(rawAssetId, groupId);
 
-      const permissions = extrinsicPermissionsToTransactionPermissions(
+      const { permissions } = extrinsicPermissionsToTransactionPermissions(
         groupPermissionsOption.unwrap()
       );
 

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -773,6 +773,7 @@ export interface CheckpointWithData {
 export interface PermissionedAccount {
   account: Account | MultiSig;
   permissions: Permissions;
+  unmatchedPermissions?: string[];
 }
 
 export type PortfolioLike =

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -983,3 +983,9 @@ export const TxTags = {
   stateTrieMigration: StateTrieMigrationTx,
   electionProviderMultiPhase: ElectionProviderMultiPhaseTx,
 };
+
+export const TX_TAG_VALUES: string[] = Object.values(TxTags)
+  .map(v => Object.values(v))
+  .flat();
+
+export const MODULE_NAMES: string[] = Object.values(ModuleName);

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -983,9 +983,3 @@ export const TxTags = {
   stateTrieMigration: StateTrieMigrationTx,
   electionProviderMultiPhase: ElectionProviderMultiPhaseTx,
 };
-
-export const TX_TAG_VALUES: string[] = Object.values(TxTags)
-  .map(v => Object.values(v))
-  .flat();
-
-export const MODULE_NAMES: string[] = Object.values(ModuleName);

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -1942,6 +1942,7 @@ describe('method: getSecondaryAccountPermissions', () => {
           transactions: null,
           transactionGroups: [],
         },
+        unmatchedPermissions: [],
       },
     ];
 
@@ -1956,10 +1957,13 @@ describe('method: getSecondaryAccountPermissions', () => {
     });
 
     meshPermissionsToPermissionsSpy.mockReturnValue({
-      assets: null,
-      portfolios: null,
-      transactions: null,
-      transactionGroups: [],
+      permissions: {
+        assets: null,
+        portfolios: null,
+        transactions: null,
+        transactionGroups: [],
+      },
+      unmatchedPermissions: [],
     });
     stringToAccountIdSpy.mockReturnValue(dsMockUtils.createMockAccountId(accountId));
   });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { coerce } from 'semver';
 
-import { TransactionArgumentType } from '~/types';
+import { ModuleName, TransactionArgumentType, TxTags } from '~/types';
 
 /**
  * Maximum amount of decimals for on-chain values
@@ -178,3 +178,7 @@ export const GLOBAL_TOKEN_URI_NAME = 'tokenUri';
 export const GLOBAL_BASE_TOKEN_URI_NAME = 'baseTokenUri';
 
 export const ASSET_ID_PREFIX = 'modlpy/pallet_asset';
+
+export const TX_TAG_VALUES: string[] = Object.values(TxTags).flatMap(v => Object.values(v));
+
+export const MODULE_NAMES: string[] = Object.values(ModuleName);

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -227,7 +227,6 @@ import {
   MetadataType,
   MetadataValue,
   MetadataValueDetails,
-  MODULE_NAMES,
   ModuleName,
   MultiClaimCondition,
   NftMetadataInput,
@@ -275,7 +274,6 @@ import {
   TransferRestrictionType,
   TransferStatus,
   TrustedClaimIssuer,
-  TX_TAG_VALUES,
   TxGroup,
   TxTag,
   TxTags,
@@ -308,6 +306,8 @@ import {
   MAX_MODULE_LENGTH,
   MAX_OFF_CHAIN_METADATA_LENGTH,
   MAX_TICKER_LENGTH,
+  MODULE_NAMES,
+  TX_TAG_VALUES,
 } from '~/utils/constants';
 import {
   asAccount,

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -1890,9 +1890,15 @@ export async function getSecondaryAccountPermissions(
     ): Promise<void> => {
       const rawIdentityId = record.asSecondaryKey;
       if (!identity || identityIdToString(rawIdentityId) === identity.did) {
+        const { permissions, unmatchedPermissions } = await meshPermissionsToPermissionsV2(
+          account,
+          context
+        );
+
         result.push({
           account,
-          permissions: await meshPermissionsToPermissionsV2(account, context),
+          permissions,
+          unmatchedPermissions,
         });
       }
     };


### PR DESCRIPTION
### Description

adds `unmatchedPermissions` for PermissionedAccount to return a list of permissions that the PermissionedAccount has but that are not present in SDK (wrong module name, incorrect extrinsic, or a combination)

### JIRA Link

https://polymesh.atlassian.net/browse/DA-1412
