### PR TITLE
Added `add` and `remove` methods for document management

### DIFF
--- a/src/api/entities/Asset/Base/Documents/index.ts
+++ b/src/api/entities/Asset/Base/Documents/index.ts
@@ -1,13 +1,21 @@
 import { BaseAsset } from '~/api/entities/Asset/Base/BaseAsset';
-import { Context, Namespace, setAssetDocuments } from '~/internal';
 import {
-  AssetDocument,
+  addAssetDocuments,
+  Context,
+  Namespace,
+  removeAssetDocuments,
+  setAssetDocuments,
+} from '~/internal';
+import {
+  AddAssetDocumentsParams,
+  AssetDocumentWithId,
   PaginationOptions,
   ProcedureMethod,
+  RemoveAssetDocumentsParams,
   ResultSet,
   SetAssetDocumentsParams,
 } from '~/types';
-import { assetToMeshAssetId, documentToAssetDocument } from '~/utils/conversion';
+import { assetToMeshAssetId, documentToAssetDocumentWithId } from '~/utils/conversion';
 import { createProcedureMethod, requestPaginated } from '~/utils/internal';
 
 /**
@@ -24,19 +32,42 @@ export class Documents extends Namespace<BaseAsset> {
       { getProcedureAndArgs: args => [setAssetDocuments, { asset: parent, ...args }] },
       context
     );
+
+    this.add = createProcedureMethod(
+      { getProcedureAndArgs: args => [addAssetDocuments, { asset: parent, ...args }] },
+      context
+    );
+
+    this.remove = createProcedureMethod(
+      { getProcedureAndArgs: args => [removeAssetDocuments, { asset: parent, ...args }] },
+      context
+    );
   }
 
   /**
    * Assign a new list of documents to the Asset by replacing the existing list of documents with the ones passed in the parameters
+   *
+   * @note this removes all existing documents and adds the new ones
    */
   public set: ProcedureMethod<SetAssetDocumentsParams, void>;
+
+  /**
+   * Add documents to the Asset's existing list of documents
+   */
+  public add: ProcedureMethod<AddAssetDocumentsParams, void>;
+
+  /**
+   * Remove specific documents from the Asset by their IDs
+   */
+  public remove: ProcedureMethod<RemoveAssetDocumentsParams, void>;
 
   /**
    * Retrieve all documents linked to the Asset
    *
    * @note supports pagination
+   * @note returns documents with their on-chain IDs which can be used with the `remove` method
    */
