### PR TITLE
feat: 🎸 support preparing a POLYX transfer via a multisig signer

### DIFF
--- a/src/api/procedures/__tests__/createTransactionBatch.ts
+++ b/src/api/procedures/__tests__/createTransactionBatch.ts
@@ -19,7 +19,7 @@ import { CreateTransactionBatchParams, TxTags } from '~/types';
 import { BatchTransactionSpec, PolymeshTx, ProcedureAuthorization } from '~/types/internal';
 import * as utilsInternalModule from '~/utils/internal';
 
-type ReturnValues = [number, number];
+type ReturnValues = number[];
 type SingleReturnValues = [number];
 
 describe('createTransactionBatch procedure', () => {
@@ -80,6 +80,7 @@ describe('createTransactionBatch procedure', () => {
         TxTags.portfolio.CreatePortfolio,
       ],
       resolvers: [(): number => 1, (): number => 2],
+      preRunValidations: [],
     });
 
     const result = await prepareCreateTransactionBatch.call<
@@ -112,6 +113,7 @@ describe('createTransactionBatch procedure', () => {
         processedTransactions: [],
         tags,
         resolvers: [],
+        preRunValidations: [],
       });
 
       const boundFunc = (getAuthorization as (this: typeof proc) => ProcedureAuthorization).bind(
@@ -202,6 +204,7 @@ describe('createTransactionBatch procedure', () => {
           TxTags.portfolio.CreatePortfolio,
         ],
         resolvers: [expect.any(Function), expect.any(Function)],
+        preRunValidations: [undefined, undefined],
       });
 
       jest.spyOn(utilsInternalModule, 'sliceBatchReceipt').mockImplementation();
@@ -250,6 +253,7 @@ describe('createTransactionBatch procedure', () => {
       ],
       tags: [TxTags.portfolio.CreatePortfolio],
       resolvers: [expect.any(Function)],
+      preRunValidations: [undefined],
     });
 
     jest.spyOn(utilsInternalModule, 'sliceBatchReceipt').mockImplementation();
@@ -295,6 +299,7 @@ describe('createTransactionBatch procedure', () => {
       ],
       tags: [TxTags.portfolio.CreatePortfolio],
       resolvers: [expect.any(Function)],
+      preRunValidations: [undefined],
     });
 
     jest.spyOn(utilsInternalModule, 'sliceBatchReceipt').mockImplementation();
@@ -340,10 +345,203 @@ describe('createTransactionBatch procedure', () => {
       ],
       tags: [TxTags.portfolio.CreatePortfolio],
       resolvers: [expect.any(Function)],
+      preRunValidations: [undefined],
     });
 
     jest.spyOn(utilsInternalModule, 'sliceBatchReceipt').mockImplementation();
 
     await expect(result!.resolvers[0]!({} as ISubmittableResult)).resolves.toBe(3);
