### PR TITLE
chore: 🤖 use spec version to update README for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Polymesh version
 
-This release is compatible with Polymesh v7
+This release is compatible with Polymesh v7.0, v7.1, v7.2
 
 ## Getting Started
 

--- a/scripts/updateReadme.js
+++ b/scripts/updateReadme.js
@@ -10,7 +10,7 @@ const getSupportedNodeVersion = () => {
     encoding: 'utf8',
   });
 
-  const regex = /export const SUPPORTED_NODE_VERSION_RANGE = '([^']+)';/g;
+  const regex = /export const SUPPORTED_SPEC_VERSION_RANGE = '([^']+)';/g;
 
   const match = regex.exec(constantsFile);
 


### PR DESCRIPTION
### Description

`SUPPORTED_NODE_VERSION_RANGE` is no longer supported by SDK and was used in `updateReadme.js` to populate supported versions in *README.md* file. This PR replaces the constant with `SUPPORTED_SPEC_VERSION_RANGE` and correctly updates the *README.md* file as well

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

DA-1507

### Checklist

- [ ] Updated the Readme.md (if required) ?
