### PR TITLE
feat: 🎸 get permissions required for a procedure

### DIFF
--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -423,4 +423,14 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
 
     return context;
   }
+
+  /**
+   * Get the authorization data (permissions) required to run this procedure
+   *
+   * @param args - procedure arguments
+   * @returns authorization data containing required roles and permissions
+   */
+  public async requiredAuthorizations(args: Args): Promise<ProcedureAuthorization> {
+    return this.getAuthorization(args);
+  }
 }

--- a/src/base/__tests__/Procedure.ts
+++ b/src/base/__tests__/Procedure.ts
@@ -653,4 +653,37 @@ describe('Procedure class', () => {
       expect(() => proc.context).toThrow('Attempt to access context before it was set');
     });
   });
+
+  describe('method: requiredAuthorizations', () => {
+    it('should return the required authorizations for the Procedure', async () => {
+      const func = async function (
+        this: Procedure<typeof procArgs, string>
+      ): Promise<TransactionSpec<string, [string]>> {
+        return {
+          transaction: dsMockUtils.createTxMock('asset', 'registerUniqueTicker'),
+          args: [procArgs.ticker],
+          resolver: 'success',
+        };
+      };
+
+      const proc = new Procedure(func, {
+        roles: [{ type: 'FakeRole' } as unknown as Role],
+        permissions: {
+          transactions: [TxTags.asset.RegisterUniqueTicker],
+          assets: [],
+          portfolios: [],
+        },
+      });
+
+      const result = await proc.requiredAuthorizations(procArgs);
+      expect(result).toEqual({
+        roles: [{ type: 'FakeRole' }],
+        permissions: {
+          transactions: [TxTags.asset.RegisterUniqueTicker],
+          assets: [],
+          portfolios: [],
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description

adds a method on Procedure to be able to get required authorizations before executing the procedure

### JIRA Link

https://polymesh.atlassian.net/browse/DA-1409

