### PR TITLE
feat: 🎸 add option to avoid checking if stat is enabled

### DIFF
--- a/src/api/procedures/__tests__/addTransferRestriction.ts
+++ b/src/api/procedures/__tests__/addTransferRestriction.ts
@@ -548,6 +548,22 @@ describe('addTransferRestriction procedure', () => {
     );
   });
 
+  it('should not throw an error if the appropriate stat is not set but skipStatIsEnabledCheck was set to true', () => {
+    statCompareEqMock.mockReturnValue(false);
+    const proc = procedureMockUtils.getInstance<AddTransferRestrictionParams, BigNumber>(
+      mockContext
+    );
+
+    args = {
+      ...args,
+      skipStatIsEnabledCheck: true,
+    };
+
+    transferConditionsToBtreeTransferConditionsSpy.mockReturnValue(mockCountBtreeSet);
+
+    return expect(prepareAddTransferRestriction.call(proc, args)).resolves.not.toThrow();
+  });
+
   describe('getAuthorization', () => {
     it('should return the appropriate roles and permissions', () => {
       args = {

--- a/src/api/procedures/addTransferRestriction.ts
+++ b/src/api/procedures/addTransferRestriction.ts
@@ -77,12 +77,13 @@ export async function prepareAddTransferRestriction(
     [statisticsQuery.assetTransferCompliances, rawAssetId],
   ]);
 
-  const neededStat = neededStatTypeForRestrictionInput({ type, claimIssuer }, context);
-  assertStatIsSet(currentStats, neededStat);
+  if (!args.skipStatIsEnabledCheck) {
+    const neededStat = neededStatTypeForRestrictionInput({ type, claimIssuer }, context);
+    assertStatIsSet(currentStats, neededStat);
+  }
+
   const maxConditions = u32ToBigNumber(consts.statistics.maxTransferConditionsPerAsset);
-
   const restrictionAmount = new BigNumber(currentRestrictions.size);
-
   if (restrictionAmount.gte(maxConditions)) {
     throw new PolymeshError({
       code: ErrorCode.LimitExceeded,

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -529,6 +529,10 @@ interface TransferRestrictionInputBase {
    * array of Identities (or DIDs) that are exempted from the Restriction
    */
   exemptedIdentities?: (Identity | string)[];
+  /**
+   * (optional) Set to `true` to skip stat is enabled check, useful for batch transactions
+   */
+  skipStatIsEnabledCheck?: boolean;
 }
 
 export interface CountTransferRestrictionInput extends TransferRestrictionInputBase {


### PR DESCRIPTION
### Description

Adds an optional argument to skip checking if stat is enabled when adding a TransferRestriction to make it possible to batch these kind of transactions

### Breaking Changes

NA

### JIRA Link

DA-1496

### Checklist

- [x] Updated the Readme.md (if required) ?
