### PR TITLE
fix: 🐛 allow specify customClaimTypeId for TrustedClaimIssuer

### DIFF
--- a/src/api/entities/Asset/Fungible/TransferRestrictions/TransferRestrictionBase.ts
+++ b/src/api/entities/Asset/Fungible/TransferRestrictions/TransferRestrictionBase.ts
@@ -348,7 +348,15 @@ export abstract class TransferRestrictionBase<
       const claimType = meshClaimTypeToClaimType(rawClaimType);
       const issuer = new Identity({ did: identityIdToString(rawIssuer) }, context);
 
-      claims.push({ claimType, issuer });
+      if (typeof claimType === 'object') {
+        claims.push({
+          claimType: claimType.type,
+          customClaimTypeId: claimType.customClaimTypeId,
+          issuer,
+        });
+      } else {
+        claims.push({ claimType, issuer });
+      }
     };
 
     [...currentStats].forEach(stat => {

--- a/src/api/entities/Asset/Fungible/TransferRestrictions/__tests__/TransferRestrictionBase.ts
+++ b/src/api/entities/Asset/Fungible/TransferRestrictions/__tests__/TransferRestrictionBase.ts
@@ -695,6 +695,7 @@ describe('TransferRestrictionBase class', () => {
     let rawCountStatType: PolymeshPrimitivesStatisticsStatType;
     let rawPercentageStatType: PolymeshPrimitivesStatisticsStatType;
     let rawClaimCountStatType: PolymeshPrimitivesStatisticsStatType;
+    let rawCustomClaimCountStatType: PolymeshPrimitivesStatisticsStatType;
     let rawClaimPercentageStatType: PolymeshPrimitivesStatisticsStatType;
 
     let activeAssetStatsMock: jest.Mock;
@@ -718,6 +719,13 @@ describe('TransferRestrictionBase class', () => {
         operationType: dsMockUtils.createMockStatisticsOpType(StatType.Count),
         claimIssuer: dsMockUtils.createMockOption([
           dsMockUtils.createMockClaimType(ClaimType.Affiliate),
+          issuerDid,
+        ]),
+      });
+      rawCustomClaimCountStatType = dsMockUtils.createMockStatisticsStatType({
+        operationType: dsMockUtils.createMockStatisticsOpType(StatType.Count),
+        claimIssuer: dsMockUtils.createMockOption([
+          dsMockUtils.createMockClaimType(ClaimType.Custom, new BigNumber(1)),
           issuerDid,
         ]),
       });
@@ -790,7 +798,10 @@ describe('TransferRestrictionBase class', () => {
     });
 
     it('should return the active stats status for (ClaimCount) when stats enabled', async () => {
-      activeAssetStatsMock.mockResolvedValueOnce([rawClaimCountStatType]);
+      activeAssetStatsMock.mockResolvedValueOnce([
+        rawCustomClaimCountStatType,
+        rawClaimCountStatType,
+      ]);
       const claimCount = new ClaimCount(asset, context);
 
       const result = await claimCount.getStat();
@@ -798,7 +809,9 @@ describe('TransferRestrictionBase class', () => {
       expect(result.isSet).toBeTruthy();
       expect(result.claims).toBeDefined();
 
-      const [claim] = result.claims || [];
+      const [customClaim, claim] = result.claims || [];
+      expect(customClaim.claimType).toEqual(ClaimType.Custom);
+      expect(customClaim.customClaimTypeId).toEqual(new BigNumber(1));
       expect(claim.claimType).toEqual(ClaimType.Affiliate);
     });
 

--- a/src/api/entities/DefaultTrustedClaimIssuer.ts
+++ b/src/api/entities/DefaultTrustedClaimIssuer.ts
@@ -1,7 +1,7 @@
 import { Context, FungibleAsset, Identity, PolymeshError } from '~/internal';
 import { trustedClaimIssuerQuery } from '~/middleware/queries/claims';
 import { Query } from '~/middleware/types';
-import { ClaimType, ErrorCode, EventIdentifier } from '~/types';
+import { ErrorCode, EventIdentifier, TrustedFor } from '~/types';
 import { Ensured } from '~/types/utils';
 import {
   assetToMeshAssetId,
@@ -78,7 +78,7 @@ export class DefaultTrustedClaimIssuer extends Identity {
   /**
    * Retrieve claim types for which this Claim Issuer is trusted. A null value means that the issuer is trusted for all claim types
    */
-  public async trustedFor(): Promise<ClaimType[] | null> {
+  public async trustedFor(): Promise<TrustedFor[] | null> {
     const {
       context: {
         polymeshApi: {

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -306,6 +306,8 @@ export interface ClaimScope {
   assetId?: string;
 }
 
+export type TrustedFor = ClaimType | { type: ClaimType.Custom; customClaimTypeId: BigNumber };
+
 /**
  * @param IsDefault - whether the Identity is a default trusted claim issuer for an asset or just
  *   for a specific compliance condition. Defaults to false
@@ -315,7 +317,7 @@ export interface TrustedClaimIssuer<IsDefault extends boolean = false> {
   /**
    * a null value means that the issuer is trusted for all claim types
    */
-  trustedFor: ClaimType[] | null;
+  trustedFor: TrustedFor[] | null;
 }
 
 export type InputTrustedClaimIssuer = Modify<
@@ -833,5 +835,5 @@ export type PortfolioMovement = FungiblePortfolioMovement | NonFungiblePortfolio
 
 export type ActiveStats = {
   isSet: boolean;
-  claims?: { claimType: ClaimType; issuer: Identity }[];
+  claims?: { claimType: ClaimType; customClaimTypeId?: BigNumber; issuer: Identity }[];
 };

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -2912,7 +2912,8 @@ export const createMockConditionType = (
  * NOTE: `isEmpty` will be set to true if no value is passed
  */
 export const createMockClaimType = (
-  claimType?: ClaimType
+  claimType?: ClaimType,
+  customClaimTypeId?: BigNumber
 ): MockCodec<PolymeshPrimitivesIdentityClaimClaimType> => {
   const claimIndexes = {
     Accredited: 1,
@@ -2928,6 +2929,13 @@ export const createMockClaimType = (
     InvestorUniquenessV2: 11,
     Custom: 12,
   };
+
+  if (claimType === ClaimType.Custom) {
+    return createMockEnum<PolymeshPrimitivesIdentityClaimClaimType>({
+      Custom: createMockU32(customClaimTypeId ?? new BigNumber(0)),
+    });
+  }
+
   return createMockEnum<PolymeshPrimitivesIdentityClaimClaimType>(
     claimType,
     claimType ? claimIndexes[claimType] : 0


### PR DESCRIPTION
### Description

- allows specifying customClaimTypeId when adding/modifying TrustedClaimIssuer for an Asset

### Breaking Changes

- return of `asset.compliance.trustedClaimIssuers.get()` will be an object in case of CustomClaim of shape { type: ClaimType.Custom, customClaimTypeId: BigNumber } 

### JIRA Link

https://polymesh.atlassian.net/browse/DA-1463