+  });
+
+  it('should combine preRunValidation functions from multiple transactions', async () => {
+    const validation1 = jest.fn().mockResolvedValue(undefined);
+    const validation2 = jest.fn().mockResolvedValue(undefined);
+
+    const transactions = [
+      new PolymeshTransaction(
+        {
+          transaction: tx1,
+          args: ['tx1'] as unknown[],
+          resolver: 1,
+          signingAddress: 'someAddress',
+          signer: {} as PolkadotSigner,
+          mortality: { immortal: false },
+          preRunValidation: validation1,
+        },
+        mockContext
+      ),
+      new PolymeshTransaction(
+        {
+          transaction: tx2,
+          args: ['tx2'] as unknown[],
+          resolver: 2,
+          signingAddress: 'someAddress',
+          signer: {} as PolkadotSigner,
+          mortality: { immortal: false },
+          preRunValidation: validation2,
+        },
+        mockContext
+      ),
+    ] as const;
+
+    const proc = procedureMockUtils.getInstance<
+      CreateTransactionBatchParams<ReturnValues>,
+      ReturnValues,
+      Storage
+    >(mockContext);
+
+    const boundFunc = (
+      prepareStorage as (
+        this: typeof proc,
+        args: CreateTransactionBatchParams<ReturnValues>
+      ) => Storage
+    ).bind(proc);
+
+    const result = boundFunc({ transactions });
+
+    expect(result.preRunValidations).toEqual([validation1, validation2]);
+
+    // Test that prepareCreateTransactionBatch combines them
+    const batchProc = procedureMockUtils.getInstance<
+      CreateTransactionBatchParams<ReturnValues>,
+      ReturnValues,
+      Storage
+    >(mockContext, result);
+
+    const batchResult = await prepareCreateTransactionBatch.call<
+      typeof batchProc,
+      never[],
+      Promise<BatchTransactionSpec<ReturnValues, unknown[][]>>
+    >(batchProc);
+
+    expect(batchResult.preRunValidation).toBeDefined();
+
+    // Call the combined validation
+    await batchResult.preRunValidation!({ asProposal: true });
+
+    expect(validation1).toHaveBeenCalledWith({ asProposal: true });
+    expect(validation2).toHaveBeenCalledWith({ asProposal: true });
+  });
+
+  it('should handle mixed transactions with and without preRunValidation', async () => {
+    const validation1 = jest.fn().mockResolvedValue(undefined);
+    const validation2 = jest.fn().mockResolvedValue(undefined);
+
+    const transactions = [
+      new PolymeshTransaction(
+        {
+          transaction: tx1,
+          args: ['tx1'] as unknown[],
+          resolver: 1,
+          signingAddress: 'someAddress',
+          signer: {} as PolkadotSigner,
+          mortality: { immortal: false },
+          preRunValidation: validation1,
+        },
+        mockContext
+      ),
+      new PolymeshTransaction(
+        {
+          transaction: tx2,
+          args: ['tx2'] as unknown[],
+          resolver: 2,
+          signingAddress: 'someAddress',
+          signer: {} as PolkadotSigner,
+          mortality: { immortal: false },
+        },
+        mockContext
+      ),
+      new PolymeshTransaction(
+        {
+          transaction: tx3,
+          args: ['tx3'] as unknown[],
+          resolver: 3,
+          signingAddress: 'someAddress',
+          signer: {} as PolkadotSigner,
+          mortality: { immortal: false },
+          preRunValidation: validation2,
+        },
+        mockContext
+      ),
+    ] as const;
+
+    const proc = procedureMockUtils.getInstance<
+      CreateTransactionBatchParams<ReturnValues>,
+      ReturnValues,
+      Storage
+    >(mockContext);
+
+    const boundFunc = (
+      prepareStorage as (
+        this: typeof proc,
+        args: CreateTransactionBatchParams<ReturnValues>
+      ) => Storage
+    ).bind(proc);
+
+    const result = boundFunc({ transactions });
+
+    const batchProc = procedureMockUtils.getInstance<
+      CreateTransactionBatchParams<ReturnValues>,
+      ReturnValues,
+      Storage
+    >(mockContext, result);
+
+    const batchResult = await prepareCreateTransactionBatch.call<
+      typeof batchProc,
+      never[],
+      Promise<BatchTransactionSpec<ReturnValues, unknown[][]>>
+    >(batchProc);
+
+    expect(batchResult.preRunValidation).toBeDefined();
+
+    await batchResult.preRunValidation!({ asProposal: false });
+
+    expect(validation1).toHaveBeenCalledWith({ asProposal: false });
+    expect(validation2).toHaveBeenCalledWith({ asProposal: false });
+  });
+
+  it('should not include preRunValidation if no transactions have it', async () => {
+    const transactions = [
+      new PolymeshTransaction(
+        {
+          transaction: tx1,
+          args: ['tx1'] as unknown[],
+          resolver: 1,
+          signingAddress: 'someAddress',
+          signer: {} as PolkadotSigner,
+          mortality: { immortal: false },
+        },
+        mockContext
+      ),
+    ] as const;
+
+    const proc = procedureMockUtils.getInstance<
+      CreateTransactionBatchParams<SingleReturnValues>,
+      SingleReturnValues,
+      Storage
+    >(mockContext);
+
+    const boundFunc = (
+      prepareStorage as (
+        this: typeof proc,
+        args: CreateTransactionBatchParams<SingleReturnValues>
+      ) => Storage
+    ).bind(proc);
+
+    const result = boundFunc({ transactions });
+
+    const batchProc = procedureMockUtils.getInstance<
+      CreateTransactionBatchParams<SingleReturnValues>,
+      SingleReturnValues,
+      Storage
+    >(mockContext, result);
+
+    const batchResult = await prepareCreateTransactionBatch.call<
+      typeof batchProc,
+      never[],
+      Promise<BatchTransactionSpec<SingleReturnValues, unknown[][]>>
+    >(batchProc);
+
+    expect(batchResult.preRunValidation).toBeUndefined();
   });
 });

