### PR TITLE
feat: 🎸 Add support for locking an instruction

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@polkadot/dev-ts": "^0.79.3",
     "@polkadot/typegen": "11.2.1",
     "@polymeshassociation/local-signing-manager": "^3.0.1",
-    "@polymeshassociation/polymesh-types": "^6.0.0",
+    "@polymeshassociation/polymesh-types": "^6.2.0",
     "@polymeshassociation/signing-manager-types": "^3.0.0",
     "@polymeshassociation/typedoc-theme": "^1.2.0",
     "@semantic-release/changelog": "^6.0.3",

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -160,3 +160,22 @@ export interface GroupedInvolvedInstructions {
    */
   owned: Omit<GroupedInstructions, 'affirmed'>;
 }
+
+export interface InstructionLockedInfo {
+  /**
+   * Whether the instruction is locked for execution
+   */
+  isLocked: boolean;
+  /**
+   * The date and time when the instruction was locked for execution
+   */
+  lockedAt: Date | null;
+  /**
+   * Time in milliseconds after which the instruction will no longer be locked for execution
+   */
+  expiry: BigNumber | null;
+  /**
+   * The date when the instruction will no longer be locked for execution
+   */
+  unlocksAt: Date | null;
+}

--- a/src/api/procedures/__tests__/lockInstructionForExecution.ts
+++ b/src/api/procedures/__tests__/lockInstructionForExecution.ts
@@ -1,0 +1,194 @@
+import { u64 } from '@polkadot/types';
+import { DispatchError } from '@polkadot/types/interfaces/system';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareLockInstructionForExecution,
+} from '~/api/procedures/lockInstructionForExecution';
+import * as procedureUtilsModule from '~/api/procedures/utils';
+import { Context, Instruction } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { AffirmationStatus, InstructionAffirmationOperation, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Instruction',
+  require('~/testUtils/mocks/entities').mockInstructionModule('~/api/entities/Instruction')
+);
+
+describe('lockInstructionForExecution procedure', () => {
+  const id = new BigNumber(1);
+  const rawInstructionId = dsMockUtils.createMockU64(id);
+
+  const consumedWeight = dsMockUtils.createMockWeight({
+    refTime: dsMockUtils.createMockCompact(dsMockUtils.createMockU64(new BigNumber(0))),
+    proofSize: dsMockUtils.createMockCompact(
+      dsMockUtils.createMockU64(new BigNumber('9455603734'))
+    ),
+  });
+
+  let mockContext: Mocked<Context>;
+  let bigNumberToU64Spy: jest.SpyInstance<u64, [BigNumber, Context]>;
+  let lockInstructionWeightMock: jest.Mock;
+
+  let lockInstructionTxMock: jest.Mock;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+
+    bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+
+    jest.spyOn(procedureUtilsModule, 'assertInstructionValidForLocking').mockImplementation();
+  });
+
+  beforeEach(() => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          { identity: entityMockUtils.getIdentityInstance(), status: AffirmationStatus.Affirmed },
+        ],
+      },
+    });
+
+    lockInstructionWeightMock = dsMockUtils.createCallMock(
+      'settlementApi',
+      'lockInstructionWeight'
+    );
+    lockInstructionWeightMock.mockReturnValue(
+      dsMockUtils.createMockLockInstructionWeight({
+        Ok: consumedWeight,
+      })
+    );
+
+    lockInstructionTxMock = dsMockUtils.createTxMock('settlement', 'lockInstruction');
+
+    mockContext = dsMockUtils.getContextInstance();
+    when(bigNumberToU64Spy).calledWith(id, mockContext).mockReturnValue(rawInstructionId);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error pending affirmation count is not zero', () => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getPendingAffirmationCount: new BigNumber(1),
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    return expect(
+      prepareLockInstructionForExecution.call(proc, {
+        id,
+      })
+    ).rejects.toThrow(
+      'Instruction needs to be affirmed by all parties before it can be locked for execution'
+    );
+  });
+
+  it('should throw an error if signer is not a mediator', () => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          {
+            identity: entityMockUtils.getIdentityInstance({ did: 'randomDid' }),
+            status: AffirmationStatus.Affirmed,
+          },
+        ],
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    return expect(
+      prepareLockInstructionForExecution.call(proc, {
+        id,
+      })
+    ).rejects.toThrow('Only mediators can lock instructions for execution');
+  });
+
+  it('should throw an error if mediator affirmation has expired', () => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          {
+            identity: entityMockUtils.getIdentityInstance(),
+            status: AffirmationStatus.Affirmed,
+            expiry: new Date('2022/01/01'),
+          },
+        ],
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    return expect(
+      prepareLockInstructionForExecution.call(proc, {
+        id,
+      })
+    ).rejects.toThrow('Mediator affirmation has expired');
+  });
+
+  it('should return an throw an error if runtime API throws an error while fetching lock weight', async () => {
+    lockInstructionWeightMock.mockReturnValue(
+      dsMockUtils.createMockLockInstructionWeight({
+        Err: 'errorResponse' as unknown as DispatchError,
+      })
+    );
+
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    return expect(
+      prepareLockInstructionForExecution.call(proc, {
+        id,
+      })
+    ).rejects.toThrow('Instruction cannot be locked for execution');
+  });
+
+  it('should return a transaction spec on successful locking', async () => {
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    const result = await prepareLockInstructionForExecution.call(proc, {
+      id,
+      operation: InstructionAffirmationOperation.Affirm,
+    });
+
+    expect(result).toEqual({
+      transaction: lockInstructionTxMock,
+      args: [rawInstructionId, consumedWeight],
+      resolver: expect.objectContaining({ id }),
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', async () => {
+      const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext, { id });
+      const boundFunc = getAuthorization.bind(proc);
+
+      const result = await boundFunc();
+
+      expect(result).toEqual({
+        permissions: {
+          assets: [],
+          portfolios: [],
+          transactions: [TxTags.settlement.LockInstruction],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/lockInstructionForExecution.ts
+++ b/src/api/procedures/lockInstructionForExecution.ts
@@ -1,0 +1,118 @@
+import BigNumber from 'bignumber.js';
+
+import { assertInstructionValidForLocking } from '~/api/procedures/utils';
+import { dispatchErrorToMessage } from '~/base/utils';
+import { Instruction, PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { bigNumberToU64 } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export type Params = {
+  id: BigNumber;
+};
+
+/**
+ * @hidden
+ */
+export async function prepareLockInstructionForExecution(
+  this: Procedure<Params, Instruction>,
+  args: Params
+): Promise<TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'lockInstruction'>>> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: { settlement: settlementTx },
+        call: { settlementApi },
+      },
+    },
+    context,
+  } = this;
+
+  const { id } = args;
+
+  const instruction = new Instruction({ id }, context);
+
+  const [{ did: signerDid }, instructionDetails, pendingAffirmationsCount, mediatorAffirmations] =
+    await Promise.all([
+      context.getSigningIdentity(),
+      instruction.detailsFromChain(),
+      instruction.getPendingAffirmationCount(),
+      instruction.getMediators(),
+    ]);
+
+  await assertInstructionValidForLocking(instructionDetails);
+
+  if (!pendingAffirmationsCount.isZero()) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message:
+        'Instruction needs to be affirmed by all parties before it can be locked for execution',
+      data: {
+        pendingAffirmationsCount,
+      },
+    });
+  }
+
+  const mediatorWithAffirmation = mediatorAffirmations.find(
+    ({ identity: { did } }) => did === signerDid
+  );
+
+  if (!mediatorWithAffirmation) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Only mediators can lock instructions for execution',
+      data: { signer: signerDid, instructionId: id.toString() },
+    });
+  }
+
+  if (mediatorWithAffirmation.expiry && mediatorWithAffirmation.expiry < new Date()) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Mediator affirmation has expired',
+    });
+  }
+
+  const rawInstructionId = bigNumberToU64(id, context);
+
+  const rawLockInstructionWeight = await settlementApi.lockInstructionWeight(rawInstructionId);
+
+  if (rawLockInstructionWeight.isErr) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Instruction cannot be locked for execution',
+      data: {
+        error: dispatchErrorToMessage(rawLockInstructionWeight.asErr),
+      },
+    });
+  }
+
+  return {
+    transaction: settlementTx.lockInstruction,
+    resolver: instruction,
+    args: [rawInstructionId, rawLockInstructionWeight.asOk],
+  };
+}
+
+/**
+ * @hidden
+ */
+export async function getAuthorization(
+  this: Procedure<Params, Instruction>
+): Promise<ProcedureAuthorization> {
+  return {
+    permissions: {
+      transactions: [TxTags.settlement.LockInstruction],
+      assets: [],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const lockInstructionForExecution = (): Procedure<Params, Instruction> =>
+  new Procedure(prepareLockInstructionForExecution, getAuthorization);

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -950,6 +950,8 @@ export type AddInstructionParams = {
   memo?: string;
   /**
    * additional identities that must affirm the instruction
+   *
+   * @note mediators are mandatory if settlement is to be locked for execution (providing `endAfterLock`)
    */
   mediators?: (string | Identity)[];
 } & (

--- a/src/base/utils.ts
+++ b/src/base/utils.ts
@@ -1,6 +1,6 @@
 import { SubmittableResult } from '@polkadot/api';
 import { getTypeDef, u32 } from '@polkadot/types';
-import { Hash, SignedBlock } from '@polkadot/types/interfaces';
+import { DispatchError, Hash, SignedBlock } from '@polkadot/types/interfaces';
 import { SpRuntimeDispatchError } from '@polkadot/types/lookup';
 import { RegistryError, TypeDef, TypeDefInfo } from '@polkadot/types/types';
 import { polymesh } from '@polymeshassociation/polymesh-types/polkadot/definitions';
@@ -151,16 +151,8 @@ export const processType = (rawType: TypeDef, name: string): TransactionArgument
   }
 };
 
-/**
- * @hidden
- */
-export const handleExtrinsicFailure = (
-  error: SpRuntimeDispatchError,
-  data?: Record<string, unknown>
-): PolymeshError => {
-  // get revert message from event
+export const dispatchErrorToMessage = (error: SpRuntimeDispatchError | DispatchError): string => {
   let message: string;
-
   if (error.isModule) {
     // known error
     const mod = error.asModule;
@@ -174,6 +166,18 @@ export const handleExtrinsicFailure = (
   } else {
     message = 'Unknown error';
   }
+  return message;
+};
+
+/**
+ * @hidden
+ */
+export const handleExtrinsicFailure = (
+  error: SpRuntimeDispatchError,
+  data?: Record<string, unknown>
+): PolymeshError => {
+  // get revert message from event
+  const message = dispatchErrorToMessage(error);
 
   return new PolymeshError({ code: ErrorCode.TransactionReverted, message, data });
 };

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -14,6 +14,7 @@ import {
   Compact,
   Enum,
   Option,
+  Result,
   Text,
   u8,
   U8aFixed,
@@ -164,7 +165,6 @@ import {
   AssetComplianceResult,
   AssetCount,
   AuthorizationType as MeshAuthorizationType,
-  CanTransferGranularReturn,
   CddStatus,
   ComplianceReport,
   ComplianceRequirementResult,
@@ -4641,22 +4641,6 @@ export const createMockNfts = (nfts?: {
  * @hidden
  * NOTE: `isEmpty` will be set to true if no value is passed
  */
-export const createMockCanTransferGranularReturn = (
-  result?:
-    | {
-        Ok: GranularCanTransferResult;
-      }
-    | {
-        Err: DispatchError;
-      }
-): MockCodec<CanTransferGranularReturn> => {
-  return createMockEnum<CanTransferGranularReturn>(result);
-};
-
-/**
- * @hidden
- * NOTE: `isEmpty` will be set to true if no value is passed
- */
 export const createMockStoredSchedule = (storedSchedule?: {
   schedule: Parameters<typeof createMockCheckpointSchedule>[0];
   id: u64 | Parameters<typeof createMockU64>[0];
@@ -5082,4 +5066,20 @@ export const createMockExemptKey = (key?: {
     { assetId, op, claimType },
     !key
   );
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
+export const createMockLockInstructionWeight = (
+  result?:
+    | {
+        Ok: Weight;
+      }
+    | {
+        Err: DispatchError;
+      }
+): MockCodec<Result<Weight, DispatchError>> => {
+  return createMockEnum<Result<Weight, DispatchError>>(result);
 };

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -58,11 +58,13 @@ import {
   GroupPermissions,
   IdentityBalance,
   InstructionDetails,
+  InstructionLockedInfo,
   InstructionStatus,
   InstructionType,
   KnownAssetType,
   KnownNftType,
   Leg,
+  MediatorAffirmation,
   MetadataDetails,
   MetadataLockStatus,
   MetadataType,
@@ -305,6 +307,9 @@ interface InstructionOptions extends EntityOptions {
   getLegsFromChain?: EntityGetter<ResultSet<Leg>>;
   detailsFromChain?: EntityGetter<InstructionDetails>;
   isPending?: EntityGetter<boolean>;
+  getLockedInfo?: EntityGetter<InstructionLockedInfo>;
+  getPendingAffirmationCount?: EntityGetter<BigNumber>;
+  getMediators?: EntityGetter<MediatorAffirmation[]>;
 }
 
 interface OfferingOptions extends EntityOptions {
@@ -1546,6 +1551,9 @@ const MockInstructionClass = createMockEntityClass<InstructionOptions>(
     getLegsFromChain!: jest.Mock;
     detailsFromChain!: jest.Mock;
     isPending!: jest.Mock;
+    getLockedInfo!: jest.Mock;
+    getPendingAffirmationCount!: jest.Mock;
+    getMediators!: jest.Mock;
 
     /**
      * @hidden
@@ -1565,6 +1573,9 @@ const MockInstructionClass = createMockEntityClass<InstructionOptions>(
       this.isPending = createEntityGetterMock(opts.isPending);
       this.getLegsFromChain = createEntityGetterMock(opts.getLegsFromChain);
       this.detailsFromChain = createEntityGetterMock(opts.detailsFromChain);
+      this.getLockedInfo = createEntityGetterMock(opts.getLockedInfo);
+      this.getPendingAffirmationCount = createEntityGetterMock(opts.getPendingAffirmationCount);
+      this.getMediators = createEntityGetterMock(opts.getMediators);
     }
   },
   () => ({
@@ -1608,6 +1619,14 @@ const MockInstructionClass = createMockEntityClass<InstructionOptions>(
       next: null,
     },
     isPending: false,
+    getLockedInfo: {
+      isLocked: false,
+      lockedAt: null,
+      expiry: null,
+      unlocksAt: null,
+    },
+    getPendingAffirmationCount: new BigNumber(0),
+    getMediators: [],
   }),
   ['Instruction']
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2829,7 +2829,7 @@ __metadata:
     "@polkadot/util": "npm:12.6.2"
     "@polkadot/util-crypto": "npm:12.6.2"
     "@polymeshassociation/local-signing-manager": "npm:^3.0.1"
-    "@polymeshassociation/polymesh-types": "npm:^6.0.0"
+    "@polymeshassociation/polymesh-types": "npm:^6.2.0"
     "@polymeshassociation/signing-manager-types": "npm:^3.0.0"
     "@polymeshassociation/typedoc-theme": "npm:^1.2.0"
     "@semantic-release/changelog": "npm:^6.0.3"
@@ -2899,7 +2899,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polymeshassociation/polymesh-types@npm:^6.0.0":
+"@polymeshassociation/polymesh-types@npm:^6.2.0":
   version: 6.2.0
   resolution: "@polymeshassociation/polymesh-types@npm:6.2.0"
   dependencies:


### PR DESCRIPTION
### Description

This adds a procedure to lock instruction for execution. Also, adds new method to get pending affirmation count for an instruction and get locked info about an instruction

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

DA-1530, DA-1524

### Checklist

- [ ] Updated the Readme.md (if required) ?
