### PR TITLE
feat: 🎸 Enable off chain funding and off chain investment changes

### DIFF
--- a/src/api/entities/Offering/__tests__/index.ts
+++ b/src/api/entities/Offering/__tests__/index.ts
@@ -387,6 +387,29 @@ describe('Offering class', () => {
     });
   });
 
+  describe('method: enableOffChainFunding', () => {
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const assetId = '0x12341234123412341234123412341234';
+      const id = new BigNumber(1);
+      const offering = new Offering({ id, assetId }, context);
+      const offChainTicker = 'OFFCHAIN';
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          { args: { asset: offering.asset, id, offChainTicker }, transformer: undefined },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await offering.enableOffChainFunding({ offChainTicker });
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
   describe('method: invest', () => {
     it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
       const assetId = '0x12341234123412341234123412341234';

--- a/src/api/entities/Offering/index.ts
+++ b/src/api/entities/Offering/index.ts
@@ -6,6 +6,7 @@ import { Investment, OfferingDetails } from '~/api/entities/Offering/types';
 import {
   closeOffering,
   Context,
+  enableOffChainFundingForOfferings,
   Entity,
   FungibleAsset,
   Identity,
@@ -16,6 +17,7 @@ import {
 import { investmentsQuery } from '~/middleware/queries/stos';
 import { Query } from '~/middleware/types';
 import {
+  EnableOffChainFundingParams,
   InvestInOfferingParams,
   ModifyOfferingTimesParams,
   NoArgsProcedureMethod,
@@ -108,6 +110,15 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
       { getProcedureAndArgs: args => [investInOffering, { asset: this.asset, id, ...args }] },
       context
     );
+    this.enableOffChainFunding = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [
+          enableOffChainFundingForOfferings,
+          { asset: this.asset, id, ...args },
+        ],
+      },
+      context
+    );
   }
 
   /**
@@ -177,6 +188,16 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
    * Unfreeze the Offering
    */
   public unfreeze: NoArgsProcedureMethod<Offering>;
+
+  /**
+   * Enable off-chain funding for the Offering
+   *
+   * @throws if:
+   *   - Trying to enable off-chain funding on an Offering that does not exist
+   *   - Trying to enable off-chain funding on an Offering that has already ended
+   *   - Trying to enable off-chain funding on an Offering that is already closed
+   */
+  public enableOffChainFunding: ProcedureMethod<EnableOffChainFundingParams, void>;
 
   /**
    * Modify the start/end time of the Offering

--- a/src/api/entities/Offering/types.ts
+++ b/src/api/entities/Offering/types.ts
@@ -89,3 +89,12 @@ export interface Investment {
   soldAmount: BigNumber;
   investedAmount: BigNumber;
 }
+
+export type OffChainFundingDetails =
+  | {
+      enabled: false;
+    }
+  | {
+      enabled: true;
+      offChainTicker: string;
+    };

--- a/src/api/entities/Offering/types.ts
+++ b/src/api/entities/Offering/types.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 
-import { DefaultPortfolio, Identity, NumberedPortfolio, Venue } from '~/internal';
+import { Account, DefaultPortfolio, Identity, NumberedPortfolio, Venue } from '~/internal';
+import { OffChainSignature } from '~/types';
 
 export enum OfferingTimingStatus {
   /**
@@ -98,3 +99,22 @@ export type OffChainFundingDetails =
       enabled: true;
       offChainTicker: string;
     };
+
+export interface OffChainFundingReceipt {
+  /**
+   * Unique receipt number set by the signer for their receipts
+   */
+  uid: BigNumber;
+  /**
+   * Signer of this receipt
+   */
+  signer: string | Account;
+  /**
+   * Signature confirming the receipt details
+   */
+  signature: OffChainSignature;
+  /**
+   * (optional) Metadata value that can be used to attach messages to the receipt
+   */
+  metadata: string | undefined;
+}

--- a/src/api/procedures/__tests__/enableOffChainFundingForOfferings.ts
+++ b/src/api/procedures/__tests__/enableOffChainFundingForOfferings.ts
@@ -1,0 +1,194 @@
+import { u64 } from '@polkadot/types';
+import { PolymeshPrimitivesAssetAssetId, PolymeshPrimitivesTicker } from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareEnableOffChainFundingForOfferings,
+} from '~/api/procedures/enableOffChainFundingForOfferings';
+import { Context, FungibleAsset } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { OfferingBalanceStatus, OfferingSaleStatus, OfferingTimingStatus, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Asset/Fungible',
+  require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+jest.mock(
+  '~/api/entities/Offering',
+  require('~/testUtils/mocks/entities').mockOfferingModule('~/api/entities/Offering')
+);
+
+describe('enableOffChainFundingForOfferings procedure', () => {
+  let mockContext: Mocked<Context>;
+  let assetToMeshAssetIdSpy: jest.SpyInstance;
+  let stringToTickerSpy: jest.SpyInstance;
+  let bigNumberToU64Spy: jest.SpyInstance<u64, [BigNumber, Context]>;
+  let assetId: string;
+  let asset: FungibleAsset;
+  let rawAssetId: PolymeshPrimitivesAssetAssetId;
+  let id: BigNumber;
+  let rawId: u64;
+  let offChainTicker: string;
+  let rawTicker: PolymeshPrimitivesTicker;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
+    bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+    stringToTickerSpy = jest.spyOn(utilsConversionModule, 'stringToTicker');
+    assetId = '0x12341234123412341234123412341234';
+    asset = entityMockUtils.getFungibleAssetInstance({ assetId });
+    id = new BigNumber(1);
+    rawAssetId = dsMockUtils.createMockAssetId(assetId);
+    rawId = dsMockUtils.createMockU64(id);
+    offChainTicker = 'OFFCHAIN';
+    rawTicker = dsMockUtils.createMockTicker(offChainTicker);
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance();
+    when(assetToMeshAssetIdSpy).calledWith(asset, mockContext).mockReturnValue(rawAssetId);
+    when(bigNumberToU64Spy).calledWith(id, mockContext).mockReturnValue(rawId);
+    when(stringToTickerSpy).calledWith(offChainTicker, mockContext).mockReturnValue(rawTicker);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if the Offering does not exist', () => {
+    entityMockUtils.configureMocks({
+      offeringOptions: {
+        exists: false,
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    return expect(
+      prepareEnableOffChainFundingForOfferings.call(proc, {
+        asset,
+        id,
+        offChainTicker,
+      })
+    ).rejects.toThrow('The Offering does not exist');
+  });
+
+  it('should throw an error if the Offering has reached its end date', () => {
+    entityMockUtils.configureMocks({
+      offeringOptions: {
+        exists: true,
+        details: {
+          status: {
+            timing: OfferingTimingStatus.Expired,
+            balance: OfferingBalanceStatus.Available,
+            sale: OfferingSaleStatus.Closed,
+          },
+        },
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    return expect(
+      prepareEnableOffChainFundingForOfferings.call(proc, {
+        asset,
+        id,
+        offChainTicker,
+      })
+    ).rejects.toThrow('The Offering has already ended');
+  });
+
+  it('should throw an error if the Offering is already closed', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    entityMockUtils.configureMocks({
+      offeringOptions: {
+        exists: true,
+        details: {
+          status: {
+            sale: OfferingSaleStatus.ClosedEarly,
+            timing: OfferingTimingStatus.Started,
+            balance: OfferingBalanceStatus.Available,
+          },
+        },
+      },
+    });
+
+    await expect(
+      prepareEnableOffChainFundingForOfferings.call(proc, {
+        asset,
+        id,
+        offChainTicker,
+      })
+    ).rejects.toThrow('The Offering is already closed');
+
+    entityMockUtils.configureMocks({
+      offeringOptions: {
+        exists: true,
+        details: {
+          status: {
+            sale: OfferingSaleStatus.Closed,
+            timing: OfferingTimingStatus.Started,
+            balance: OfferingBalanceStatus.Available,
+          },
+        },
+      },
+    });
+
+    return expect(
+      prepareEnableOffChainFundingForOfferings.call(proc, {
+        asset,
+        id,
+        offChainTicker,
+      })
+    ).rejects.toThrow('The Offering is already closed');
+  });
+
+  it('should return a enableOffchainFunding transaction spec', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const transaction = dsMockUtils.createTxMock('sto', 'enableOffchainFunding');
+
+    const result = await prepareEnableOffChainFundingForOfferings.call(proc, {
+      asset,
+      id,
+      offChainTicker,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawAssetId, rawId, rawTicker],
+      resolver: undefined,
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(boundFunc({ asset, id, offChainTicker })).toEqual({
+        permissions: {
+          transactions: [TxTags.sto.EnableOffchainFunding],
+          assets: [asset],
+          portfolios: [],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/__tests__/investInOffering.ts
+++ b/src/api/procedures/__tests__/investInOffering.ts
@@ -613,5 +613,25 @@ describe('investInOffering procedure', () => {
         fundingPortfolioId,
       });
     });
+
+    it('should return the investment and off chain funding receipt', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext);
+      const boundFunc = prepareStorage.bind(proc);
+
+      const result = boundFunc({
+        id,
+        asset,
+        purchasePortfolio,
+        purchaseAmount,
+        offChainFundingReceipt,
+        offChainTicker,
+      });
+
+      expect(result).toEqual({
+        purchasePortfolioId,
+        offChainFundingReceipt,
+        offChainTicker,
+      });
+    });
   });
 });

--- a/src/api/procedures/enableOffChainFundingForOfferings.ts
+++ b/src/api/procedures/enableOffChainFundingForOfferings.ts
@@ -1,0 +1,99 @@
+import BigNumber from 'bignumber.js';
+
+import { FungibleAsset, Offering, PolymeshError, Procedure } from '~/internal';
+import {
+  EnableOffChainFundingParams,
+  ErrorCode,
+  OfferingSaleStatus,
+  OfferingTimingStatus,
+  TxTags,
+} from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { assetToMeshAssetId, bigNumberToU64, stringToTicker } from '~/utils/conversion';
+
+export interface Params extends EnableOffChainFundingParams {
+  id: BigNumber;
+  asset: FungibleAsset;
+}
+
+/**
+ * @hidden
+ */
+export async function prepareEnableOffChainFundingForOfferings(
+  this: Procedure<Params, void>,
+  args: Params
+): Promise<TransactionSpec<void, ExtrinsicParams<'sto', 'enableOffchainFunding'>>> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: { sto: txSto },
+      },
+    },
+    context,
+  } = this;
+  const { asset, id, offChainTicker } = args;
+
+  const rawAssetId = assetToMeshAssetId(asset, context);
+  const rawId = bigNumberToU64(id, context);
+  const rawTicker = stringToTicker(offChainTicker, context);
+
+  const offering = new Offering({ id, assetId: asset.id }, context);
+
+  const [
+    exists,
+    {
+      status: { timing, sale },
+    },
+  ] = await Promise.all([offering.exists(), offering.details()]);
+
+  if (!exists) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The Offering does not exist',
+      data: { id },
+    });
+  }
+
+  if (timing === OfferingTimingStatus.Expired) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The Offering has already ended',
+      data: { id },
+    });
+  }
+
+  if ([OfferingSaleStatus.Closed, OfferingSaleStatus.ClosedEarly].includes(sale)) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The Offering is already closed',
+    });
+  }
+
+  return {
+    transaction: txSto.enableOffchainFunding,
+    args: [rawAssetId, rawId, rawTicker],
+    resolver: undefined,
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void>,
+  { asset }: Params
+): ProcedureAuthorization {
+  return {
+    permissions: {
+      transactions: [TxTags.sto.EnableOffchainFunding],
+      assets: [asset],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const enableOffChainFundingForOfferings = (): Procedure<Params, void> =>
+  new Procedure(prepareEnableOffChainFundingForOfferings, getAuthorization);

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -43,6 +43,7 @@ import {
   MetadataType,
   MetadataValueDetails,
   NftCollection,
+  OffChainFundingReceipt,
   OfferingTier,
   PermissionedAccount,
   PermissionsLike,
@@ -1555,24 +1556,40 @@ export type ModifyOfferingTimesParams =
     }
   | { start: Date; end: Date | null };
 
-export interface InvestInOfferingParams {
-  /**
-   * portfolio in which the purchased Asset tokens will be stored
-   */
-  purchasePortfolio: PortfolioLike;
-  /**
-   * portfolio from which funds will be withdrawn to pay for the Asset tokens
-   */
-  fundingPortfolio: PortfolioLike;
-  /**
-   * amount of Asset tokens to purchase
-   */
-  purchaseAmount: BigNumber;
-  /**
-   * maximum average price to pay per Asset token (optional)
-   */
-  maxPrice?: BigNumber;
-}
+export type InvestInOfferingParams =
+  | {
+      /**
+       * portfolio in which the purchased Asset tokens will be stored
+       */
+      purchasePortfolio: PortfolioLike;
+      /**
+       * amount of Asset tokens to purchase
+       */
+      purchaseAmount: BigNumber;
+      /**
+       * maximum average price to pay per Asset token (optional)
+       */
+      maxPrice?: BigNumber;
+    } & (
+      | {
+          /**
+           * portfolio from which funds will be withdrawn to pay for the Asset tokens
+           */
+          fundingPortfolio: PortfolioLike;
+        }
+      | {
+          /**
+           * ticker of the offchain funding asset
+           */
+          offChainTicker: string;
+          /**
+           * (optional) offchain receipts required for investing via off chain funding
+           *
+           * Receipt can be generated using {@link api/entities/Offering!Offering.generateOffChainFundingReceipt | generateOffChainFundingReceipt} method
+           */
+          offChainFundingReceipt: OffChainFundingReceipt;
+        }
+    );
 
 export interface RenamePortfolioParams {
   name: string;

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1908,3 +1908,10 @@ export type InitiateCorporateActionParams = {
    */
   defaultTaxWithholding: BigNumber | null;
 };
+
+export interface EnableOffChainFundingParams {
+  /**
+   * The ticker of the off-chain asset
+   */
+  offChainTicker: string;
+}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -176,3 +176,4 @@ export { setStakingController } from '~/api/procedures/setStakingController';
 export { setStakingPayee } from '~/api/procedures/setStakingPayee';
 export { withdrawUnbondedPolyx } from '~/api/procedures/withdrawUnbondedPolyx';
 export { nominateValidators } from '~/api/procedures/nominateValidators';
+export { enableOffChainFundingForOfferings } from '~/api/procedures/enableOffChainFundingForOfferings';

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -71,6 +71,7 @@ import {
   MetadataValue,
   MultiSigProposalDetails,
   NftMetadata,
+  OffChainFundingDetails,
   OfferingBalanceStatus,
   OfferingDetails,
   OfferingSaleStatus,
@@ -316,6 +317,7 @@ interface OfferingOptions extends EntityOptions {
   id?: BigNumber;
   assetId?: string;
   details?: EntityGetter<OfferingDetails>;
+  offChainFundingDetails?: EntityGetter<OffChainFundingDetails>;
 }
 
 interface CheckpointOptions extends EntityOptions {
@@ -1743,6 +1745,7 @@ const MockOfferingClass = createMockEntityClass<OfferingOptions>(
     id!: BigNumber;
     asset!: FungibleAsset;
     details!: jest.Mock;
+    offChainFundingDetails!: jest.Mock;
 
     /**
      * @hidden
@@ -1759,6 +1762,7 @@ const MockOfferingClass = createMockEntityClass<OfferingOptions>(
       this.id = opts.id;
       this.asset = getFungibleAssetInstance({ assetId: opts.assetId });
       this.details = createEntityGetterMock(opts.details);
+      this.offChainFundingDetails = createEntityGetterMock(opts.offChainFundingDetails);
     }
   },
   () => ({
@@ -1786,6 +1790,9 @@ const MockOfferingClass = createMockEntityClass<OfferingOptions>(
       totalRemaining: new BigNumber(700000000),
       raisingCurrency: 'USD',
       minInvestment: new BigNumber(100000000),
+    },
+    offChainFundingDetails: {
+      enabled: false,
     },
     assetId: '12341234-1234-1234-1234-123412341234',
     id: new BigNumber(1),

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -161,6 +161,7 @@ import {
   NftLeg,
   NonFungiblePortfolioMovement,
   OffChainAffirmationReceipt,
+  OffChainFundingReceipt,
   OffChainLeg,
   OfferingBalanceStatus,
   OfferingSaleStatus,
@@ -325,6 +326,7 @@ import {
   nftInputToNftMetadataVec,
   nftMovementToPortfolioFund,
   nftToMeshNft,
+  offChainFundingReceiptDetailsToMeshReceiptDetails,
   offChainMetadataToMeshReceiptMetadata,
   offeringTierToPriceTier,
   percentageToPermill,
@@ -12729,5 +12731,40 @@ describe('exemptionToTransferExemption', () => {
       opType: StatType.Count,
       claimType: ClaimType.Jurisdiction,
     });
+  });
+});
+
+describe('offChainFundingReceiptDetailsToMeshReceiptDetails', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  it('should convert off chain funding receipt details to mesh receipt details', () => {
+    const context = dsMockUtils.getContextInstance();
+    jest.spyOn(utilsInternalModule, 'assertAddressValid').mockImplementation();
+
+    const fakeResult = 'fakeResult' as unknown as PolymeshPrimitivesStoFundraiserReceiptDetails;
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesStoFundraiserReceiptDetails', expect.any(Object))
+      .mockReturnValue(fakeResult);
+
+    const mockReceiptDetails: OffChainFundingReceipt = {
+      uid: new BigNumber(1),
+      signer: 'someSigner',
+      signature: {
+        type: SignerKeyRingType.Sr25519,
+        value: '0xsignature',
+      },
+      metadata: 'testMetadata',
+    };
+
+    const result = offChainFundingReceiptDetailsToMeshReceiptDetails(mockReceiptDetails, context);
+
+    expect(result).toEqual(fakeResult);
   });
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -248,6 +248,7 @@ import {
   NftMetadataInput,
   NonFungiblePortfolioMovement,
   OffChainAffirmationReceipt,
+  OffChainFundingReceipt,
   OfferingBalanceStatus,
   OfferingDetails,
   OfferingSaleStatus,
@@ -6150,5 +6151,23 @@ export function fundingToRawFunding(
 
   return context.createType('PalletStoFundingMethod', {
     OffChain: args.receiptDetails,
+  });
+}
+
+/**
+ * @hidden
+ */
+export function offChainFundingReceiptDetailsToMeshReceiptDetails(
+  receiptDetails: OffChainFundingReceipt,
+  context: Context
+): PolymeshPrimitivesStoFundraiserReceiptDetails {
+  const { uid, signer, signature, metadata } = receiptDetails;
+  const { address: signerAddress } = asAccount(signer, context);
+
+  return context.createType('PolymeshPrimitivesStoFundraiserReceiptDetails', {
+    uid: bigNumberToU64(uid, context),
+    signer: stringToAccountId(signerAddress, context),
+    signature: signatureToMeshRuntimeMultiSignature(signature.type, signature.value, context),
+    metadata: optionize(offChainMetadataToMeshReceiptMetadata)(metadata, context),
   });
 }


### PR DESCRIPTION
### Description

Adds support for - 
* Enabling off chain funding for a specific ticker for an offering
* Investing via off chain ticker

### Breaking Changes

`InvestInOfferingParams` has been changed to accept `fundingPortfolio` optionally when off chain investment is being done. New `offChainFundingReceipt` and `offChainTicker` are required when specifying off chain investment

### JIRA Link

DA-1531, DA-1525

### Checklist

- [ ] Updated the Readme.md (if required) ?
