### PR TITLE
feat: 🎸 Add support for filtering custom claim types

### DIFF
--- a/src/api/client/Claims.ts
+++ b/src/api/client/Claims.ts
@@ -15,13 +15,13 @@ import {
   claimsQuery,
   customClaimTypeQuery,
 } from '~/middleware/queries/claims';
-import { ClaimsOrderBy, ClaimTypeEnum, Query } from '~/middleware/types';
+import { ClaimsOrderBy, Query } from '~/middleware/types';
 import {
   CddClaim,
   ClaimData,
   ClaimOperation,
   ClaimScope,
-  ClaimType,
+  ClaimTypeInput,
   CustomClaim,
   CustomClaimType,
   CustomClaimTypeWithDid,
@@ -42,6 +42,7 @@ import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 import {
   bigNumberToU32,
   bytesToString,
+  claimTypeInputToMiddlewareClaimTypeDetails,
   identityIdToString,
   meshClaimToClaim,
   momentToDate,
@@ -197,7 +198,7 @@ export class Claims {
       targets?: (string | Identity)[];
       trustedClaimIssuers?: (string | Identity)[];
       scope?: Scope;
-      claimTypes?: ClaimType[];
+      claimTypes?: ClaimTypeInput[];
       includeExpired?: boolean;
       size?: BigNumber;
       start?: BigNumber;
@@ -222,8 +223,8 @@ export class Claims {
       trustedClaimIssuers: trustedClaimIssuers?.map(trustedClaimIssuer =>
         signerToString(trustedClaimIssuer)
       ),
-      claimTypes: Array.isArray(claimTypes) ? claimTypes.map(ct => ClaimTypeEnum[ct]) : undefined,
       includeExpired,
+      ...claimTypeInputToMiddlewareClaimTypeDetails(claimTypes),
     };
 
     if (!targets) {
@@ -293,7 +294,6 @@ export class Claims {
     if (isMiddlewareAvailable) {
       const { data, count, next } = await this.getIdentitiesWithClaims({
         targets: [did],
-        claimTypes: [ClaimType.Custom],
         includeExpired: false,
         size,
         start: new BigNumber(0),
@@ -331,7 +331,6 @@ export class Claims {
           promises.push(
             this.getIdentitiesWithClaims({
               targets: [did],
-              claimTypes: [ClaimType.Custom],
               includeExpired: false,
               start,
               size,
@@ -355,16 +354,6 @@ export class Claims {
 
     const identityClaimsFromChain = await context.getIdentityClaimsFromChain({
       targets: [did],
-      claimTypes: [
-        ClaimType.Accredited,
-        ClaimType.Affiliate,
-        ClaimType.Blocked,
-        ClaimType.BuyLockup,
-        ClaimType.Exempted,
-        ClaimType.Jurisdiction,
-        ClaimType.KnowYourCustomer,
-        ClaimType.SellLockup,
-      ],
       includeExpired: true,
     });
 

--- a/src/api/client/__tests__/Claims.ts
+++ b/src/api/client/__tests__/Claims.ts
@@ -109,7 +109,7 @@ describe('Claims Class', () => {
       jest.useRealTimers();
     });
 
-    it('should return a list of Identities with claims associated to them', async () => {
+    it('should return a list2 of Identities with claims associated to them', async () => {
       const targetDid = 'someTargetDid';
       const issuerDid = 'someIssuerDid';
       const date = 1589816265000;
@@ -171,6 +171,7 @@ describe('Claims Class', () => {
           trustedClaimIssuers: [issuerDid],
           claimTypes: [ClaimTypeEnum.CustomerDueDiligence],
           includeExpired: false,
+          scope: undefined,
         }),
         {
           claims: claimsQueryResponse,
@@ -583,7 +584,6 @@ describe('Claims Class', () => {
       when(getIdentitiesWithClaimsSpy)
         .calledWith({
           targets: [target],
-          claimTypes: [ClaimType.Custom],
           includeExpired: false,
           start: new BigNumber(0),
           size: new BigNumber(DEFAULT_GQL_PAGE_SIZE),
@@ -655,7 +655,6 @@ describe('Claims Class', () => {
       when(getIdentitiesWithClaimsSpy)
         .calledWith({
           targets: [target],
-          claimTypes: [ClaimType.Custom],
           includeExpired: false,
           start: next,
           size: new BigNumber(DEFAULT_GQL_PAGE_SIZE),

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -313,9 +313,11 @@ export interface ClaimScope {
   assetId?: string | undefined;
 }
 
-export type TrustedFor =
-  | Exclude<ClaimType, ClaimType.Custom>
-  | { type: ClaimType.Custom; customClaimTypeId: BigNumber };
+export type CustomClaimWithTypeId = { type: ClaimType.Custom; customClaimTypeId: BigNumber };
+
+export type TrustedFor = Exclude<ClaimType, ClaimType.Custom> | CustomClaimWithTypeId;
+
+export type ClaimTypeInput = TrustedFor;
 
 /**
  * @param IsDefault - whether the Identity is a default trusted claim issuer for an asset or just

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -1260,6 +1260,8 @@ describe('Context class', () => {
       const cddId = 'someCddId';
       const date = 1589816265000;
       const customerDueDiligenceType = ClaimTypeEnum.CustomerDueDiligence;
+      const customClaimType = ClaimTypeEnum.Custom;
+      const customClaimTypeId = new BigNumber(1);
       const claim = {
         target: expect.objectContaining({ did: targetDid }),
         issuer: expect.objectContaining({ did: issuerDid }),
@@ -1279,8 +1281,9 @@ describe('Context class', () => {
           ...claim,
           expiry: null,
           claim: {
-            type: customerDueDiligenceType,
-            id: cddId,
+            type: customClaimType,
+            customClaimTypeId,
+            scope: {},
           },
         },
       ];
@@ -1302,7 +1305,9 @@ describe('Context class', () => {
           {
             ...commonClaimData,
             expiry: null,
-            type: customerDueDiligenceType,
+            type: customClaimType,
+            customClaimTypeId,
+            scope: undefined,
           },
         ],
       };
@@ -1313,7 +1318,8 @@ describe('Context class', () => {
           {
             dids: [targetDid],
             trustedClaimIssuers: [targetDid],
-            claimTypes: [ClaimTypeEnum.Accredited],
+            claimTypes: [ClaimTypeEnum.CustomerDueDiligence],
+            customClaimTypeIds: [customClaimTypeId.toString()],
             includeExpired: true,
           },
           new BigNumber(2),
@@ -1327,7 +1333,13 @@ describe('Context class', () => {
       let result = await context.issuedClaims({
         targets: [targetDid],
         trustedClaimIssuers: [targetDid],
-        claimTypes: [ClaimType.Accredited],
+        claimTypes: [
+          ClaimType.CustomerDueDiligence,
+          {
+            type: ClaimType.Custom,
+            customClaimTypeId,
+          },
+        ],
         includeExpired: true,
         size: new BigNumber(2),
         start: new BigNumber(0),
@@ -1493,6 +1505,17 @@ describe('Context class', () => {
       });
 
       expect(result.data.length).toEqual(0);
+
+      const customClaimTypeId = new BigNumber(1);
+
+      dsMockUtils.createQueryMock('identity', 'customClaims', {
+        entries: [
+          tuple(
+            [dsMockUtils.createMockU32(customClaimTypeId), dsMockUtils.createMockOption()],
+            dsMockUtils.createMockOption(dsMockUtils.createMockBytes('custom Claim'))
+          ),
+        ],
+      });
 
       result = await context.issuedClaims({
         targets: [targetDid],

--- a/src/middleware/__tests__/queries/claims.ts
+++ b/src/middleware/__tests__/queries/claims.ts
@@ -36,6 +36,7 @@ describe('claimsQuery', () => {
       scope: { type: ClaimScopeTypeEnum.Asset, value: '0x12341234123412341234123412341234' },
       trustedClaimIssuers: ['someTrustedClaim'],
       claimTypes: [ClaimTypeEnum.Accredited],
+      customClaimTypeIds: ['123', '456'],
       includeExpired: true,
       size: DEFAULT_GQL_PAGE_SIZE,
       start: 0,
@@ -64,11 +65,12 @@ describe('claimsQuery', () => {
   });
 
   it('should not include undefined values in the variables', () => {
-    const result = claimsQuery(false, { includeExpired: true });
+    const result = claimsQuery(false, { includeExpired: true, customClaimTypeIds: ['123', '456'] });
     expect(result.variables).toEqual({
       includeExpired: true,
       size: DEFAULT_GQL_PAGE_SIZE,
       start: 0,
+      customClaimTypeIds: ['123', '456'],
     });
   });
 });


### PR DESCRIPTION
### Description

This adds support to filter targeting claims, issued claims etc for custom type claims as well.

### Breaking Changes

BREAKING CHANGE: 🧨 Type of attribute `claimTypes` (present as filtering option in getters in number of methods in Claims namespace ) has been changed from `ClaimType` to `ClaimTypeInput`

### JIRA Link

DA-1537

### Checklist

- [ ] Updated the Readme.md (if required) ?