--- a/src/api/procedures/__tests__/transferPolyx.ts
+++ b/src/api/procedures/__tests__/transferPolyx.ts
@@ -2,10 +2,10 @@ import { PolymeshPrimitivesMemo } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 
 import { getAuthorization, prepareTransferPolyx } from '~/api/procedures/transferPolyx';
-import { Context } from '~/internal';
+import { Context, PolymeshError } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { TransferPolyxParams } from '~/types';
+import { ErrorCode, TransferPolyxParams } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as utilsInternalModule from '~/utils/internal';
 
@@ -44,20 +44,7 @@ describe('transferPolyx procedure', () => {
     jest.restoreAllMocks();
   });
 
-  it('should throw an error if the user has insufficient balance to transfer', () => {
-    dsMockUtils.createQueryMock('identity', 'didRecords', { returnValue: {} });
-
-    const proc = procedureMockUtils.getInstance<TransferPolyxParams, void>(mockContext);
-
-    return expect(
-      prepareTransferPolyx.call(proc, {
-        to: 'someAccount',
-        amount: new BigNumber(101),
-      })
-    ).rejects.toThrow('Insufficient free balance');
-  });
-
-  it('should return a balance transfer transaction spec', async () => {
+  it('should return a balance transfer transaction spec with preRunValidation', async () => {
     const to = entityMockUtils.getAccountInstance({ address: 'someAccount' });
     const amount = new BigNumber(99);
     const memo = 'someMessage';
@@ -69,19 +56,21 @@ describe('transferPolyx procedure', () => {
     jest.spyOn(utilsConversionModule, 'bigNumberToBalance').mockReturnValue(rawAmount);
     jest.spyOn(utilsConversionModule, 'stringToMemo').mockReturnValue(rawMemo);
 
-    let tx = dsMockUtils.createTxMock('balances', 'transfer');
     const proc = procedureMockUtils.getInstance<TransferPolyxParams, void>(mockContext);
+
+    let tx = dsMockUtils.createTxMock('balances', 'transfer');
 
     let result = await prepareTransferPolyx.call(proc, {
       to,
       amount,
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       transaction: tx,
       args: [rawAccount, rawAmount],
       resolver: undefined,
     });
+    expect(result.preRunValidation).toBeDefined();
 
     tx = dsMockUtils.createTxMock('balances', 'transferWithMemo');
 
@@ -91,10 +80,159 @@ describe('transferPolyx procedure', () => {
       memo,
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       transaction: tx,
       args: [rawAccount, rawAmount, rawMemo],
       resolver: undefined,
+    });
+    expect(result.preRunValidation).toBeDefined();
+  });
+
+  describe('preRunValidation', () => {
+    it('should check signing account balance when asProposal is false', async () => {
+      const amount = new BigNumber(101);
+      const signingAccount = entityMockUtils.getAccountInstance({
+        address: 'signerAddress',
+        getBalance: {
+          free: new BigNumber(100),
+          locked: new BigNumber(0),
+          total: new BigNumber(100),
+        },
+      });
+
+      const rawAccount = dsMockUtils.createMockAccountId('someAccount');
+      const rawAmount = dsMockUtils.createMockBalance(amount);
+
+      jest.spyOn(utilsConversionModule, 'stringToAccountId').mockReturnValue(rawAccount);
+      jest.spyOn(utilsConversionModule, 'bigNumberToBalance').mockReturnValue(rawAmount);
+      dsMockUtils.createTxMock('balances', 'transfer');
+
+      mockContext.getSigningAccount.mockReturnValue(signingAccount);
+
+      const proc = procedureMockUtils.getInstance<TransferPolyxParams, void>(mockContext);
+
+      const result = await prepareTransferPolyx.call(proc, {
+        to: 'someAccount',
+        amount,
+      });
+
+      await expect(result.preRunValidation!({ asProposal: false })).rejects.toThrow(
+        new PolymeshError({
+          code: ErrorCode.InsufficientBalance,
+          message: 'Insufficient free balance',
+          data: {
+            freeBalance: new BigNumber(100),
+            fromAccount: 'signerAddress',
+          },
+        })
+      );
+    });
+
+    it('should check acting account balance when asProposal is true', async () => {
+      const amount = new BigNumber(101);
+      const signingAccount = entityMockUtils.getAccountInstance({
+        address: 'signerAddress',
+      });
+      const actingAccount = entityMockUtils.getAccountInstance({
+        address: 'multiSigAddress',
+        getBalance: {
+          free: new BigNumber(100),
+          locked: new BigNumber(0),
+          total: new BigNumber(100),
+        },
+      });
+
+      const rawAccount = dsMockUtils.createMockAccountId('someAccount');
+      const rawAmount = dsMockUtils.createMockBalance(amount);
+
+      jest.spyOn(utilsConversionModule, 'stringToAccountId').mockReturnValue(rawAccount);
+      jest.spyOn(utilsConversionModule, 'bigNumberToBalance').mockReturnValue(rawAmount);
+      dsMockUtils.createTxMock('balances', 'transfer');
+
+      mockContext.getSigningAccount.mockReturnValue(signingAccount);
+      mockContext.getActingAccount.mockResolvedValue(actingAccount);
+
+      const proc = procedureMockUtils.getInstance<TransferPolyxParams, void>(mockContext);
+
+      const result = await prepareTransferPolyx.call(proc, {
+        to: 'someAccount',
+        amount,
+      });
+
+      await expect(result.preRunValidation!({ asProposal: true })).rejects.toThrow(
+        new PolymeshError({
+          code: ErrorCode.InsufficientBalance,
+          message: 'Insufficient free balance',
+          data: {
+            freeBalance: new BigNumber(100),
+            fromAccount: 'multiSigAddress',
+          },
+        })
+      );
+    });
+
+    it('should pass validation when signing account has sufficient balance (asProposal=false)', async () => {
+      const amount = new BigNumber(50);
+      const signingAccount = entityMockUtils.getAccountInstance({
+        address: 'signerAddress',
+        getBalance: {
+          free: new BigNumber(100),
+          locked: new BigNumber(0),
+          total: new BigNumber(100),
+        },
+      });
+
+      const rawAccount = dsMockUtils.createMockAccountId('someAccount');
+      const rawAmount = dsMockUtils.createMockBalance(amount);
+
+      jest.spyOn(utilsConversionModule, 'stringToAccountId').mockReturnValue(rawAccount);
+      jest.spyOn(utilsConversionModule, 'bigNumberToBalance').mockReturnValue(rawAmount);
+      dsMockUtils.createTxMock('balances', 'transfer');
+
+      mockContext.getSigningAccount.mockReturnValue(signingAccount);
+
+      const proc = procedureMockUtils.getInstance<TransferPolyxParams, void>(mockContext);
+
+      const result = await prepareTransferPolyx.call(proc, {
+        to: 'someAccount',
+        amount,
+      });
+
+      await expect(result.preRunValidation!({ asProposal: false })).resolves.not.toThrow();
+    });
+
+    it('should pass validation when acting account has sufficient balance (asProposal=true)', async () => {
+      const amount = new BigNumber(50);
+      const signingAccount = entityMockUtils.getAccountInstance({
+        address: 'signerAddress',
+      });
+      const actingAccount = entityMockUtils.getAccountInstance({
+        address: 'multiSigAddress',
+        getBalance: {
+          free: new BigNumber(100),
+          locked: new BigNumber(0),
+          total: new BigNumber(100),
+        },
+      });
+
+      const rawAccount = dsMockUtils.createMockAccountId('someAccount');
+      const rawAmount = dsMockUtils.createMockBalance(amount);
+
+      jest.spyOn(utilsConversionModule, 'stringToAccountId').mockReturnValue(rawAccount);
+      jest.spyOn(utilsConversionModule, 'bigNumberToBalance').mockReturnValue(rawAmount);
+      dsMockUtils.createTxMock('balances', 'transfer');
+
+      mockContext.getSigningAccount.mockReturnValue(signingAccount);
+      mockContext.getActingAccount.mockResolvedValue(actingAccount);
+
+      const proc = procedureMockUtils.getInstance<TransferPolyxParams, void>(mockContext);
+
+      const result = await prepareTransferPolyx.call(proc, {
+        to: 'someAccount',
+        amount,
+      });
+
+      await expect(result.preRunValidation!({ asProposal: true })).resolves.not.toThrow();
     });
   });
 

--- a/src/api/procedures/createTransactionBatch.ts
+++ b/src/api/procedures/createTransactionBatch.ts
@@ -20,6 +20,7 @@ export interface Storage {
   processedTransactions: TxWithArgs[];
   tags: TxTag[];
   resolvers: ResolverFunction<unknown>[];
+  preRunValidations: (((args: { asProposal: boolean }) => Promise<void>) | undefined)[];
 }
 
 /**
@@ -28,12 +29,27 @@ export interface Storage {
 export async function prepareCreateTransactionBatch<ReturnValues extends unknown[]>(
   this: Procedure<CreateTransactionBatchParams<ReturnValues>, ReturnValues, Storage>
 ): Promise<BatchTransactionSpec<ReturnValues, unknown[][]>> {
-  const { processedTransactions: transactions, resolvers } = this.storage;
+  const { processedTransactions: transactions, resolvers, preRunValidations } = this.storage;
+
+  // Combine all preRunValidation functions into one
+  const combinedPreRunValidation = preRunValidations.some(v => v !== undefined)
+    ? async (args: { asProposal: boolean }): Promise<void> => {
+        await Promise.all(
+          preRunValidations.map(validation => {
+            if (validation) {
+              return validation(args);
+            }
+            return Promise.resolve();
+          })
+        );
+      }
+    : undefined;
 
   return {
     transactions,
     resolver: receipt =>
       Promise.all(resolvers.map(resolver => resolver(receipt))) as Promise<ReturnValues>,
+    preRunValidation: combinedPreRunValidation,
   };
 }
 
@@ -66,6 +82,7 @@ export function prepareStorage<ReturnValues extends unknown[]>(
   const resolvers: ResolverFunction<unknown>[] = [];
   const transactions: TxWithArgs[] = [];
   const tags: TxTag[] = [];
+  const preRunValidations: (((args: { asProposal: boolean }) => Promise<void>) | undefined)[] = [];
 
   /*
    * We extract each transaction spec and build an array of all transactions (with args and fees), resolvers and transformers,
@@ -81,7 +98,7 @@ export function prepareStorage<ReturnValues extends unknown[]>(
 
   if (inputTransactions.length === 1 && isPolymeshTransaction(firstTx)) {
     const spec = PolymeshTransaction.toTransactionSpec(firstTx);
-    const { transaction: tx, args: txArgs, fee, feeMultiplier } = spec;
+    const { transaction: tx, args: txArgs, fee, feeMultiplier, preRunValidation } = spec;
 
     transactions.push({
       transaction: tx,
@@ -91,6 +108,7 @@ export function prepareStorage<ReturnValues extends unknown[]>(
     });
 
     tags.push(transactionToTxTag(tx));
+    preRunValidations.push(preRunValidation);
 
     const { transformer = identity, resolver } = spec;
 
@@ -110,17 +128,18 @@ export function prepareStorage<ReturnValues extends unknown[]>(
       processedTransactions: transactions,
       resolvers,
       tags,
+      preRunValidations,
     };
   }
 
-  inputTransactions.forEach(transaction => {
+  for (const transaction of inputTransactions) {
     let spec: TransactionSpec<unknown, unknown[]> | BatchTransactionSpec<unknown, unknown[][]>;
 
     const startIndex = transactions.length;
 
     if (isPolymeshTransaction(transaction)) {
       spec = PolymeshTransaction.toTransactionSpec(transaction);
-      const { transaction: tx, args: txArgs, fee, feeMultiplier } = spec;
+      const { transaction: tx, args: txArgs, fee, feeMultiplier, preRunValidation } = spec;
 
       transactions.push({
         transaction: tx,
@@ -130,11 +149,12 @@ export function prepareStorage<ReturnValues extends unknown[]>(
       });
 
       tags.push(transactionToTxTag(tx));
+      preRunValidations.push(preRunValidation);
     } else {
       spec = PolymeshTransactionBatch.toTransactionSpec(transaction);
-      const { transactions: batchTransactions } = spec;
+      const { transactions: batchTransactions, preRunValidation } = spec;
 
-      batchTransactions.forEach(({ transaction: tx, args: txArgs, fee, feeMultiplier }) => {
+      for (const { transaction: tx, args: txArgs, fee, feeMultiplier } of batchTransactions) {
         transactions.push({
           transaction: tx,
           args: txArgs,
@@ -143,7 +163,9 @@ export function prepareStorage<ReturnValues extends unknown[]>(
         });
 
         tags.push(transactionToTxTag(tx));
-      });
+      }
+
+      preRunValidations.push(preRunValidation);
     }
 
     const { transformer = identity, resolver } = spec;
@@ -165,12 +187,13 @@ export function prepareStorage<ReturnValues extends unknown[]>(
 
       return transformer(value);
     });
-  });
+  }
 
   return {
     processedTransactions: transactions,
     resolvers,
     tags,
+    preRunValidations,
   };
 }
 

--- a/src/api/procedures/transferPolyx.ts
+++ b/src/api/procedures/transferPolyx.ts
@@ -1,4 +1,4 @@
-import { PolymeshError, Procedure } from '~/internal';
+import { Account, PolymeshError, Procedure } from '~/internal';
 import { ErrorCode, TransferPolyxParams } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import {
@@ -11,7 +11,7 @@ import {
 /**
  * @hidden
  */
-export async function prepareTransferPolyx(
+export function prepareTransferPolyx(
   this: Procedure<TransferPolyxParams>,
   args: TransferPolyxParams
 ): Promise<
@@ -28,34 +28,49 @@ export async function prepareTransferPolyx(
   const { to, amount, memo } = args;
 
   const rawAccountId = stringToAccountId(signerToString(to), context);
-
-  const { free: freeBalance } = await context.accountBalance();
-
-  if (amount.isGreaterThan(freeBalance)) {
-    throw new PolymeshError({
-      code: ErrorCode.InsufficientBalance,
-      message: 'Insufficient free balance',
-      data: {
-        freeBalance,
-      },
-    });
-  }
-
   const rawAmount = bigNumberToBalance(amount, context);
 
+  const preRunValidation = async ({ asProposal }: { asProposal: boolean }): Promise<void> => {
+    const signingAccount = context.getSigningAccount();
+    let fromAccount: Account;
+
+    if (asProposal) {
+      // Running as proposal - use MultiSig account balance
+      fromAccount = await context.getActingAccount();
+    } else {
+      // Running directly - use signing account balance
+      fromAccount = signingAccount;
+    }
+
+    const { free: freeBalance } = await fromAccount.getBalance();
+
+    if (amount.isGreaterThan(freeBalance)) {
+      throw new PolymeshError({
+        code: ErrorCode.InsufficientBalance,
+        message: 'Insufficient free balance',
+        data: {
+          freeBalance,
+          fromAccount: fromAccount.address,
+        },
+      });
+    }
+  };
+
   if (memo) {
-    return {
+    return Promise.resolve({
       transaction: tx.balances.transferWithMemo,
       args: [rawAccountId, rawAmount, stringToMemo(memo, context)],
       resolver: undefined,
-    };
+      preRunValidation,
+    });
   }
 
-  return {
+  return Promise.resolve({
     transaction: tx.balances.transfer,
     args: [rawAccountId, rawAmount],
     resolver: undefined,
-  };
+    preRunValidation,
+  });
 }
 
 /**

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -65,13 +65,14 @@ export abstract class PolymeshTransactionBase<
   public static toTransactionSpec<R, T>(
     transaction: PolymeshTransactionBase<R, T>
   ): BaseTransactionSpec<R, T> {
-    const { resolver, transformer, paidForBy, multiSig } = transaction;
+    const { resolver, transformer, paidForBy, multiSig, preRunValidation } = transaction;
 
     return {
       resolver,
       transformer,
       paidForBy,
       multiSig,
+      preRunValidation,
     };
   }
 
@@ -178,6 +179,13 @@ export abstract class PolymeshTransactionBase<
     | undefined
     | ((result: ReturnValue) => Promise<TransformedReturnValue> | TransformedReturnValue);
 
+  /**
+   * @hidden
+   *
+   * Optional validation function that runs before the transaction. Receives an object indicating whether it's running as a proposal.
+   */
+  protected preRunValidation?: ((args: { asProposal: boolean }) => Promise<void>) | undefined;
+
   protected context: Context;
 
   /**
@@ -209,6 +217,7 @@ export abstract class PolymeshTransactionBase<
       mortality,
       multiSig,
       multiSigOpts,
+      preRunValidation,
     } = transactionSpec;
 
     this.signingAddress = signingAddress;
@@ -220,6 +229,7 @@ export abstract class PolymeshTransactionBase<
     this.paidForBy = paidForBy;
     this.transformer = transformer;
     this.resolver = resolver;
+    this.preRunValidation = preRunValidation;
   }
 
   /**
@@ -243,6 +253,10 @@ export abstract class PolymeshTransactionBase<
     }
 
     try {
+      if (this.preRunValidation) {
+        await this.preRunValidation({ asProposal: true });
+      }
+
       await this.assertFeesCovered();
 
       const receipt = await this.internalRun();
@@ -286,6 +300,10 @@ export abstract class PolymeshTransactionBase<
     }
 
     try {
+      if (this.preRunValidation) {
+        await this.preRunValidation({ asProposal: false });
+      }
+
       await this.assertFeesCovered();
 
       const receipt = await this.internalRun();

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -90,6 +90,33 @@ describe('Polymesh Transaction Base class', () => {
         resolver,
         transformer,
         paidForBy,
+        preRunValidation: undefined,
+      });
+    });
+
+    it('should include preRunValidation in the returned spec', () => {
+      const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+      const args = tuple('BAR');
+      const resolver = (): number => 1;
+      const preRunValidation = jest.fn().mockResolvedValue(undefined);
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver,
+          preRunValidation,
+        },
+        context
+      );
+
+      expect(PolymeshTransactionBase.toTransactionSpec(tx)).toEqual({
+        multiSig: null,
+        resolver,
+        transformer: undefined,
+        paidForBy: undefined,
+        preRunValidation,
       });
     });
   });
@@ -954,6 +981,73 @@ describe('Polymesh Transaction Base class', () => {
 
       return expect(tx.run()).rejects.toThrow(expectedError);
     });
+
+    it('should call preRunValidation with false before running the transaction', async () => {
+      const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+      const args = tuple('VALIDATION_TEST');
+      const preRunValidation = jest.fn().mockResolvedValue(undefined);
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver: undefined,
+          preRunValidation,
+        },
+        context
+      );
+
+      await tx.run();
+
+      expect(preRunValidation).toHaveBeenCalledWith({ asProposal: false });
+      expect(transaction).toHaveBeenCalledWith(...args);
+    });
+
+    it('should throw an error if preRunValidation fails', async () => {
+      const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+      const args = tuple('VALIDATION_FAILURE_TEST');
+      const validationError = new PolymeshError({
+        code: ErrorCode.InsufficientBalance,
+        message: 'Insufficient balance',
+      });
+      const preRunValidation = jest.fn().mockRejectedValue(validationError);
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver: undefined,
+          preRunValidation,
+        },
+        context
+      );
+
+      await expect(tx.run()).rejects.toThrow(validationError);
+      expect(preRunValidation).toHaveBeenCalledWith({ asProposal: false });
+      expect(transaction).not.toHaveBeenCalled();
+    });
+
+    it('should not call preRunValidation if it is not provided', async () => {
+      const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+      const args = tuple('NO_VALIDATION_TEST');
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args,
+          resolver: undefined,
+        },
+        context
+      );
+
+      await tx.run();
+
+      expect(transaction).toHaveBeenCalledWith(...args);
+      expect(tx.status).toBe(TransactionStatus.Succeeded);
+    });
   });
 
   describe('method: runAsProposal', () => {
@@ -1163,6 +1257,90 @@ describe('Polymesh Transaction Base class', () => {
       );
 
       await expect(tx.runAsProposal()).rejects.toThrow(PolymeshError);
+    });
+
+    it('should call preRunValidation with true before running as proposal', async () => {
+      const underlyingTx = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+      const args = [dsMockUtils.createMockText('VALIDATION_PROPOSAL_TEST')];
+      const preRunValidation = jest.fn().mockResolvedValue(undefined);
+
+      dsMockUtils.createTxMock('multiSig', 'createProposal', {
+        autoResolve: MockTxStatus.Succeeded,
+      });
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction: underlyingTx,
+          args,
+          resolver: 3,
+          multiSig,
+          preRunValidation,
+        },
+        context
+      );
+
+      await tx.runAsProposal();
+
+      expect(preRunValidation).toHaveBeenCalledWith({ asProposal: true });
+      expect(underlyingTx).toHaveBeenCalledWith(...args);
+    });
+
+    it('should throw an error if preRunValidation fails when running as proposal', async () => {
+      const underlyingTx = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+      const args = [dsMockUtils.createMockText('VALIDATION_FAILURE_PROPOSAL_TEST')];
+      const validationError = new PolymeshError({
+        code: ErrorCode.InsufficientBalance,
+        message: 'MultiSig has insufficient balance',
+      });
+      const preRunValidation = jest.fn().mockRejectedValue(validationError);
+
+      dsMockUtils.createTxMock('multiSig', 'createProposal', {
+        autoResolve: MockTxStatus.Succeeded,
+      });
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction: underlyingTx,
+          args,
+          resolver: 3,
+          multiSig,
+          preRunValidation,
+        },
+        context
+      );
+
+      await expect(tx.runAsProposal()).rejects.toThrow(validationError);
+      expect(preRunValidation).toHaveBeenCalledWith({ asProposal: true });
+      expect(underlyingTx).not.toHaveBeenCalled();
+    });
+
+    it('should not call preRunValidation if it is not provided when running as proposal', async () => {
+      const underlyingTx = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+      const args = [dsMockUtils.createMockText('NO_VALIDATION_PROPOSAL_TEST')];
+
+      const transaction = dsMockUtils.createTxMock('multiSig', 'createProposal', {
+        autoResolve: MockTxStatus.Succeeded,
+      });
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction: underlyingTx,
+          args,
+          resolver: 3,
+          multiSig,
+        },
+        context
+      );
+
+      const result = await tx.runAsProposal();
+
+      expect(underlyingTx).toHaveBeenCalledWith(...args);
+      expect(transaction).toHaveBeenCalled();
+      expect(result).toBeInstanceOf(MultiSigProposal);
+      expect(tx.status).toBe(TransactionStatus.Succeeded);
     });
   });
 

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -881,7 +881,8 @@ function configureContext(opts: ContextOptions): void {
     : getSigningAccount.mockImplementation(() => {
         throw new Error('There is no Account associated with the SDK');
       });
-  const getActingAccount = getSigningAccount;
+  const getActingAccount = jest.fn();
+  getActingAccount.mockImplementation(() => getSigningAccount());
   const signingAddress = opts.withSigningManager ? opts.signingAddress : undefined;
   const getSigningAddress = jest.fn();
   opts.withSigningManager

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -186,6 +186,13 @@ export interface BaseTransactionSpec<ReturnValue, TransformedReturnValue = Retur
   multiSig?: MultiSig | null | undefined;
 
   /**
+   * Optional validation function that runs before the transaction is executed.
+   * Receives an object indicating whether the transaction will run as a MultiSig proposal.
+   * This allows procedures to defer validation logic (like balance checks) until the execution method is known.
+   */
+  preRunValidation?: ((args: { asProposal: boolean }) => Promise<void>) | undefined;
+
+  /**
    * value that the transaction will return once it has run, or a function that returns that value
    */
   resolver: MaybeResolverFunction<ReturnValue>;


### PR DESCRIPTION
### Description

The current `transferPolyx` method always checks the balance of the signing account when preparing a POLYX transfer transaction. This results in an `Insufficient free balance` error if the signing key doesn't not have enough POLYX to match the amount being being sent from the MS which prevents the transaction from being later submitted as a multisig proposal.

This PR adds a optional `preRunValidation` function to the `BaseTransactionSpec` and includes it in the transferPolyx method to perform correct validation of signer or multisig balance depending on whether the transaction is run as a proposal or standard transaction.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
