### PR TITLE
fix: 🐛 allow payee to set auto stake for themselves

### DIFF
--- a/src/api/procedures/__tests__/setStakingPayee.ts
+++ b/src/api/procedures/__tests__/setStakingPayee.ts
@@ -102,6 +102,23 @@ describe('setStakingPayee procedure', () => {
     return expect(prepareSetStakingPayee.call(proc, args)).rejects.toThrow(expectedError);
   });
 
+  it('should allow the same payee if auto stake value differs', async () => {
+    currentPayee.account = entityMockUtils.getAccountInstance({ isEqual: true });
+
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      actingAccount,
+      currentPayee,
+      ledger,
+    });
+
+    const args = {
+      payee: newPayee,
+      autoStake: true,
+    };
+
+    return expect(prepareSetStakingPayee.call(proc, args)).resolves.not.toThrow();
+  });
+
   it('should return a setPayee transaction spec', async () => {
     const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
       actingAccount,

--- a/src/api/procedures/setStakingPayee.ts
+++ b/src/api/procedures/setStakingPayee.ts
@@ -36,7 +36,7 @@ export async function prepareSetStakingPayee(
 
   const payee = asAccount(payeeInput, context);
 
-  if (currentPayee.account.isEqual(payee)) {
+  if (currentPayee.autoStaked === autoStake && currentPayee.account.isEqual(payee)) {
     throw new PolymeshError({
       code: ErrorCode.NoDataChange,
       message: 'The given payee is already set',


### PR DESCRIPTION
### Description

consider autoStake when calculating NoDataChange error

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
