### PR TITLE
fix: add missing ResultSet interface to paginated queries

### DIFF
--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -337,6 +337,7 @@ export class Network {
   /**
    * Retrieve a list of events. Can be filtered using parameters
    *
+   * @deprecated
    * @param opts.moduleId - type of the module to fetch
    * @param opts.eventId - type of the event to fetch
    * @param opts.eventArg0 - event parameter value to filter by in position 0

--- a/src/api/client/__tests__/Settlements.ts
+++ b/src/api/client/__tests__/Settlements.ts
@@ -210,7 +210,11 @@ describe('Settlements Class', () => {
 
       const result = await settlements.getHistoricalInstructions({});
 
-      expect(result).toEqual([mockHistoricInstruction]);
+      expect(result).toEqual({
+        data: [mockHistoricInstruction],
+        next: new BigNumber(1),
+        count: new BigNumber(5),
+      });
     });
   });
 });

--- a/src/api/entities/Asset/NonFungible/AssetHolders/index.ts
+++ b/src/api/entities/Asset/NonFungible/AssetHolders/index.ts
@@ -46,6 +46,7 @@ export class AssetHolders extends Namespace<NftCollection> {
 
     return {
       data,
+      count: new BigNumber(totalCount),
       next,
     };
   }

--- a/src/api/entities/Asset/__tests__/NonFungible/AssetHolders.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/AssetHolders.ts
@@ -99,6 +99,7 @@ describe('AssetHolder class', () => {
           }),
         ]),
         next: null,
+        count: new BigNumber(2),
       });
     });
   });

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -1264,6 +1264,12 @@ describe('Identity class', () => {
   });
 
   describe('method: getHistoricalInstructions', () => {
+    let calculateNextSpy: jest.SpyInstance;
+
+    beforeAll(() => {
+      calculateNextSpy = jest.spyOn(utilsInternalModule, 'calculateNextKey');
+    });
+
     it('should return the list of all instructions where the Identity was involved', async () => {
       const identity = new Identity({ did: 'someDid' }, context);
       const middlewareInstructionToHistoricInstructionSpy = jest.spyOn(
@@ -1288,7 +1294,47 @@ describe('Identity class', () => {
 
       const result = await identity.getHistoricalInstructions();
 
-      expect(result).toEqual([mockHistoricInstruction]);
+      expect(result).toEqual({
+        data: [mockHistoricInstruction],
+        next: new BigNumber(1),
+        count: new BigNumber(5),
+      });
+      expect(calculateNextSpy).toHaveBeenCalledWith(new BigNumber(5), 1, undefined);
+    });
+
+    it('should return the list of all instructions where the Identity was involved when using pagination', async () => {
+      const identity = new Identity({ did: 'someDid' }, context);
+      const start = new BigNumber(0);
+
+      const middlewareInstructionToHistoricInstructionSpy = jest.spyOn(
+        utilsConversionModule,
+        'middlewareInstructionToHistoricInstruction'
+      );
+
+      calculateNextSpy = jest.spyOn(utilsInternalModule, 'calculateNextKey');
+      const instructionsResponse = {
+        totalCount: 5,
+        nodes: [{ id: '1' }],
+      };
+
+      const query = await historicalInstructionsQuery({ identity: identity.did }, context);
+
+      dsMockUtils.createApolloQueryMock(query, {
+        instructions: instructionsResponse,
+      });
+
+      const mockHistoricInstruction = 'mockData' as unknown as HistoricInstruction;
+
+      middlewareInstructionToHistoricInstructionSpy.mockReturnValue(mockHistoricInstruction);
+
+      const result = await identity.getHistoricalInstructions({ start });
+
+      expect(result).toEqual({
+        data: [mockHistoricInstruction],
+        next: new BigNumber(1),
+        count: new BigNumber(5),
+      });
+      expect(calculateNextSpy).toHaveBeenCalledWith(new BigNumber(5), 1, start);
     });
   });
 

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -923,20 +923,27 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    */
   public async getHistoricalInstructions(
     filter?: Omit<HistoricalInstructionFilters, 'identity'>
-  ): Promise<HistoricInstruction[]> {
+  ): Promise<ResultSet<HistoricInstruction>> {
     const { context, did } = this;
 
     const query = await historicalInstructionsQuery({ ...filter, identity: did }, context);
 
     const {
       data: {
-        instructions: { nodes: instructionsResult },
+        instructions: { nodes: instructionsResult, totalCount },
       },
     } = await context.queryMiddleware<Ensured<Query, 'instructions'>>(query);
 
-    return instructionsResult.map(instruction =>
-      middlewareInstructionToHistoricInstruction(instruction, context)
-    );
+    const count = new BigNumber(totalCount);
+    const next = calculateNextKey(count, instructionsResult.length, filter?.start);
+
+    return {
+      data: instructionsResult.map(instruction =>
+        middlewareInstructionToHistoricInstruction(instruction, context)
+      ),
+      next,
+      count,
+    };
   }
 
   /**

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -1288,6 +1288,7 @@ export class Context {
    * Retrieve POLYX transactions for a given identity or list of accounts
    *
    * @note uses the middleware V2
+   * @note supports pagination
    */
   public async getPolyxTransactions(args: {
     identity?: string | Identity;


### PR DESCRIPTION
### Description

- Adds missing ResultSet interface to paginated queries.
- marks Network.getEventsByIndexedArgs deprecated
- updates comment doc to indicate paginated method

### Breaking Changes

- changes data structure returned by Identity.getHistoricalInstuctions
- changes data structure returned by Settlements.getHistoricalInstuctions

### JIRA Link

https://polymesh.atlassian.net/browse/DA-1405

### Checklist

- [ ] Updated the Readme.md (if required) ?
