### PR TITLE
fix: 🐛 Correct validation for NFT collection ownership transfer

### DIFF
--- a/src/api/procedures/__tests__/consumeAuthorizationRequests.ts
+++ b/src/api/procedures/__tests__/consumeAuthorizationRequests.ts
@@ -12,11 +12,19 @@ import { Account, AuthorizationRequest, Context, Identity } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import { Authorization, AuthorizationType, SignerValue, TxTags } from '~/types';
+import { hexToUuid } from '~/utils';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(
   '~/api/entities/Asset/Fungible',
   require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+
+jest.mock(
+  '~/api/entities/Asset/NonFungible/NftCollection',
+  require('~/testUtils/mocks/entities').mockNftCollectionModule(
+    '~/api/entities/Asset/NonFungible/NftCollection'
+  )
 );
 
 jest.mock(
@@ -84,7 +92,7 @@ describe('consumeAuthorizationRequests procedure', () => {
         issuer: entityMockUtils.getIdentityInstance({ did: 'issuerDid1' }),
         data: {
           type: AuthorizationType.TransferAssetOwnership,
-          value: '0x12347',
+          value: hexToUuid('0x12341234123412341234123412341234'),
         },
       },
       {
@@ -124,7 +132,7 @@ describe('consumeAuthorizationRequests procedure', () => {
         issuer: entityMockUtils.getIdentityInstance({ did: 'issuerDid7' }),
         data: {
           type: AuthorizationType.TransferAssetOwnership,
-          value: '0x12347',
+          value: hexToUuid('0x12341234123412341234123412341234'),
         },
       },
     ];

--- a/src/api/procedures/utils.ts
+++ b/src/api/procedures/utils.ts
@@ -11,7 +11,6 @@ import {
   CheckpointSchedule,
   Context,
   CustomPermissionGroup,
-  FungibleAsset,
   Identity,
   Instruction,
   KnownPermissionGroup,
@@ -43,7 +42,7 @@ import {
   TxTag,
 } from '~/types';
 import { assetIdToString, u32ToBigNumber, u64ToBigNumber } from '~/utils/conversion';
-import { asIdentity, filterEventRecords } from '~/utils/internal';
+import { asAsset, asIdentity, filterEventRecords } from '~/utils/internal';
 
 /**
  * @hidden
@@ -413,24 +412,6 @@ export async function assertTransferTickerAuthorizationValid(
 /**
  * @hidden
  *
- * Asserts valid transfer asset ownership authorization
- */
-export async function assertTransferAssetOwnershipAuthorizationValid(
-  data: GenericAuthorizationData,
-  context: Context
-): Promise<void> {
-  const asset = new FungibleAsset({ assetId: data.value }, context);
-  const exists = await asset.exists();
-  if (!exists)
-    throw new PolymeshError({
-      code: ErrorCode.UnmetPrerequisite,
-      message: 'The Asset does not exist',
-    });
-}
-
-/**
- * @hidden
- *
  * Asserts valid add multisig signer authorization
  */
 export async function assertMultiSigSignerAuthorizationValid(
@@ -603,7 +584,8 @@ export async function assertAuthorizationRequestValid(
     case AuthorizationType.TransferTicker:
       return assertTransferTickerAuthorizationValid(data, context);
     case AuthorizationType.TransferAssetOwnership:
-      return assertTransferAssetOwnershipAuthorizationValid(data, context);
+      await asAsset(data.value, context);
+      return;
     case AuthorizationType.BecomeAgent:
       // no additional checks
       return;


### PR DESCRIPTION
### Description

`assertTransferAssetOwnershipAuthorizationValid` function creates a `new FungibleAsset` even when the actual asset is a NFT collection. As a result when `exists` is called it fails as the fungible asset exists method requires the collection ID to be zero.

This fixes the logic to check asset ID to be either of Fungible Asset or NFT collection

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

DA-1502

### Checklist

- [ ] Updated the Readme.md (if required) ?
