### PR TITLE
feat: 🎸 allow multiSig signer to remove payer

### DIFF
--- a/src/api/procedures/__tests__/removeMultiSigPayer.ts
+++ b/src/api/procedures/__tests__/removeMultiSigPayer.ts
@@ -150,7 +150,7 @@ describe('removeMultiSigPayer procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return RemovePayer transaction when removing via signer', () => {
+    it('should require no transaction permissions when removing via signer', () => {
       const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
         currentPayer,
         signingIdentity,
@@ -160,7 +160,7 @@ describe('removeMultiSigPayer procedure', () => {
 
       expect(boundFunc()).toEqual({
         permissions: {
-          transactions: [TxTags.multiSig.RemovePayer],
+          transactions: [],
         },
       });
     });

--- a/src/api/procedures/removeMultiSigPayer.ts
+++ b/src/api/procedures/removeMultiSigPayer.ts
@@ -102,9 +102,7 @@ export function getAuthorization(this: Procedure<Params, void, Storage>): Proced
   } = this;
   const transactions = [];
 
-  if (isMultiSigSigner) {
-    transactions.push(TxTags.multiSig.RemovePayer);
-  } else {
+  if (!isMultiSigSigner) {
     transactions.push(TxTags.multiSig.RemovePayerViaPayer);
   }
 


### PR DESCRIPTION
### Description

we have already the required functionality to support subsidizing MultiSig

to remove Payer via MultiSig signer we need not to check for TX permissions as in Procedure the account for which the Permissions are checked gets converted to MultiSig (not the Signer) thus resulting in getting the permissions for MultiSig which might not have (most likely) specified the RemovePayer permissions, chain does not require them and without this check the transaction executes


### JIRA Link

https://polymesh.atlassian.net/browse/DA-1529

