### PR TITLE
fix: 🐛 allow specify customClaimTypeId for TrustedClaimIssuer

### DIFF
--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -21,6 +21,7 @@ import {
   StatClaimIssuer,
   StatType,
   TransferRestriction,
+  TrustedFor,
   Venue,
 } from '~/types';
 
@@ -483,7 +484,7 @@ export interface AssetStat {
 export interface TransferExemptKey {
   assetId: string;
   opType: StatType;
-  claimType: ClaimType | null;
+  claimType: TrustedFor | null;
 }
 
 /**

--- a/src/api/entities/DefaultTrustedClaimIssuer.ts
+++ b/src/api/entities/DefaultTrustedClaimIssuer.ts
@@ -1,7 +1,7 @@
 import { Context, FungibleAsset, Identity, PolymeshError } from '~/internal';
 import { trustedClaimIssuerQuery } from '~/middleware/queries/claims';
 import { Query } from '~/middleware/types';
-import { ClaimType, ErrorCode, EventIdentifier } from '~/types';
+import { ErrorCode, EventIdentifier, TrustedFor } from '~/types';
 import { Ensured } from '~/types/utils';
 import {
   assetToMeshAssetId,
@@ -78,7 +78,7 @@ export class DefaultTrustedClaimIssuer extends Identity {
   /**
    * Retrieve claim types for which this Claim Issuer is trusted. A null value means that the issuer is trusted for all claim types
    */
-  public async trustedFor(): Promise<ClaimType[] | null> {
+  public async trustedFor(): Promise<TrustedFor[] | null> {
     const {
       context: {
         polymeshApi: {

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -313,6 +313,8 @@ export interface ClaimScope {
   assetId?: string;
 }
 
+export type TrustedFor = ClaimType | { type: ClaimType.Custom; customClaimTypeId: BigNumber };
+
 /**
  * @param IsDefault - whether the Identity is a default trusted claim issuer for an asset or just
  *   for a specific compliance condition. Defaults to false
@@ -322,7 +324,7 @@ export interface TrustedClaimIssuer<IsDefault extends boolean = false> {
   /**
    * a null value means that the issuer is trusted for all claim types
    */
-  trustedFor: ClaimType[] | null;
+  trustedFor: TrustedFor[] | null;
 }
 
 export type InputTrustedClaimIssuer = Modify<
@@ -831,5 +833,5 @@ export type PortfolioMovement = FungiblePortfolioMovement | NonFungiblePortfolio
 
 export type ActiveStats = {
   isSet: boolean;
-  claims?: { claimType: ClaimType; issuer: Identity }[];
+  claims?: { claimType: ClaimType; customClaimTypeId?: BigNumber; issuer: Identity }[];
 };

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -2918,7 +2918,8 @@ export const createMockConditionType = (
  * NOTE: `isEmpty` will be set to true if no value is passed
  */
 export const createMockClaimType = (
-  claimType?: ClaimType
+  claimType?: ClaimType,
+  customClaimTypeId?: BigNumber
 ): MockCodec<PolymeshPrimitivesIdentityClaimClaimType> => {
   const claimIndexes = {
     Accredited: 1,
@@ -2934,6 +2935,13 @@ export const createMockClaimType = (
     InvestorUniquenessV2: 11,
     Custom: 12,
   };
+
+  if (claimType === ClaimType.Custom) {
+    return createMockEnum<PolymeshPrimitivesIdentityClaimClaimType>({
+      Custom: createMockU32(customClaimTypeId ?? new BigNumber(0)),
+    });
+  }
+
   return createMockEnum<PolymeshPrimitivesIdentityClaimClaimType>(
     claimType,
     claimType ? claimIndexes[claimType] : 0

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -4964,12 +4964,10 @@ describe('meshClaimTypeToClaimType and claimTypeToMeshClaimType', () => {
       result = meshClaimTypeToClaimType(claimType);
       expect(result).toEqual(fakeResult);
 
-      fakeResult = ClaimType.Custom;
-
-      claimType = dsMockUtils.createMockClaimType(fakeResult);
+      claimType = dsMockUtils.createMockClaimType(ClaimType.Custom);
 
       result = meshClaimTypeToClaimType(claimType);
-      expect(result).toEqual(fakeResult);
+      expect(result).toEqual({ type: ClaimType.Custom, customClaimTypeId: new BigNumber(0) });
     });
 
     it('should throw an error if it un-parses an unknown type', () => {
@@ -7296,12 +7294,18 @@ describe('trustedClaimIssuerToTrustedIssuer and trustedIssuerToTrustedClaimIssue
   });
 
   describe('trustedClaimIssuerToTrustedIssuer', () => {
-    it('should convert a did string into an PolymeshPrimitivesIdentityId', () => {
-      const did = 'someDid';
-      const fakeResult = 'type' as unknown as PolymeshPrimitivesConditionTrustedIssuer;
-      const context = dsMockUtils.getContextInstance();
+    let context: Context;
+    let did: string;
+    let fakeResult: PolymeshPrimitivesConditionTrustedIssuer;
 
-      let issuer: TrustedClaimIssuer = {
+    beforeEach(() => {
+      context = dsMockUtils.getContextInstance();
+      did = 'someDid';
+      fakeResult = 'type' as unknown as PolymeshPrimitivesConditionTrustedIssuer;
+    });
+
+    it('should handle null trustedFor', () => {
+      const issuer: TrustedClaimIssuer = {
         identity: entityMockUtils.getIdentityInstance({ did }),
         trustedFor: null,
       };
@@ -7313,10 +7317,12 @@ describe('trustedClaimIssuerToTrustedIssuer and trustedIssuerToTrustedClaimIssue
         })
         .mockReturnValue(fakeResult);
 
-      let result = trustedClaimIssuerToTrustedIssuer(issuer, context);
+      const result = trustedClaimIssuerToTrustedIssuer(issuer, context);
       expect(result).toBe(fakeResult);
+    });
 
-      issuer = {
+    it('should handle array of claim types', () => {
+      const issuer: TrustedClaimIssuer = {
         identity: entityMockUtils.getIdentityInstance({ did }),
         trustedFor: [ClaimType.Accredited, ClaimType.Blocked],
       };
@@ -7328,7 +7334,34 @@ describe('trustedClaimIssuerToTrustedIssuer and trustedIssuerToTrustedClaimIssue
         })
         .mockReturnValue(fakeResult);
 
-      result = trustedClaimIssuerToTrustedIssuer(issuer, context);
+      const result = trustedClaimIssuerToTrustedIssuer(issuer, context);
+      expect(result).toBe(fakeResult);
+    });
+
+    it('should handle custom claim type', () => {
+      const customClaimTypeId = new BigNumber(1);
+      const issuer: TrustedClaimIssuer = {
+        identity: entityMockUtils.getIdentityInstance({ did }),
+        trustedFor: [{ type: ClaimType.Custom, customClaimTypeId }],
+      };
+
+      const mockTrustedFor = 'Custom' as unknown as PolymeshPrimitivesIdentityClaimClaimType;
+
+      when(context.createType)
+        .calledWith('PolymeshPrimitivesIdentityClaimClaimType', {
+          Custom: bigNumberToU32(customClaimTypeId, context),
+        })
+        .mockReturnValue(mockTrustedFor);
+
+      when(context.createType)
+        .calledWith('PolymeshPrimitivesConditionTrustedIssuer', {
+          issuer: stringToIdentityId(did, context),
+          trustedFor: { Specific: [mockTrustedFor] },
+        })
+        .mockReturnValue(fakeResult);
+
+      const result = trustedClaimIssuerToTrustedIssuer(issuer, context);
+
       expect(result).toBe(fakeResult);
     });
   });


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

### Breaking Changes

BREAKING CHANGE: 🧨 Return of trustedClaimIssuers.get() will be an object for custom claim containing customClaimTypeId

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