-  public async get(paginationOpts?: PaginationOptions): Promise<ResultSet<AssetDocument>> {
+  public async get(paginationOpts?: PaginationOptions): Promise<ResultSet<AssetDocumentWithId>> {
     const {
       context: {
         polymeshApi: { query },
@@ -51,7 +82,10 @@ export class Documents extends Namespace<BaseAsset> {
       paginationOpts,
     });
 
-    const data: AssetDocument[] = entries.map(([, doc]) => documentToAssetDocument(doc.unwrap()));
+    const data: AssetDocumentWithId[] = entries.map(([key, doc]) => {
+      const [, id] = key.args;
+      return documentToAssetDocumentWithId({ document: doc.unwrap(), id });
+    });
 
     return {
       data,

--- a/src/api/entities/Asset/__tests__/Base/Documents.ts
+++ b/src/api/entities/Asset/__tests__/Base/Documents.ts
@@ -5,7 +5,7 @@ import { when } from 'jest-when';
 import { Documents } from '~/api/entities/Asset/Base/Documents';
 import { FungibleAsset, Namespace, PolymeshTransaction } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
-import { AssetDocument } from '~/types';
+import { AssetDocument, AssetDocumentWithId } from '~/types';
 import { tuple } from '~/types/utils';
 import * as utilsInternalModule from '~/utils/internal';
 
@@ -69,6 +69,64 @@ describe('Documents class', () => {
     });
   });
 
+  describe('method: add', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const context = dsMockUtils.getContextInstance();
+      const asset = entityMockUtils.getFungibleAssetInstance();
+      const documents = new Documents(asset, context);
+
+      const args = {
+        documents: [
+          {
+            name: 'someName',
+            uri: 'someUri',
+            contentHash: 'someHash',
+          },
+        ],
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args: { asset, ...args }, transformer: undefined }, context, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await documents.add(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: remove', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const context = dsMockUtils.getContextInstance();
+      const asset = entityMockUtils.getFungibleAssetInstance();
+      const documents = new Documents(asset, context);
+
+      const args = {
+        documentIds: [new BigNumber(1), new BigNumber(2)],
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args: { asset, ...args }, transformer: undefined }, context, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await documents.remove(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
   describe('method: get', () => {
     afterAll(() => {
       jest.restoreAllMocks();
@@ -91,6 +149,12 @@ describe('Documents class', () => {
           contentHash: '0x02',
         },
       ];
+      const expectedDocumentsWithId: AssetDocumentWithId[] = expectedDocuments.map(
+        (doc, index) => ({
+          ...doc,
+          id: new BigNumber(index),
+        })
+      );
       const entries = expectedDocuments.map(({ name, uri, contentHash, type, filedAt }, index) =>
         tuple(
           {
@@ -139,11 +203,11 @@ describe('Documents class', () => {
         { arg: undefined }
       );
 
-      expect(result).toEqual({ data: expectedDocuments, next: null });
+      expect(result).toEqual({ data: expectedDocumentsWithId, next: null });
 
       result = await documents.get({ size, start });
 
-      expect(result).toEqual({ data: expectedDocuments.slice(1), next: null });
+      expect(result).toEqual({ data: expectedDocumentsWithId.slice(1), next: null });
     });
   });
 });

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -84,6 +84,16 @@ export interface AssetDocument {
 }
 
 /**
+ * Asset Document with its on-chain identifier
+ */
+export interface AssetDocumentWithId extends AssetDocument {
+  /**
+   * Document ID as stored on-chain
+   */
+  id: BigNumber;
+}
+
+/**
  * Properties that uniquely identify an Asset
  */
 export interface UniqueIdentifiers {

--- a/src/api/procedures/__tests__/addAssetDocuments.ts
+++ b/src/api/procedures/__tests__/addAssetDocuments.ts
@@ -1,0 +1,148 @@
+import { Vec } from '@polkadot/types';
+import { PolymeshPrimitivesAssetAssetId, PolymeshPrimitivesDocument } from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareAddAssetDocuments,
+} from '~/api/procedures/addAssetDocuments';
+import { BaseAsset, Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { AssetDocument, TxTags } from '~/types';
+import { PolymeshTx } from '~/types/internal';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Asset/Fungible',
+  require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+
+describe('addAssetDocuments procedure', () => {
+  let mockContext: Mocked<Context>;
+  let assetToMeshAssetIdSpy: jest.SpyInstance;
+  let assetDocumentToDocumentSpy: jest.SpyInstance<
+    PolymeshPrimitivesDocument,
+    [AssetDocument, Context]
+  >;
+  let assetId: string;
+  let asset: BaseAsset;
+  let documents: AssetDocument[];
+  let rawAssetId: PolymeshPrimitivesAssetAssetId;
+  let rawDocuments: PolymeshPrimitivesDocument[];
+  let args: Params;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks({
+      contextOptions: {
+        balance: {
+          free: new BigNumber(500),
+          locked: new BigNumber(0),
+          total: new BigNumber(500),
+        },
+      },
+    });
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
+    assetDocumentToDocumentSpy = jest.spyOn(utilsConversionModule, 'assetDocumentToDocument');
+    assetId = '0x12341234123412341234123412341234';
+    asset = entityMockUtils.getBaseAssetInstance({ assetId });
+    documents = [
+      {
+        name: 'someDocument',
+        uri: 'someUri',
+        contentHash: '0x01',
+      },
+      {
+        name: 'otherDocument',
+        uri: 'otherUri',
+        contentHash: '0x02',
+      },
+    ];
+    rawAssetId = dsMockUtils.createMockAssetId(assetId);
+    rawDocuments = documents.map(({ name, uri, contentHash, type, filedAt }) =>
+      dsMockUtils.createMockDocument({
+        name: dsMockUtils.createMockBytes(name),
+        uri: dsMockUtils.createMockBytes(uri),
+        contentHash: dsMockUtils.createMockDocumentHash({
+          H128: dsMockUtils.createMockU8aFixed(contentHash, true),
+        }),
+        docType: dsMockUtils.createMockOption(type ? dsMockUtils.createMockBytes(type) : null),
+        filingDate: dsMockUtils.createMockOption(
+          filedAt ? dsMockUtils.createMockMoment(new BigNumber(filedAt.getTime())) : null
+        ),
+      })
+    );
+    args = {
+      asset,
+      documents,
+    };
+  });
+
+  let addDocumentsTransaction: PolymeshTx<
+    [Vec<PolymeshPrimitivesDocument>, PolymeshPrimitivesAssetAssetId]
+  >;
+
+  beforeEach(() => {
+    addDocumentsTransaction = dsMockUtils.createTxMock('asset', 'addDocuments');
+
+    mockContext = dsMockUtils.getContextInstance();
+
+    when(assetToMeshAssetIdSpy).calledWith(asset, mockContext).mockReturnValue(rawAssetId);
+    documents.forEach((doc, index) => {
+      when(assetDocumentToDocumentSpy)
+        .calledWith(doc, mockContext)
+        .mockReturnValue(rawDocuments[index]!);
+    });
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if the documents list is empty', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    expect(() => prepareAddAssetDocuments.call(proc, { ...args, documents: [] })).toThrow(
+      'The documents list cannot be empty'
+    );
+  });
+
+  it('should add an add documents transaction to the queue', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const result = await prepareAddAssetDocuments.call(proc, args);
+
+    expect(result).toEqual({
+      transaction: addDocumentsTransaction,
+      feeMultiplier: new BigNumber(rawDocuments.length),
+      args: [rawDocuments, rawAssetId],
+      resolver: undefined,
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(boundFunc(args)).toEqual({
+        permissions: {
+          assets: [expect.objectContaining({ id: assetId })],
+          transactions: [TxTags.asset.AddDocuments],
+          portfolios: [],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/__tests__/removeAssetDocuments.ts
+++ b/src/api/procedures/__tests__/removeAssetDocuments.ts
@@ -1,0 +1,118 @@
+import { u32, Vec } from '@polkadot/types';
+import { PolymeshPrimitivesAssetAssetId } from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareRemoveAssetDocuments,
+} from '~/api/procedures/removeAssetDocuments';
+import { BaseAsset, Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { TxTags } from '~/types';
+import { PolymeshTx } from '~/types/internal';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Asset/Fungible',
+  require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+
+describe('removeAssetDocuments procedure', () => {
+  let mockContext: Mocked<Context>;
+  let assetToMeshAssetIdSpy: jest.SpyInstance;
+  let bigNumberToU32Spy: jest.SpyInstance<u32, [BigNumber, Context]>;
+  let assetId: string;
+  let asset: BaseAsset;
+  let documentIds: BigNumber[];
+  let rawAssetId: PolymeshPrimitivesAssetAssetId;
+  let rawDocumentIds: u32[];
+  let args: Params;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks({
+      contextOptions: {
+        balance: {
+          free: new BigNumber(500),
+          locked: new BigNumber(0),
+          total: new BigNumber(500),
+        },
+      },
+    });
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
+    bigNumberToU32Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU32');
+    assetId = '0x12341234123412341234123412341234';
+    asset = entityMockUtils.getBaseAssetInstance({ assetId });
+    documentIds = [new BigNumber(1), new BigNumber(2), new BigNumber(3)];
+    rawAssetId = dsMockUtils.createMockAssetId(assetId);
+    rawDocumentIds = documentIds.map(id => dsMockUtils.createMockU32(id));
+    args = {
+      asset,
+      documentIds,
+    };
+  });
+
+  let removeDocumentsTransaction: PolymeshTx<[Vec<u32>, PolymeshPrimitivesAssetAssetId]>;
+
+  beforeEach(() => {
+    removeDocumentsTransaction = dsMockUtils.createTxMock('asset', 'removeDocuments');
+
+    mockContext = dsMockUtils.getContextInstance();
+
+    when(assetToMeshAssetIdSpy).calledWith(asset, mockContext).mockReturnValue(rawAssetId);
+    documentIds.forEach((id, index) => {
+      when(bigNumberToU32Spy).calledWith(id, mockContext).mockReturnValue(rawDocumentIds[index]!);
+    });
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if the document IDs list is empty', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    expect(() => prepareRemoveAssetDocuments.call(proc, { ...args, documentIds: [] })).toThrow(
+      'The document IDs list cannot be empty'
+    );
+  });
+
+  it('should add a remove documents transaction to the queue', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const result = await prepareRemoveAssetDocuments.call(proc, args);
+
+    expect(result).toEqual({
+      transaction: removeDocumentsTransaction,
+      feeMultiplier: new BigNumber(rawDocumentIds.length),
+      args: [rawDocumentIds, rawAssetId],
+      resolver: undefined,
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(boundFunc(args)).toEqual({
+        permissions: {
+          assets: [expect.objectContaining({ id: assetId })],
+          transactions: [TxTags.asset.RemoveDocuments],
+          portfolios: [],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/addAssetDocuments.ts
+++ b/src/api/procedures/addAssetDocuments.ts
@@ -1,0 +1,68 @@
+import BigNumber from 'bignumber.js';
+
+import { BaseAsset, PolymeshError, Procedure } from '~/internal';
+import { AddAssetDocumentsParams, ErrorCode, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { assetDocumentToDocument, assetToMeshAssetId } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export type Params = AddAssetDocumentsParams & {
+  asset: BaseAsset;
+};
+
+/**
+ * @hidden
+ */
+export function prepareAddAssetDocuments(
+  this: Procedure<Params, void>,
+  args: Params
+): Promise<TransactionSpec<void, ExtrinsicParams<'asset', 'addDocuments'>>> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    context,
+  } = this;
+  const { asset, documents } = args;
+
+  if (!documents.length) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The documents list cannot be empty',
+    });
+  }
+
+  const rawDocuments = documents.map(doc => assetDocumentToDocument(doc, context));
+  const rawAssetId = assetToMeshAssetId(asset, context);
+
+  return Promise.resolve({
+    transaction: tx.asset.addDocuments,
+    feeMultiplier: new BigNumber(documents.length),
+    args: [rawDocuments, rawAssetId],
+    resolver: undefined,
+  });
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void>,
+  { asset }: Params
+): ProcedureAuthorization {
+  return {
+    permissions: {
+      assets: [asset],
+      transactions: [TxTags.asset.AddDocuments],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const addAssetDocuments = (): Procedure<Params, void> =>
+  new Procedure(prepareAddAssetDocuments, getAuthorization);

--- a/src/api/procedures/removeAssetDocuments.ts
+++ b/src/api/procedures/removeAssetDocuments.ts
@@ -1,0 +1,68 @@
+import BigNumber from 'bignumber.js';
+
+import { BaseAsset, PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, RemoveAssetDocumentsParams, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { assetToMeshAssetId, bigNumberToU32 } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export type Params = RemoveAssetDocumentsParams & {
+  asset: BaseAsset;
+};
+
+/**
+ * @hidden
+ */
+export function prepareRemoveAssetDocuments(
+  this: Procedure<Params, void>,
+  args: Params
+): Promise<TransactionSpec<void, ExtrinsicParams<'asset', 'removeDocuments'>>> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    context,
+  } = this;
+  const { asset, documentIds } = args;
+
+  if (!documentIds.length) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The document IDs list cannot be empty',
+    });
+  }
+
+  const rawDocumentIds = documentIds.map(id => bigNumberToU32(id, context));
+  const rawAssetId = assetToMeshAssetId(asset, context);
+
+  return Promise.resolve({
+    transaction: tx.asset.removeDocuments,
+    feeMultiplier: new BigNumber(documentIds.length),
+    args: [rawDocumentIds, rawAssetId],
+    resolver: undefined,
+  });
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void>,
+  { asset }: Params
+): ProcedureAuthorization {
+  return {
+    permissions: {
+      assets: [asset],
+      transactions: [TxTags.asset.RemoveDocuments],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const removeAssetDocuments = (): Procedure<Params, void> =>
+  new Procedure(prepareRemoveAssetDocuments, getAuthorization);

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1468,6 +1468,20 @@ export interface SetAssetDocumentsParams {
   documents: AssetDocument[];
 }
 
+export interface AddAssetDocumentsParams {
+  /**
+   * documents to add to the asset
+   */
+  documents: AssetDocument[];
+}
+
+export interface RemoveAssetDocumentsParams {
+  /**
+   * IDs of documents to remove from the asset
+   */
+  documentIds: BigNumber[];
+}
+
 export interface LaunchOfferingParams {
   /**
    * portfolio in which the Asset tokens to be sold are stored

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -57,6 +57,8 @@ export {
 } from '~/api/procedures/modifySignerPermissions';
 export { reserveTicker } from '~/api/procedures/reserveTicker';
 export { setAssetDocuments } from '~/api/procedures/setAssetDocuments';
+export { addAssetDocuments } from '~/api/procedures/addAssetDocuments';
+export { removeAssetDocuments } from '~/api/procedures/removeAssetDocuments';
 export { setAssetRequirements } from '~/api/procedures/setAssetRequirements';
 export { modifyComplianceRequirement } from '~/api/procedures/modifyComplianceRequirement';
 export { addAssetRequirement } from '~/api/procedures/addAssetRequirement';

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -135,6 +135,7 @@ import {
   AccountWithSignature,
   AffirmationStatus,
   AssetDocument,
+  AssetDocumentWithId,
   Authorization,
   AuthorizationType,
   ChildKeyWithAuth,
@@ -257,6 +258,7 @@ import {
   distributionToDividendDistributionParams,
   documentHashToString,
   documentToAssetDocument,
+  documentToAssetDocumentWithId,
   endConditionToSettlementType,
   exemptionToTransferExemption,
   expiryToMoment,
@@ -3825,6 +3827,57 @@ describe('assetDocumentToDocument and documentToAssetDocument', () => {
       });
 
       result = documentToAssetDocument(doc);
+      expect(result).toEqual(fakeResult);
+    });
+  });
+
+  describe('documentToAssetDocumentWithId', () => {
+    it('should convert a polkadot Document object with ID to an AssetDocumentWithId object', () => {
+      const name = 'someName';
+      const uri = 'someUri';
+      const contentHash = '0x111111';
+      const filedAt = new Date();
+      const type = 'someType';
+      const docId = new BigNumber(42);
+      const mockId = dsMockUtils.createMockU32(docId);
+
+      let fakeResult: AssetDocumentWithId = {
+        name,
+        uri,
+        id: docId,
+      };
+
+      let doc = dsMockUtils.createMockDocument({
+        uri: dsMockUtils.createMockBytes(uri),
+        name: dsMockUtils.createMockBytes(name),
+        contentHash: dsMockUtils.createMockDocumentHash('None'),
+        docType: dsMockUtils.createMockOption(),
+        filingDate: dsMockUtils.createMockOption(),
+      });
+
+      let result = documentToAssetDocumentWithId({ document: doc, id: mockId });
+      expect(result).toEqual(fakeResult);
+
+      fakeResult = {
+        ...fakeResult,
+        contentHash,
+        filedAt,
+        type,
+      };
+
+      doc = dsMockUtils.createMockDocument({
+        uri: dsMockUtils.createMockBytes(uri),
+        name: dsMockUtils.createMockBytes(name),
+        contentHash: dsMockUtils.createMockDocumentHash({
+          H128: dsMockUtils.createMockU8aFixed(contentHash, true),
+        }),
+        docType: dsMockUtils.createMockOption(dsMockUtils.createMockBytes(type)),
+        filingDate: dsMockUtils.createMockOption(
+          dsMockUtils.createMockMoment(new BigNumber(filedAt.getTime()))
+        ),
+      });
+
+      result = documentToAssetDocumentWithId({ document: doc, id: mockId });
       expect(result).toEqual(fakeResult);
     });
   });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -194,6 +194,7 @@ import {
   AddCountStatInput,
   AffirmationStatus,
   AssetDocument,
+  AssetDocumentWithId,
   AssetStat,
   Authorization,
   AuthorizationType,
@@ -2242,6 +2243,24 @@ export function documentToAssetDocument({
   }
 
   return doc;
+}
+
+/**
+ * @hidden
+ * Convert a Document and its ID to an AssetDocumentWithId
+ */
+export function documentToAssetDocumentWithId({
+  document,
+  id,
+}: {
+  document: PolymeshPrimitivesDocument;
+  id: u32;
+}): AssetDocumentWithId {
+  const assetDoc = documentToAssetDocument(document);
+  return {
+    ...assetDoc,
+    id: u32ToBigNumber(id),
+  };
 }
 
 /**


### PR DESCRIPTION
### Description

Adds `add()` and `remove()` methods to the `Documents` namespace for more efficient asset document management. Previously, adding a single document required removing and re-adding all existing documents via `set()`. Now users can perform granular operations:

- **`add()`** - Add documents to existing list
- **`remove()`** - Remove specific documents by ID  
- **`set()`** - Replace all documents (existing behavior)
- **`get()`** - Now returns documents with their on-chain IDs

**Key improvements:**
- Reduced transaction fees for incremental document changes
- `Documents.get()` now returns `ResultSet<AssetDocumentWithId>` instead of `ResultSet<AssetDocument>`. Since `AssetDocumentWithId` extends `AssetDocument`, this is backward compatible for most use cases, but the type signature includes an additional `id` field. The id is required with the `remove()` method
- Document IDs now exposed in `get()` results for use with `remove()`

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?