### PR TITLE
feat: 🎸 Add optional skip checks for procedures and on getting asset

### DIFF
--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -269,17 +269,28 @@ export class Assets {
   /**
    * Retrieve a FungibleAsset
    *
+   * @param args.assetId - Unique Id of the Fungible Asset (for spec version 6.x, this is same as ticker)
    * @param args.ticker - Asset ticker
-   * @param args.assetId - Unique Id of the Asset (for spec version 6.x, this is same as ticker)
+   * @param args.skipExistsCheck - when true, method will not check if the Asset exists
    */
-  public async getFungibleAsset(args: { assetId: string }): Promise<FungibleAsset>;
-  public async getFungibleAsset(args: { ticker: string }): Promise<FungibleAsset>;
+  public async getFungibleAsset(args: {
+    assetId: string;
+    skipExistsCheck?: boolean;
+  }): Promise<FungibleAsset>;
+
+  // eslint-disable-next-line require-jsdoc
+  public async getFungibleAsset(args: {
+    ticker: string;
+    skipExistsCheck?: boolean;
+  }): Promise<FungibleAsset>;
+
   // eslint-disable-next-line require-jsdoc
   public async getFungibleAsset(args: {
     ticker?: string;
     assetId?: string;
+    skipExistsCheck?: boolean;
   }): Promise<FungibleAsset> {
-    const { ticker, assetId } = args;
+    const { ticker, assetId, skipExistsCheck = false } = args;
 
     const { context } = this;
 
@@ -287,13 +298,17 @@ export class Assets {
 
     const asset = new FungibleAsset({ assetId: assetIdValue }, context);
 
-    const exists = await asset.exists();
+    if (!skipExistsCheck) {
+      const exists = await asset.exists();
 
-    if (!exists) {
-      throw new PolymeshError({
-        code: ErrorCode.DataUnavailable,
-        message: `There is no Asset with ${ticker ? 'ticker' : 'asset ID'} "${ticker ?? assetId}"`,
-      });
+      if (!exists) {
+        throw new PolymeshError({
+          code: ErrorCode.DataUnavailable,
+          message: `There is no Asset with ${ticker ? 'ticker' : 'asset ID'} "${
+            ticker ?? assetId
+          }"`,
+        });
+      }
     }
 
     return asset;
@@ -302,17 +317,28 @@ export class Assets {
   /**
    * Retrieve an NftCollection
    *
+   * @param args.assetId - Unique Id of the NftCollection (for spec version 6.x, this is same as ticker)
    * @param args.ticker - NftCollection ticker
+   * @param args.skipExistsCheck - when true, method will not check if the NftCollection exists
    */
-  public async getNftCollection(args: { ticker: string }): Promise<NftCollection>;
-  public async getNftCollection(args: { assetId: string }): Promise<NftCollection>;
+  public async getNftCollection(args: {
+    ticker: string;
+    skipExistsCheck?: boolean;
+  }): Promise<NftCollection>;
+
+  // eslint-disable-next-line require-jsdoc
+  public async getNftCollection(args: {
+    assetId: string;
+    skipExistsCheck?: boolean;
+  }): Promise<NftCollection>;
 
   // eslint-disable-next-line require-jsdoc
   public async getNftCollection(args: {
     ticker?: string;
     assetId?: string;
+    skipExistsCheck?: boolean;
   }): Promise<NftCollection> {
-    const { ticker, assetId } = args;
+    const { ticker, assetId, skipExistsCheck = false } = args;
 
     const { context } = this;
 
@@ -320,15 +346,17 @@ export class Assets {
 
     const collection = new NftCollection({ assetId: assetIdValue }, context);
 
-    const exists = await collection.exists();
+    if (!skipExistsCheck) {
+      const exists = await collection.exists();
 
-    if (!exists) {
-      throw new PolymeshError({
-        code: ErrorCode.DataUnavailable,
-        message: `There is no NftCollection with ${ticker ? 'ticker' : 'asset ID'} "${
-          ticker ?? assetId
-        }"`,
-      });
+      if (!exists) {
+        throw new PolymeshError({
+          code: ErrorCode.DataUnavailable,
+          message: `There is no NftCollection with ${ticker ? 'ticker' : 'asset ID'} "${
+            ticker ?? assetId
+          }"`,
+        });
+      }
     }
 
     return collection;

--- a/src/api/client/__tests__/Assets.ts
+++ b/src/api/client/__tests__/Assets.ts
@@ -435,6 +435,11 @@ describe('Assets Class', () => {
       const asset = await assets.getFungibleAsset({ assetId });
 
       expect(asset.id).toEqual(hexToUuid(assetId));
+
+      entityMockUtils.configureMocks({ fungibleAssetOptions: { exists: false } });
+      const asset2 = await assets.getFungibleAsset({ assetId, skipExistsCheck: true });
+      expect(asset2.id).toEqual(hexToUuid(assetId));
+      expect(asset2.exists).not.toHaveBeenCalled();
     });
 
     it('should return a specific Asset for a ticker', async () => {
@@ -442,6 +447,11 @@ describe('Assets Class', () => {
 
       const asset = await assets.getFungibleAsset({ ticker });
       expect(asset.id).toBe(assetId);
+
+      entityMockUtils.configureMocks({ fungibleAssetOptions: { exists: false } });
+      const asset2 = await assets.getFungibleAsset({ ticker, skipExistsCheck: true });
+      expect(asset2.id).toEqual(assetId);
+      expect(asset2.exists).not.toHaveBeenCalled();
     });
 
     it('should throw if the Asset does not exist', async () => {
@@ -465,6 +475,11 @@ describe('Assets Class', () => {
     it('should return the collection for a specific asset ID', async () => {
       const nftCollection = await assets.getNftCollection({ assetId });
       expect(nftCollection.id).toEqual(hexToUuid(assetId));
+
+      entityMockUtils.configureMocks({ nftCollectionOptions: { exists: false } });
+      const nftCollection2 = await assets.getNftCollection({ assetId, skipExistsCheck: true });
+      expect(nftCollection2.id).toEqual(hexToUuid(assetId));
+      expect(nftCollection2.exists).not.toHaveBeenCalled();
     });
 
     it('should return the collection for a specific ticker', async () => {
@@ -472,6 +487,11 @@ describe('Assets Class', () => {
 
       const nftCollection = await assets.getNftCollection({ ticker });
       expect(nftCollection.id).toEqual(hexToUuid(assetId));
+
+      entityMockUtils.configureMocks({ nftCollectionOptions: { exists: false } });
+      const nftCollection2 = await assets.getNftCollection({ ticker, skipExistsCheck: true });
+      expect(nftCollection2.id).toEqual(hexToUuid(assetId));
+      expect(nftCollection2.exists).not.toHaveBeenCalled();
     });
 
     it('should throw if the collection does not exist', async () => {

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -87,6 +87,29 @@ export interface ProcedureAuthorizationStatus {
   noIdentity: boolean;
 }
 
+export interface SkipChecksOpt {
+  /**
+   * whether to skip the roles check
+   */
+  roles?: boolean;
+  /**
+   * whether to skip the signer permissions check
+   */
+  signerPermissions?: boolean;
+  /**
+   * whether to skip the agent permissions check
+   */
+  agentPermissions?: boolean;
+  /**
+   * whether to skip the account frozen check
+   */
+  accountFrozen?: boolean;
+  /**
+   * whether to skip the identity check (i.e. whether the signing Account has an associated Identity)
+   */
+  identity?: boolean;
+}
+
 export interface ProcedureOpts {
   /**
    * Account or address of a signing key to replace the current one (for this procedure only)
@@ -113,6 +136,15 @@ export interface ProcedureOpts {
    * These options will only apply when the `signingAccount` is a MultiSig signer and the transaction is being wrapped as a proposal
    */
   multiSigOpts?: MultiSigProcedureOpt;
+
+  /**
+   * This option allows for skipping checks for the Procedure. By default, all checks are performed.
+   *
+   * This can be useful while batching transactions which could have failed due to insufficient roles or permissions individually, but you don't want to fail the entire batch.
+   *
+   * @note even if the checks are skipped from being validated on the SDK, they will still be validated on the chain
+   */
+  skipChecks?: SkipChecksOpt;
 }
 
 /**

--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -348,7 +348,7 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
       // parallelize the async calls
       const prepareTransactionsPromise = defusePromise(this.prepareTransactions(procArgs));
       const { roles, signerPermissions, agentPermissions, accountFrozen, noIdentity } =
-        await this._checkAuthorization(procArgs, ctx);
+        await this._checkAuthorization(procArgs, ctx, opts);
 
       if (noIdentity) {
         throw new PolymeshError({


### PR DESCRIPTION
### Description

* Adds in optional `skipExistsCheck` to methods of Assets class to get fungible and non-fungible asset
* Adds optional `skipChecks` to `ProcedureOpts` to allow skipping of various checks at procedure level

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

DA-1465

### Checklist

- [ ] Updated the Readme.md (if required) ?
