### PR TITLE
refactor: 💡 modify getValues to check all paths

### DIFF
--- a/src/api/entities/Asset/Fungible/TransferRestrictions/index.ts
+++ b/src/api/entities/Asset/Fungible/TransferRestrictions/index.ts
@@ -1,3 +1,9 @@
+import {
+  PolymeshPrimitivesStatisticsStat1stKey,
+  PolymeshPrimitivesStatisticsStat2ndKey,
+} from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
+
 import { setTransferRestrictionsExemptions } from '~/api/procedures/setTransferRestrictionExemptions';
 import {
   Context,
@@ -11,22 +17,34 @@ import {
   setTransferRestrictions,
 } from '~/internal';
 import {
+  AccreditedValue,
   ActiveTransferRestrictions,
+  AffiliateValue,
   AssetStat,
+  ClaimType,
+  CountryCode,
+  JurisdictionValue,
   ProcedureMethod,
   SetTransferRestrictionStatParams,
+  StatType,
   TransferRestrictionExemption,
   TransferRestrictionExemptionParams,
   TransferRestrictionParams,
+  TransferRestrictionStatValues,
 } from '~/types';
 import {
   assetComplianceToTransferRestrictions,
   assetStatToStat,
+  assetToMeshAssetId,
   exemptionToTransferExemption,
+  getStat1stKey,
+  getStat2ndKey,
   identityIdToString,
+  meshStatToStatType,
   stringToAssetId,
+  u128ToBigNumber,
 } from '~/utils/conversion';
-import { createProcedureMethod } from '~/utils/internal';
+import { createProcedureMethod, requestMulti } from '~/utils/internal';
 
 /**
  * Handles all Transfer Restriction related functionality
@@ -143,6 +161,213 @@ export class TransferRestrictions extends Namespace<FungibleAsset> {
     const stats = [...rawStats].map(stat => assetStatToStat(stat));
 
     return stats;
+  }
+
+  /**
+   * Get the values of all active transfer restrictions for this Asset
+   * @returns an array of objects containing the values of all active transfer restrictions for this Asset
+   */
+  public async getValues(): Promise<TransferRestrictionStatValues[]> {
+    const {
+      parent,
+      context,
+      context: {
+        polymeshApi: {
+          query: { statistics },
+        },
+      },
+    } = this;
+
+    const rawAssetId = assetToMeshAssetId(parent, context);
+    const activeStats = await statistics.activeAssetStats(rawAssetId);
+
+    const queries: [
+      typeof statistics.assetStats,
+      [PolymeshPrimitivesStatisticsStat1stKey, PolymeshPrimitivesStatisticsStat2ndKey]
+    ][] = [];
+
+    const stats: {
+      type: StatType;
+      issuer?: Identity;
+      claimType?: ClaimType.Accredited | ClaimType.Affiliate | ClaimType.Jurisdiction;
+      claimValue?: boolean | CountryCode | null;
+    }[] = [];
+
+    const result: TransferRestrictionStatValues[] = [];
+
+    activeStats.forEach(stat => {
+      const stat1stKey = getStat1stKey(rawAssetId, stat, context);
+      const statType = meshStatToStatType(stat);
+
+      if (stat.claimIssuer.isSome) {
+        const [rawClaimClaimType, rawIssuer] = stat.claimIssuer.unwrap();
+        const issuer = new Identity({ did: identityIdToString(rawIssuer) }, context);
+
+        const { type } = rawClaimClaimType;
+
+        if (type === ClaimType.Accredited || type === ClaimType.Affiliate) {
+          const claimType = type as ClaimType.Accredited | ClaimType.Affiliate;
+
+          result.push({
+            type: statType,
+            value: new BigNumber(0),
+            claim: {
+              issuer,
+              claimType,
+              value:
+                claimType === ClaimType.Accredited
+                  ? { accredited: new BigNumber(0), nonAccredited: new BigNumber(0) }
+                  : { affiliate: new BigNumber(0), nonAffiliate: new BigNumber(0) },
+            },
+          });
+
+          stats.push({
+            type: statType,
+            issuer,
+            claimType,
+            claimValue: true,
+          });
+          stats.push({
+            type: statType,
+            issuer,
+            claimType,
+            claimValue: false,
+          });
+
+          queries.push([
+            statistics.assetStats,
+            [stat1stKey, getStat2ndKey(context, claimType, true)],
+          ]);
+          queries.push([
+            statistics.assetStats,
+            [stat1stKey, getStat2ndKey(context, claimType, false)],
+          ]);
+        } else if (type === ClaimType.Jurisdiction) {
+          result.push({
+            type: statType,
+            value: new BigNumber(0),
+            claim: {
+              issuer,
+              claimType: ClaimType.Jurisdiction,
+              value: [],
+            },
+          });
+
+          const countryCodes = Object.values(CountryCode);
+
+          countryCodes.forEach(countryCode => {
+            stats.push({
+              type: statType,
+              issuer,
+              claimType: ClaimType.Jurisdiction,
+              claimValue: countryCode,
+            });
+          });
+
+          stats.push({
+            type: statType,
+            issuer,
+            claimType: ClaimType.Jurisdiction,
+            claimValue: null,
+          });
+
+          countryCodes.forEach(countryCode => {
+            queries.push([
+              statistics.assetStats,
+              [stat1stKey, getStat2ndKey(context, ClaimType.Jurisdiction, countryCode)],
+            ]);
+          });
+
+          queries.push([
+            statistics.assetStats,
+            [stat1stKey, getStat2ndKey(context, ClaimType.Jurisdiction)],
+          ]);
+        }
+      } else {
+        stats.push({
+          type: statType,
+        });
+
+        queries.push([statistics.assetStats, [stat1stKey, getStat2ndKey(context)]]);
+
+        result.push({
+          type: statType,
+          value: new BigNumber(0),
+        });
+      }
+    });
+
+    const values = await requestMulti(context, queries);
+
+    const statsWithValue = stats
+      .map((stat, index) => {
+        return {
+          ...stat,
+          value:
+            stat.type === StatType.Count || stat.type === StatType.ScopedCount
+              ? u128ToBigNumber(values[index])
+              : u128ToBigNumber(values[index]).shiftedBy(-6),
+        };
+      })
+      .filter(stat => stat.value.gt(0));
+
+    const isClaimStat = (
+      stat: TransferRestrictionStatValues
+    ): stat is TransferRestrictionStatValues & {
+      claim: {
+        issuer: Identity;
+        claimType: ClaimType.Accredited | ClaimType.Affiliate | ClaimType.Jurisdiction;
+        value: AccreditedValue | AffiliateValue | JurisdictionValue[];
+      };
+    } => {
+      return stat.claim !== undefined;
+    };
+
+    statsWithValue.forEach(stat => {
+      const { claimType, issuer, claimValue } = stat;
+
+      if (claimType && issuer) {
+        const statResult = result
+          .filter(isClaimStat)
+          .find(
+            resultStat =>
+              resultStat.type === stat.type &&
+              resultStat.claim.issuer.did === issuer.did &&
+              resultStat.claim.claimType === claimType
+          );
+
+        statResult!.value = statResult!.value.plus(stat.value);
+
+        if (claimType === ClaimType.Jurisdiction) {
+          (statResult!.claim!.value as JurisdictionValue[]).push({
+            countryCode: stat.claimValue as CountryCode | null,
+            count: stat.value,
+          });
+        } else if (claimType === ClaimType.Accredited) {
+          const value = statResult!.claim!.value as AccreditedValue;
+          if (claimValue === true) {
+            value.accredited = value.accredited.plus(stat.value);
+          } else {
+            value.nonAccredited = value.nonAccredited.plus(stat.value);
+          }
+        } else if (claimType === ClaimType.Affiliate) {
+          const value = statResult!.claim!.value as AffiliateValue;
+          if (claimValue === true) {
+            value.affiliate = value.affiliate.plus(stat.value);
+          } else {
+            value.nonAffiliate = value.nonAffiliate.plus(stat.value);
+          }
+        }
+      } else {
+        const statResult = result
+          .filter(resultStat => !isClaimStat(resultStat))
+          .find(resultStat => resultStat.type === stat.type);
+
+        statResult!.value = statResult!.value.plus(stat.value);
+      }
+    });
+
+    return result;
   }
 
   /**

--- a/src/api/entities/Asset/__tests__/Fungible/TransferRestrictions.ts
+++ b/src/api/entities/Asset/__tests__/Fungible/TransferRestrictions.ts
@@ -1,3 +1,11 @@
+import { u128 } from '@polkadot/types';
+import {
+  PolymeshPrimitivesAssetAssetId,
+  PolymeshPrimitivesIdentityId,
+  PolymeshPrimitivesStatisticsStat1stKey,
+  PolymeshPrimitivesStatisticsStat2ndKey,
+  PolymeshPrimitivesStatisticsStatType,
+} from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -5,8 +13,9 @@ import { TransferRestrictions } from '~/api/entities/Asset/Fungible/TransferRest
 import { Context, FungibleAsset, Namespace, PolymeshTransaction } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { createMockAssetId, createMockStatisticsOpType } from '~/testUtils/mocks/dataSources';
-import { ClaimType, StatType, TransferRestrictionType } from '~/types';
+import { ClaimType, CountryCode, StatType, TransferRestrictionType } from '~/types';
 import { tuple } from '~/types/utils';
+import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(
   '~/base/Procedure',
@@ -279,6 +288,231 @@ describe('TransferRestrictions class', () => {
           identity: expect.objectContaining({ did: 'someDid' }),
         },
       ]);
+    });
+  });
+
+  describe('getValues', () => {
+    const assetId = '12341234-1234-1234-1234-123412341234';
+    let rawAssetId: PolymeshPrimitivesAssetAssetId;
+
+    let rawCountStatType: PolymeshPrimitivesStatisticsStatType;
+    let rawPercentageStatType: PolymeshPrimitivesStatisticsStatType;
+    let rawClaimCountStatType: PolymeshPrimitivesStatisticsStatType;
+    let rawJurisdictionStatType: PolymeshPrimitivesStatisticsStatType;
+    let rawClaimPercentageStatType: PolymeshPrimitivesStatisticsStatType;
+    let issuerDid: PolymeshPrimitivesIdentityId;
+
+    let stat1stKey: PolymeshPrimitivesStatisticsStat1stKey;
+    let stat2ndKey: PolymeshPrimitivesStatisticsStat2ndKey;
+    let rawValue: u128;
+    let value: BigNumber;
+
+    let meshStatToStatTypeSpy: jest.SpyInstance;
+    let assetToMeshAssetIdSpy: jest.SpyInstance;
+    let u128ToBigNumberSpy: jest.SpyInstance;
+    let queryMultiMock: jest.Mock;
+    let getStat1stKeySpy: jest.SpyInstance;
+    let getStat2ndKeySpy: jest.SpyInstance;
+
+    beforeAll(() => {
+      entityMockUtils.initMocks();
+      dsMockUtils.initMocks();
+      procedureMockUtils.initMocks();
+
+      assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
+      meshStatToStatTypeSpy = jest.spyOn(utilsConversionModule, 'meshStatToStatType');
+      u128ToBigNumberSpy = jest.spyOn(utilsConversionModule, 'u128ToBigNumber');
+      getStat1stKeySpy = jest.spyOn(utilsConversionModule, 'getStat1stKey');
+      getStat2ndKeySpy = jest.spyOn(utilsConversionModule, 'getStat2ndKey');
+    });
+
+    afterEach(() => {
+      dsMockUtils.reset();
+      entityMockUtils.reset();
+      procedureMockUtils.reset();
+      jest.restoreAllMocks();
+    });
+
+    beforeEach(() => {
+      context = dsMockUtils.getContextInstance();
+
+      rawAssetId = dsMockUtils.createMockAssetId(assetId);
+      asset = new FungibleAsset({ assetId }, context);
+      value = new BigNumber(10);
+      rawValue = dsMockUtils.createMockU128(value);
+
+      issuerDid = dsMockUtils.createMockIdentityId();
+
+      rawCountStatType = dsMockUtils.createMockStatisticsStatType({
+        operationType: dsMockUtils.createMockStatisticsOpType(StatType.Count),
+        claimIssuer: dsMockUtils.createMockOption(),
+      });
+      rawPercentageStatType = dsMockUtils.createMockStatisticsStatType({
+        operationType: dsMockUtils.createMockStatisticsOpType(StatType.Balance),
+        claimIssuer: dsMockUtils.createMockOption(),
+      });
+      rawClaimCountStatType = dsMockUtils.createMockStatisticsStatType({
+        operationType: dsMockUtils.createMockStatisticsOpType(StatType.Count),
+        claimIssuer: dsMockUtils.createMockOption([
+          dsMockUtils.createMockClaimType(ClaimType.Affiliate),
+          issuerDid,
+        ]),
+      });
+      rawJurisdictionStatType = dsMockUtils.createMockStatisticsStatType({
+        operationType: dsMockUtils.createMockStatisticsOpType(StatType.ScopedCount),
+        claimIssuer: dsMockUtils.createMockOption([
+          dsMockUtils.createMockClaimType(ClaimType.Jurisdiction),
+          issuerDid,
+        ]),
+      });
+
+      rawClaimPercentageStatType = dsMockUtils.createMockStatisticsStatType({
+        operationType: dsMockUtils.createMockStatisticsOpType(StatType.ScopedBalance),
+        claimIssuer: dsMockUtils.createMockOption([
+          dsMockUtils.createMockClaimType(ClaimType.Accredited),
+          issuerDid,
+        ]),
+      });
+
+      queryMultiMock = dsMockUtils.getQueryMultiMock();
+
+      when(assetToMeshAssetIdSpy).calledWith(asset, context).mockReturnValue(rawAssetId);
+      when(meshStatToStatTypeSpy)
+        .calledWith(rawCountStatType, context)
+        .mockReturnValue(StatType.Count);
+      when(meshStatToStatTypeSpy)
+        .calledWith(rawPercentageStatType, context)
+        .mockReturnValue(StatType.Balance);
+      when(meshStatToStatTypeSpy)
+        .calledWith(rawClaimCountStatType, context)
+        .mockReturnValue(StatType.Count);
+      when(meshStatToStatTypeSpy)
+        .calledWith(rawClaimPercentageStatType, context)
+        .mockReturnValue(StatType.ScopedBalance);
+      when(meshStatToStatTypeSpy)
+        .calledWith(rawJurisdictionStatType, context)
+        .mockReturnValue(StatType.ScopedCount);
+      when(u128ToBigNumberSpy).calledWith(rawValue).mockReturnValue(value);
+      when(getStat1stKeySpy)
+        .calledWith(asset, rawCountStatType, context)
+        .mockReturnValue(stat1stKey);
+      when(getStat1stKeySpy)
+        .calledWith(asset, rawPercentageStatType, context)
+        .mockReturnValue(stat1stKey);
+      when(getStat1stKeySpy)
+        .calledWith(asset, rawClaimCountStatType, context)
+        .mockReturnValue(stat1stKey);
+      when(getStat1stKeySpy)
+        .calledWith(asset, rawClaimPercentageStatType, context)
+        .mockReturnValue(stat1stKey);
+      when(getStat1stKeySpy)
+        .calledWith(asset, rawJurisdictionStatType, context)
+        .mockReturnValue(stat1stKey);
+      when(getStat2ndKeySpy).calledWith(context).mockReturnValue(stat2ndKey);
+      when(getStat2ndKeySpy)
+        .calledWith(context, ClaimType.Accredited, expect.any(Boolean))
+        .mockReturnValue(stat2ndKey);
+      when(getStat2ndKeySpy)
+        .calledWith(context, ClaimType.Affiliate, expect.any(Boolean))
+        .mockReturnValue(stat2ndKey);
+      when(getStat2ndKeySpy)
+        .calledWith(context, ClaimType.Jurisdiction, expect.anything())
+        .mockReturnValue(stat2ndKey);
+
+      dsMockUtils.createQueryMock('statistics', 'activeAssetStats', {
+        returnValue: [
+          rawCountStatType,
+          rawPercentageStatType,
+          rawClaimCountStatType,
+          rawClaimPercentageStatType,
+          rawJurisdictionStatType,
+        ],
+      });
+      dsMockUtils.createQueryMock('statistics', 'assetStats');
+
+      queryMultiMock.mockResolvedValue([
+        rawValue,
+        rawValue,
+        rawValue,
+        rawValue,
+        rawValue,
+        rawValue,
+        rawValue,
+        rawValue,
+        // for Jurisdiction without country code
+        rawValue,
+        // for Jurisdiction with country code
+        ...new Array(Object.keys(CountryCode).length).fill(rawValue),
+      ]);
+    });
+
+    afterAll(() => {
+      dsMockUtils.cleanup();
+      procedureMockUtils.cleanup();
+    });
+
+    it('should return the stat values for the asset', async () => {
+      stat1stKey = {
+        assetId: rawAssetId,
+        statType: 'MaxInvestorCount',
+      } as unknown as PolymeshPrimitivesStatisticsStat1stKey;
+      stat2ndKey = {
+        isNoClaimStat: true,
+        type: 'NoClaimStat',
+      } as PolymeshPrimitivesStatisticsStat2ndKey;
+
+      const result = await asset.transferRestrictions.getValues();
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: StatType.Count,
+            value: new BigNumber(10),
+          }),
+          expect.objectContaining({
+            type: StatType.Balance,
+            value: new BigNumber(10).shiftedBy(-6),
+          }),
+          expect.objectContaining({
+            claim: {
+              claimType: ClaimType.Affiliate,
+              issuer: expect.anything(),
+              value: {
+                affiliate: new BigNumber(10),
+                nonAffiliate: new BigNumber(10),
+              },
+            },
+            type: StatType.ScopedCount,
+            value: new BigNumber(20),
+          }),
+          expect.objectContaining({
+            claim: {
+              claimType: ClaimType.Accredited,
+              issuer: expect.anything(),
+              value: {
+                accredited: new BigNumber(10).shiftedBy(-6),
+                nonAccredited: new BigNumber(10).shiftedBy(-6),
+              },
+            },
+            type: StatType.ScopedBalance,
+            value: new BigNumber(20).shiftedBy(-6),
+          }),
+          expect.objectContaining({
+            claim: {
+              claimType: ClaimType.Jurisdiction,
+              issuer: expect.anything(),
+              value: expect.arrayContaining([
+                expect.objectContaining({
+                  count: expect.any(BigNumber),
+                  countryCode: expect.any(String),
+                }),
+              ]),
+            },
+            type: StatType.ScopedBalance,
+            value: expect.any(BigNumber),
+          }),
+        ])
+      );
     });
   });
 });

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -13,6 +13,7 @@ import { EventIdEnum } from '~/middleware/types';
 import {
   ClaimType,
   Compliance,
+  CountryCode,
   EventIdentifier,
   MetadataDetails,
   MetadataType,
@@ -396,14 +397,66 @@ export interface HeldNfts {
   nfts: Nft[];
 }
 
-/**
- * A Transfer Restriction along with its current value
- */
-export interface TransferRestrictionValues {
-  restriction: TransferRestriction;
+export type AccreditedValue = {
+  /**
+   * The count or percentage of Asset holders that are accredited
+   */
+  accredited: BigNumber;
 
   /**
-   * The current value of the transfer restriction
+   * The count or percentage of Asset holders that are not accredited
+   */
+  nonAccredited: BigNumber;
+};
+
+export type AffiliateValue = {
+  /**
+   * The count or percentage of Asset holders that are affiliates
+   */
+  affiliate: BigNumber;
+
+  /**
+   * The count or percentage of Asset holders that are not affiliates
+   */
+  nonAffiliate: BigNumber;
+};
+
+export type JurisdictionValue = {
+  /**
+   * The country code of the jurisdiction
+   * @note null if the jurisdiction is not specified
+   */
+  countryCode: CountryCode | null;
+
+  /**
+   * The count or percentage of Asset holders with the jurisdiction
+   */
+  count: BigNumber;
+};
+
+/**
+ * Asset Stat along with its current value
+ */
+export interface TransferRestrictionStatValues {
+  /**
+   * The claim of the stat
+   * @note for scoped stats, this is the claim of the stat
+   * @note for count stats, this is undefined
+   */
+  claim?: {
+    issuer: Identity;
+    claimType: ClaimType;
+    value: AccreditedValue | AffiliateValue | JurisdictionValue[];
+  };
+
+  /**
+   * The type of the stat
+   */
+  type: StatType;
+  /**
+   * The total value of of the Asset Stat
+   * @note for scoped stats, this is the total value of all claims
+   * @note for count stats, this is the value of the stat
    */
   value: BigNumber;
 }

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -569,7 +569,7 @@ export type ClaimCountStatInput =
   | {
       issuer: Identity;
       claimType: ClaimType.Jurisdiction;
-      value: { countryCode: CountryCode; count: BigNumber }[];
+      value: { countryCode: CountryCode | undefined; count: BigNumber }[];
     };
 
 export interface ScheduleWithDetails {

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -4290,7 +4290,7 @@ export function transferRestrictionTypeToStatOpType(
 export function createStat2ndKey(
   type: 'NoClaimStat' | StatClaimType,
   context: Context,
-  claimStat?: 'yes' | 'no' | CountryCode
+  claimStat?: 'yes' | 'no' | CountryCode | undefined
 ): PolymeshPrimitivesStatisticsStat2ndKey {
   if (type === 'NoClaimStat') {
     return context.createType('PolymeshPrimitivesStatisticsStat2ndKey', type);
@@ -5864,62 +5864,31 @@ export function meshBallotDetailsToCorporateBallotDetails(
 /**
  * @hidden
  */
-export function transferRestrictionToPolymeshPrimitivesStatisticsStat1stKey(
+export function getStat1stKey(
   rawAssetId: PolymeshPrimitivesAssetAssetId,
-  restriction: TransferRestriction,
+  statType: PolymeshPrimitivesStatisticsStatType,
   context: Context
 ): PolymeshPrimitivesStatisticsStat1stKey {
-  const { type, value } = restriction;
-
-  const operationType = transferRestrictionTypeToStatOpType(type, context);
-
-  if (type === TransferRestrictionType.Count || type === TransferRestrictionType.Percentage) {
-    return context.createType('PolymeshPrimitivesStatisticsStat1stKey', {
-      assetId: rawAssetId,
-      statType: context.createType('PolymeshPrimitivesStatisticsStatType', {
-        operationType,
-        claimIssuer: undefined,
-      }),
-    });
-  }
-
   return context.createType('PolymeshPrimitivesStatisticsStat1stKey', {
     assetId: rawAssetId,
-    statType: context.createType('PolymeshPrimitivesStatisticsStatType', {
-      operationType,
-      claimIssuer: [
-        claimTypeToMeshClaimType(value.claim.type, context),
-        stringToIdentityId(value.issuer.did, context),
-      ],
-    }),
+    statType,
   });
 }
 
 /**
  * @hidden
  */
-export function transferRestrictionToPolymeshPrimitivesStatisticsStat2ndKey(
-  restriction: TransferRestriction,
-  context: Context
+export function getStat2ndKey(
+  context: Context,
+  claimType?: ClaimType,
+  claimValue?: boolean | CountryCode
 ): PolymeshPrimitivesStatisticsStat2ndKey {
-  const { type, value } = restriction;
-
-  if (type === TransferRestrictionType.Count || type === TransferRestrictionType.Percentage) {
+  if (!claimType) {
     return context.createType('PolymeshPrimitivesStatisticsStat2ndKey', 'NoClaimStat');
   }
 
-  let claimValue: boolean | CountryCode | undefined;
-
-  if (value.claim.type === ClaimType.Accredited) {
-    claimValue = value.claim.accredited;
-  } else if (value.claim.type === ClaimType.Affiliate) {
-    claimValue = value.claim.affiliate;
-  } else if (value.claim.type === ClaimType.Jurisdiction) {
-    claimValue = value.claim.countryCode;
-  }
-
   return context.createType('PolymeshPrimitivesStatisticsStat2ndKey', {
-    claim: { [value.claim.type]: claimValue },
+    claim: { [claimType]: claimValue },
   });
 }
 


### PR DESCRIPTION
### Description

- allows getting all paths for asset stat values (e.g. how many accredited and non-accredited investors are there)
- updates the enableStat (adjustments to type) to allow setting stat value for investors without a jurisdiction

Note: didn't mark as breaking as the previous version is not yet in use

### JIRA Link

https://polymesh.atlassian.net/browse/DA-1515
