### PR TITLE
fix: 🐛 transfer restrictions

### DIFF
--- a/src/api/entities/Asset/Fungible/TransferRestrictions/index.ts
+++ b/src/api/entities/Asset/Fungible/TransferRestrictions/index.ts
@@ -18,6 +18,7 @@ import {
   SetTransferExemptionsParams,
   SetTransferRestrictionParams,
   setTransferRestrictions,
+  SetTransferRestrictionsStorage,
 } from '~/internal';
 import {
   ActiveTransferRestrictions,
@@ -62,7 +63,8 @@ export class TransferRestrictions extends Namespace<FungibleAsset> {
     this.setRestrictions = createProcedureMethod<
       TransferRestrictionParams,
       SetTransferRestrictionParams,
-      void
+      void,
+      SetTransferRestrictionsStorage
     >(
       {
         getProcedureAndArgs: args => [setTransferRestrictions, { ...args, asset: parent }],
@@ -230,7 +232,7 @@ export class TransferRestrictions extends Namespace<FungibleAsset> {
       claimType?: TrustedFor;
     }[] = [];
 
-    activeStats.forEach(stat => {
+    for (const stat of activeStats) {
       const stat1stKey = getStat1stKey(rawAssetId, stat, context);
       const statType = meshStatToStatType(stat);
 
@@ -282,7 +284,7 @@ export class TransferRestrictions extends Namespace<FungibleAsset> {
           statType,
         });
       }
-    });
+    }
 
     return {
       jurisdictionQueries,
@@ -290,6 +292,194 @@ export class TransferRestrictions extends Namespace<FungibleAsset> {
       nonJurisdictionQueries,
       nonJurisdictionMappings,
     };
+  }
+
+  /**
+   * Process jurisdiction entries and extract jurisdiction values
+   */
+  private processJurisdictionEntries(
+    entries:
+      | [
+          StorageKey<
+            [PolymeshPrimitivesStatisticsStat1stKey, PolymeshPrimitivesStatisticsStat2ndKey]
+          >,
+          u128
+        ][]
+      | undefined,
+    statType: StatType
+  ): JurisdictionValue[] {
+    const jurisdictionValues: JurisdictionValue[] = [];
+
+    for (const [key, rawValue] of entries ?? []) {
+      const secondKey = key.args[1];
+
+      if (secondKey.isNoClaimStat) {
+        // No jurisdiction claim
+        jurisdictionValues.push({
+          countryCode: null,
+          value: u128ToStatValue(rawValue, statType),
+        });
+      } else if (secondKey.isClaim && secondKey.asClaim.isJurisdiction) {
+        // Specific jurisdiction
+        const countryCode = secondKey.asClaim.asJurisdiction.toString() as CountryCode;
+        jurisdictionValues.push({
+          countryCode,
+          value: u128ToStatValue(rawValue, statType),
+        });
+      }
+    }
+
+    return jurisdictionValues;
+  }
+
+  /**
+   * Process jurisdiction results and add them to the result array
+   */
+  private processJurisdictionResults(
+    jurisdictionResults: [
+      StorageKey<[PolymeshPrimitivesStatisticsStat1stKey, PolymeshPrimitivesStatisticsStat2ndKey]>,
+      u128
+    ][][],
+    jurisdictionMappings: {
+      statType: StatType;
+      issuer: Identity;
+      claimType: TrustedFor;
+    }[],
+    result: TransferRestrictionStatValues[]
+  ): void {
+    for (let index = 0; index < jurisdictionMappings.length; index++) {
+      const mapping = jurisdictionMappings[index]!;
+      const entries = jurisdictionResults[index];
+      const { statType, issuer, claimType } = mapping;
+
+      const jurisdictionValues = this.processJurisdictionEntries(entries, statType);
+      const totalValue = jurisdictionValues.reduce(
+        (sum, jv) => sum.plus(jv.value),
+        new BigNumber(0)
+      );
+
+      result.push({
+        type: statType,
+        value: totalValue,
+        claim: {
+          issuer,
+          claimType,
+          value: jurisdictionValues,
+        },
+      });
+    }
+  }
+
+  /**
+   * Get claim type for comparison
+   */
+  private getClaimTypeForComparison(claimType: TrustedFor): ClaimType {
+    return typeof claimType === 'object' ? claimType.type : claimType;
+  }
+
+  /**
+   * Process accredited/affiliate claim types
+   */
+  private processAccreditedAffiliateClaim(
+    statType: StatType,
+    issuer: Identity,
+    claimType: TrustedFor,
+    nonJurisdictionResults: u128[],
+    resultIndex: number
+  ): { result: TransferRestrictionStatValues; newIndex: number } {
+    const withClaimValue = u128ToStatValue(nonJurisdictionResults[resultIndex]!, statType);
+    const withoutClaimValue = u128ToStatValue(nonJurisdictionResults[resultIndex + 1]!, statType);
+    const totalValue = withClaimValue.plus(withoutClaimValue);
+
+    return {
+      result: {
+        type: statType,
+        value: totalValue,
+        claim: {
+          issuer,
+          claimType,
+          value: { withClaim: withClaimValue, withoutClaim: withoutClaimValue },
+        },
+      },
+      newIndex: resultIndex + 2,
+    };
+  }
+
+  /**
+   * Process custom claim types
+   */
+  private processCustomClaim(
+    statType: StatType,
+    issuer: Identity,
+    claimType: TrustedFor,
+    nonJurisdictionResults: u128[],
+    resultIndex: number
+  ): { result: TransferRestrictionStatValues; newIndex: number } {
+    return {
+      result: {
+        claim: {
+          issuer,
+          claimType,
+        },
+        type: statType,
+        value: u128ToStatValue(nonJurisdictionResults[resultIndex]!, statType),
+      },
+      newIndex: resultIndex + 1,
+    };
+  }
+
+  /**
+   * Process non-jurisdiction results and add them to the result array
+   */
+  private processNonJurisdictionResults(
+    nonJurisdictionMappings: {
+      statType: StatType;
+      issuer?: Identity;
+      claimType?: TrustedFor;
+    }[],
+    nonJurisdictionResults: u128[],
+    result: TransferRestrictionStatValues[]
+  ): void {
+    let resultIndex = 0;
+
+    for (const mapping of nonJurisdictionMappings) {
+      const { statType, issuer, claimType } = mapping;
+
+      if (claimType && issuer) {
+        const claimTypeForComparison = this.getClaimTypeForComparison(claimType);
+
+        if (
+          claimTypeForComparison === ClaimType.Accredited ||
+          claimTypeForComparison === ClaimType.Affiliate
+        ) {
+          const { result: claimResult, newIndex } = this.processAccreditedAffiliateClaim(
+            statType,
+            issuer,
+            claimType,
+            nonJurisdictionResults,
+            resultIndex
+          );
+          result.push(claimResult);
+          resultIndex = newIndex;
+        } else {
+          const { result: claimResult, newIndex } = this.processCustomClaim(
+            statType,
+            issuer,
+            claimType,
+            nonJurisdictionResults,
+            resultIndex
+          );
+          result.push(claimResult);
+          resultIndex = newIndex;
+        }
+      } else {
+        result.push({
+          type: statType,
+          value: u128ToStatValue(nonJurisdictionResults[resultIndex]!, statType),
+        });
+        resultIndex++;
+      }
+    }
   }
 
   /**
@@ -323,105 +513,13 @@ export class TransferRestrictions extends Namespace<FungibleAsset> {
       nonJurisdictionMappings,
     } = this.assembleAssetMappings(activeStats, rawAssetId, context);
 
-    // Execute all queries in parallel
     const [jurisdictionResults, nonJurisdictionResults] = await Promise.all([
       Promise.all(jurisdictionQueries),
       nonJurisdictionQueries.length > 0 ? requestMulti(context, nonJurisdictionQueries) : [],
     ]);
 
-    // Process jurisdiction results
-    jurisdictionMappings.forEach((mapping, index) => {
-      const entries = jurisdictionResults[index];
-      const { statType, issuer, claimType } = mapping;
-
-      const jurisdictionValues: JurisdictionValue[] = [];
-
-      entries!.forEach(([key, rawValue]) => {
-        const secondKey = key.args[1];
-
-        if (secondKey.isNoClaimStat) {
-          // No jurisdiction claim
-          jurisdictionValues.push({
-            countryCode: null,
-            value: u128ToStatValue(rawValue, statType),
-          });
-        } else if (secondKey.isClaim && secondKey.asClaim.isJurisdiction) {
-          // Specific jurisdiction
-          const countryCode = secondKey.asClaim.asJurisdiction.toString() as CountryCode;
-          jurisdictionValues.push({
-            countryCode,
-            value: u128ToStatValue(rawValue, statType),
-          });
-        }
-      });
-
-      const totalValue = jurisdictionValues.reduce(
-        (sum, jv) => sum.plus(jv.value),
-        new BigNumber(0)
-      );
-
-      result.push({
-        type: statType,
-        value: totalValue,
-        claim: {
-          issuer,
-          claimType,
-          value: jurisdictionValues,
-        },
-      });
-    });
-
-    // Process non-jurisdiction results
-    let resultIndex = 0;
-    nonJurisdictionMappings.forEach(mapping => {
-      const { statType, issuer, claimType } = mapping;
-
-      if (claimType && issuer) {
-        const claimTypeForComparison = typeof claimType === 'object' ? claimType.type : claimType;
-
-        if (
-          claimTypeForComparison === ClaimType.Accredited ||
-          claimTypeForComparison === ClaimType.Affiliate
-        ) {
-          // Get the specific claim values (true/false queries only)
-          const withClaimValue = u128ToStatValue(nonJurisdictionResults[resultIndex]!, statType);
-          const withoutClaimValue = u128ToStatValue(
-            nonJurisdictionResults[resultIndex + 1]!,
-            statType
-          );
-          resultIndex += 2;
-
-          const totalValue = withClaimValue.plus(withoutClaimValue);
-          result.push({
-            type: statType,
-            value: totalValue,
-            claim: {
-              issuer,
-              claimType,
-              value: { withClaim: withClaimValue, withoutClaim: withoutClaimValue },
-            },
-          });
-        } else {
-          // Custom claims and other unsupported types - get NoClaimStat total holder/balance value only
-          result.push({
-            claim: {
-              issuer,
-              claimType,
-            },
-            type: statType,
-            value: u128ToStatValue(nonJurisdictionResults[resultIndex]!, statType),
-          });
-          resultIndex++;
-        }
-      } else {
-        // Handle non-claim stats
-        result.push({
-          type: statType,
-          value: u128ToStatValue(nonJurisdictionResults[resultIndex]!, statType),
-        });
-        resultIndex++;
-      }
-    });
+    this.processJurisdictionResults(jurisdictionResults, jurisdictionMappings, result);
+    this.processNonJurisdictionResults(nonJurisdictionMappings, nonJurisdictionResults, result);
 
     return result;
   }

--- a/src/api/entities/Asset/__tests__/Fungible/TransferRestrictions.ts
+++ b/src/api/entities/Asset/__tests__/Fungible/TransferRestrictions.ts
@@ -802,5 +802,194 @@ describe('TransferRestrictions class', () => {
         returnValue: originalActiveAssetStats,
       });
     });
+
+    it('should handle jurisdiction entries when entries is undefined', async () => {
+      // Set up only the jurisdiction stat (which is ScopedBalance type)
+      dsMockUtils.createQueryMock('statistics', 'activeAssetStats', {
+        returnValue: [rawJurisdictionBalanceStatType],
+      });
+
+      // Mock jurisdiction entries to return undefined (this should trigger the ?? [] fallback)
+      const jurisdictionEntriesMock = dsMockUtils.createQueryMock('statistics', 'assetStats', {
+        returnValue: jest.fn(),
+      });
+      jurisdictionEntriesMock.entries = jest.fn().mockResolvedValue(undefined);
+
+      const result = await asset.transferRestrictions.getValues();
+
+      // Should handle undefined entries gracefully and return empty jurisdiction values
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            claim: expect.objectContaining({
+              claimType: ClaimType.Jurisdiction,
+              issuer: expect.anything(),
+              value: [], // Empty array when entries is undefined
+            }),
+            type: StatType.ScopedBalance,
+            value: new BigNumber(0), // No values to sum
+          }),
+        ])
+      );
+    });
+
+    it('should handle jurisdiction mappings with falsy mapping values', async () => {
+      // Set up only the jurisdiction stat (which is ScopedBalance type)
+      dsMockUtils.createQueryMock('statistics', 'activeAssetStats', {
+        returnValue: [rawJurisdictionBalanceStatType],
+      });
+
+      // Mock jurisdiction entries to return empty array
+      const jurisdictionEntriesMock = dsMockUtils.createQueryMock('statistics', 'assetStats', {
+        returnValue: jest.fn(),
+      });
+      jurisdictionEntriesMock.entries = jest.fn().mockResolvedValue([]);
+
+      // Mock the jurisdiction queries to return some falsy values (null/undefined) in the mappings
+      // This will trigger the !mapping check on line 338
+      queryMultiMock.mockResolvedValue([
+        [], // jurisdictionResults with some falsy mappings
+      ]);
+
+      const result = await asset.transferRestrictions.getValues();
+
+      // Should handle falsy mappings gracefully
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            claim: expect.objectContaining({
+              claimType: ClaimType.Jurisdiction,
+              issuer: expect.anything(),
+              value: [], // Empty array when mappings are falsy
+            }),
+            type: StatType.ScopedBalance,
+            value: new BigNumber(0), // No values to sum
+          }),
+        ])
+      );
+    });
+
+    it('should handle jurisdiction mappings array with falsy values at specific indices', async () => {
+      // Simple test to cover the continue statement when mapping is falsy
+
+      // Set up only the jurisdiction stat (which is ScopedBalance type)
+      dsMockUtils.createQueryMock('statistics', 'activeAssetStats', {
+        returnValue: [rawJurisdictionBalanceStatType],
+      });
+
+      // Mock jurisdiction entries to return empty array
+      const jurisdictionEntriesMock = dsMockUtils.createQueryMock('statistics', 'assetStats', {
+        returnValue: jest.fn(),
+      });
+      jurisdictionEntriesMock.entries = jest.fn().mockResolvedValue([]);
+
+      // Mock the assembleAssetMappings method to return jurisdictionMappings with a falsy value
+      const assembleAssetMappingsSpy = jest.spyOn(
+        transferRestrictions as unknown as { assembleAssetMappings: () => unknown },
+        'assembleAssetMappings'
+      );
+
+      // Create a sparse array with a hole at index 0
+      const sparseMappings = [];
+      sparseMappings[0] = null; // Falsy value at index 0
+      sparseMappings[1] = {
+        statType: StatType.ScopedBalance,
+        issuer: expect.anything(),
+        claimType: ClaimType.Jurisdiction,
+      };
+
+      assembleAssetMappingsSpy.mockReturnValue({
+        jurisdictionQueries: [
+          Promise.resolve([]), // Empty entries for index 0
+          Promise.resolve([]), // Empty entries for index 1
+        ],
+        jurisdictionMappings: sparseMappings,
+        nonJurisdictionQueries: [],
+        nonJurisdictionMappings: [],
+      });
+
+      const result = await asset.transferRestrictions.getValues();
+
+      // Should handle falsy mappings gracefully and skip the null entry
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            claim: expect.objectContaining({
+              claimType: ClaimType.Jurisdiction,
+              issuer: expect.anything(),
+              value: [], // Empty array when entries is empty
+            }),
+            type: StatType.ScopedBalance,
+            value: new BigNumber(0), // No values to sum
+          }),
+        ])
+      );
+
+      // Restore the spy
+      assembleAssetMappingsSpy.mockRestore();
+    });
+
+    it('should handle jurisdiction mappings with undefined values', async () => {
+      // Test to cover the continue statement by creating a scenario where mapping is undefined
+
+      // Set up only the jurisdiction stat (which is ScopedBalance type)
+      dsMockUtils.createQueryMock('statistics', 'activeAssetStats', {
+        returnValue: [rawJurisdictionBalanceStatType],
+      });
+
+      // Mock jurisdiction entries to return empty array
+      const jurisdictionEntriesMock = dsMockUtils.createQueryMock('statistics', 'assetStats', {
+        returnValue: jest.fn(),
+      });
+      jurisdictionEntriesMock.entries = jest.fn().mockResolvedValue([]);
+
+      // Mock the assembleAssetMappings method to return jurisdictionMappings with undefined values
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const assembleAssetMappingsSpy = jest.spyOn(
+        transferRestrictions as unknown as { assembleAssetMappings: () => void },
+        'assembleAssetMappings'
+      );
+
+      // Create an array with undefined at index 0
+      const mappingsWithUndefined = [
+        undefined, // This should trigger the continue statement
+        {
+          statType: StatType.ScopedBalance,
+          issuer: expect.anything(),
+          claimType: ClaimType.Jurisdiction,
+        },
+      ];
+
+      // @ts-expect-error mockReturnValue typing mismatch is intentional for test
+      assembleAssetMappingsSpy.mockReturnValue({
+        jurisdictionQueries: [
+          Promise.resolve([]), // Empty entries for index 0
+          Promise.resolve([]), // Empty entries for index 1
+        ],
+        jurisdictionMappings: mappingsWithUndefined,
+        nonJurisdictionQueries: [],
+        nonJurisdictionMappings: [],
+      });
+
+      const result = await asset.transferRestrictions.getValues();
+
+      // Should handle undefined mappings gracefully and skip the undefined entry
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            claim: expect.objectContaining({
+              claimType: ClaimType.Jurisdiction,
+              issuer: expect.anything(),
+              value: [], // Empty array when entries is empty
+            }),
+            type: StatType.ScopedBalance,
+            value: new BigNumber(0), // No values to sum
+          }),
+        ])
+      );
+
+      // Restore the spy
+      assembleAssetMappingsSpy.mockRestore();
+    });
   });
 });

--- a/src/api/procedures/__tests__/setTransferRestrictions.ts
+++ b/src/api/procedures/__tests__/setTransferRestrictions.ts
@@ -11,11 +11,15 @@ import {
   getAuthorization,
   Params,
   prepareSetTransferRestrictions,
+  prepareStorage,
+  setTransferRestrictions,
+  SetTransferRestrictionsStorage,
 } from '~/api/procedures/setTransferRestrictions';
-import { Context, PolymeshError } from '~/internal';
+import { Context, PolymeshError, Procedure } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import {
+  AssetStat,
   ClaimType,
   CountryCode,
   ErrorCode,
@@ -53,6 +57,8 @@ describe('setTransferRestrictions procedure', () => {
   let percentage: BigNumber;
   let min: BigNumber;
   let max: BigNumber;
+  let claimPercentageMin: BigNumber;
+  let claimPercentageMax: BigNumber;
   let issuer: Identity;
   let rawAssetId: PolymeshPrimitivesAssetAssetId;
   let rawCount: u64;
@@ -60,11 +66,20 @@ describe('setTransferRestrictions procedure', () => {
   let rawCountRestriction: PolymeshPrimitivesTransferComplianceTransferCondition;
   let rawPercentageRestriction: PolymeshPrimitivesTransferComplianceTransferCondition;
   let rawClaimCountRestriction: PolymeshPrimitivesTransferComplianceTransferCondition;
+  let rawClaimPercentageRestriction: PolymeshPrimitivesTransferComplianceTransferCondition;
   let rawConditionsBtreeSet: BTreeSet<PolymeshPrimitivesTransferComplianceTransferCondition>;
   let setAssetTransferComplianceTransaction: PolymeshTx<
     [PolymeshPrimitivesAssetAssetId, PolymeshPrimitivesTransferComplianceTransferCondition]
   >;
   let mockStats: BTreeSet;
+  let currentStats: AssetStat[];
+  let storage: SetTransferRestrictionsStorage;
+
+  const getProc = (): Procedure<Params, void, SetTransferRestrictionsStorage> =>
+    procedureMockUtils.getInstance<Params, void, SetTransferRestrictionsStorage>(
+      mockContext,
+      storage
+    );
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -89,7 +104,58 @@ describe('setTransferRestrictions procedure', () => {
     percentage = new BigNumber(49);
     min = new BigNumber(10);
     max = new BigNumber(20);
+    claimPercentageMin = new BigNumber(5);
+    claimPercentageMax = new BigNumber(15);
     issuer = entityMockUtils.getIdentityInstance({ did: 'issuerDid' });
+
+    currentStats = [
+      { type: StatType.Count },
+      { type: StatType.Balance },
+      {
+        type: StatType.ScopedCount,
+        claimIssuer: {
+          issuer,
+          claimType: ClaimType.Accredited,
+        },
+      },
+      {
+        type: StatType.ScopedCount,
+        claimIssuer: {
+          issuer,
+          claimType: ClaimType.Affiliate,
+        },
+      },
+      {
+        type: StatType.ScopedCount,
+        claimIssuer: {
+          issuer,
+          claimType: ClaimType.Jurisdiction,
+        },
+      },
+      {
+        type: StatType.ScopedBalance,
+        claimIssuer: {
+          issuer,
+          claimType: ClaimType.Accredited,
+        },
+      },
+      {
+        type: StatType.ScopedBalance,
+        claimIssuer: {
+          issuer,
+          claimType: ClaimType.Affiliate,
+        },
+      },
+      {
+        type: StatType.ScopedBalance,
+        claimIssuer: {
+          issuer,
+          claimType: ClaimType.Jurisdiction,
+        },
+      },
+    ];
+
+    storage = { currentStats };
 
     mockStats = dsMockUtils.createMockBtreeSet([
       dsMockUtils.createMockStatisticsStatType({
@@ -129,6 +195,17 @@ describe('setTransferRestrictions procedure', () => {
       ],
       isClaimCount: true,
     });
+    const rawMinPermill = dsMockUtils.createMockPermill(claimPercentageMin.multipliedBy(10000));
+    const rawMaxPermill = dsMockUtils.createMockPermill(claimPercentageMax.multipliedBy(10000));
+    rawClaimPercentageRestriction = dsMockUtils.createMockTransferCondition({
+      ClaimOwnership: [
+        dsMockUtils.createMockStatisticsStatClaim({ Accredited: dsMockUtils.createMockBool(true) }),
+        dsMockUtils.createMockIdentityId('issuerDid'),
+        rawMinPermill,
+        rawMaxPermill,
+      ],
+      isClaimOwnership: true,
+    });
     rawConditionsBtreeSet = dsMockUtils.createMockBtreeSet([
       rawCountRestriction,
       rawPercentageRestriction,
@@ -138,7 +215,7 @@ describe('setTransferRestrictions procedure', () => {
     when(complianceConditionsToBtreeSetSpy)
       .calledWith([rawCountRestriction, rawPercentageRestriction], mockContext)
       .mockReturnValue(rawConditionsBtreeSet);
-    assertStatSetSpy.mockResolvedValue(undefined);
+    assertStatSetSpy.mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -154,7 +231,7 @@ describe('setTransferRestrictions procedure', () => {
 
   describe('prepareSetTransferRestrictions', () => {
     it('should prepare a transaction with count restrictions', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -165,7 +242,7 @@ describe('setTransferRestrictions procedure', () => {
           {
             min: new BigNumber(2),
             max: new BigNumber(10),
-            issuer: entityMockUtils.getIdentityInstance(),
+            issuer,
             claim: { type: ClaimType.Accredited, accredited: false },
             type: TransferRestrictionType.ClaimCount,
           },
@@ -193,7 +270,7 @@ describe('setTransferRestrictions procedure', () => {
     });
 
     it('should prepare a transaction with percentage restrictions', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -224,8 +301,55 @@ describe('setTransferRestrictions procedure', () => {
       });
     });
 
+    it('should prepare a transaction with claim percentage restrictions', async () => {
+      const proc = getProc();
+      const accreditedClaim = { type: ClaimType.Accredited, accredited: true } as const;
+      const args: Params = {
+        asset,
+        restrictions: [
+          {
+            min: claimPercentageMin,
+            max: claimPercentageMax,
+            issuer,
+            claim: accreditedClaim,
+            type: TransferRestrictionType.ClaimPercentage,
+          },
+        ],
+      };
+
+      when(transferRestrictionToPolymeshTransferConditionSpy)
+        .calledWith(
+          {
+            type: TransferRestrictionType.ClaimPercentage,
+            value: {
+              min: claimPercentageMin,
+              max: claimPercentageMax,
+              claim: accreditedClaim,
+              issuer,
+            },
+          },
+          mockContext
+        )
+        .mockReturnValue(rawClaimPercentageRestriction);
+
+      const claimPercentageConditionBtreeSet = dsMockUtils.createMockBtreeSet([
+        rawClaimPercentageRestriction,
+      ]) as BTreeSet<PolymeshPrimitivesTransferComplianceTransferCondition>;
+      when(complianceConditionsToBtreeSetSpy)
+        .calledWith([rawClaimPercentageRestriction], mockContext)
+        .mockReturnValue(claimPercentageConditionBtreeSet);
+
+      const result = await prepareSetTransferRestrictions.call(proc, args);
+
+      expect(result).toEqual({
+        transaction: setAssetTransferComplianceTransaction,
+        args: [rawAssetId, claimPercentageConditionBtreeSet],
+        resolver: undefined,
+      });
+    });
+
     it('should prepare a transaction with multiple restrictions', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -257,7 +381,7 @@ describe('setTransferRestrictions procedure', () => {
     });
 
     it('should throw an error for duplicate ClaimType.Accredited restrictions', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -284,17 +408,19 @@ describe('setTransferRestrictions procedure', () => {
         ],
       };
 
-      const expectedError = new PolymeshError({
-        code: ErrorCode.ValidationError,
-        message: 'Duplicate ClaimType found in input',
-        data: { claimType: ClaimType.Accredited },
-      });
-
-      await expect(prepareSetTransferRestrictions.call(proc, args)).rejects.toThrow(expectedError);
+      try {
+        await prepareSetTransferRestrictions.call(proc, args);
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PolymeshError);
+        expect((error as PolymeshError).message).toBe('Duplicate ClaimType found in input');
+        expect((error as PolymeshError).code).toBe(ErrorCode.ValidationError);
+        expect((error as PolymeshError).data).toEqual({ claimType: ClaimType.Accredited });
+      }
     });
 
     it('should throw an error for duplicate ClaimType.Affiliate restrictions', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -321,17 +447,19 @@ describe('setTransferRestrictions procedure', () => {
         ],
       };
 
-      const expectedError = new PolymeshError({
-        code: ErrorCode.ValidationError,
-        message: 'Duplicate ClaimType found in input',
-        data: { claimType: ClaimType.Affiliate },
-      });
-
-      await expect(prepareSetTransferRestrictions.call(proc, args)).rejects.toThrow(expectedError);
+      try {
+        await prepareSetTransferRestrictions.call(proc, args);
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PolymeshError);
+        expect((error as PolymeshError).message).toBe('Duplicate ClaimType found in input');
+        expect((error as PolymeshError).code).toBe(ErrorCode.ValidationError);
+        expect((error as PolymeshError).data).toEqual({ claimType: ClaimType.Affiliate });
+      }
     });
 
     it('should throw an error for duplicate Jurisdiction restrictions with same country code', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -358,17 +486,21 @@ describe('setTransferRestrictions procedure', () => {
         ],
       };
 
-      const expectedError = new PolymeshError({
-        code: ErrorCode.ValidationError,
-        message: 'Duplicate Jurisdiction CountryCode found in input',
-        data: { countryCode: CountryCode.Us },
-      });
-
-      await expect(prepareSetTransferRestrictions.call(proc, args)).rejects.toThrow(expectedError);
+      try {
+        await prepareSetTransferRestrictions.call(proc, args);
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PolymeshError);
+        expect((error as PolymeshError).message).toBe(
+          'Duplicate Jurisdiction CountryCode found in input'
+        );
+        expect((error as PolymeshError).code).toBe(ErrorCode.ValidationError);
+        expect((error as PolymeshError).data).toEqual({ countryCode: CountryCode.Us });
+      }
     });
 
     it('should throw an error for duplicate Jurisdiction restrictions with undefined country code', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -395,17 +527,21 @@ describe('setTransferRestrictions procedure', () => {
         ],
       };
 
-      const expectedError = new PolymeshError({
-        code: ErrorCode.ValidationError,
-        message: 'Duplicate Jurisdiction CountryCode found in input',
-        data: { countryCode: undefined },
-      });
-
-      await expect(prepareSetTransferRestrictions.call(proc, args)).rejects.toThrow(expectedError);
+      try {
+        await prepareSetTransferRestrictions.call(proc, args);
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PolymeshError);
+        expect((error as PolymeshError).message).toBe(
+          'Duplicate Jurisdiction CountryCode found in input'
+        );
+        expect((error as PolymeshError).code).toBe(ErrorCode.ValidationError);
+        expect((error as PolymeshError).data).toEqual({ countryCode: undefined });
+      }
     });
 
     it('should not throw an error for different Jurisdiction restrictions with different country codes', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -454,7 +590,7 @@ describe('setTransferRestrictions procedure', () => {
     });
 
     it('should not throw an error for different ClaimType restrictions', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -503,7 +639,7 @@ describe('setTransferRestrictions procedure', () => {
     });
 
     it('should not throw an error for non-ClaimCount restriction types', async () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -542,7 +678,7 @@ describe('setTransferRestrictions procedure', () => {
 
   describe('getAuthorization', () => {
     it('should return the appropriate roles and permissions', () => {
-      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const proc = getProc();
       const args: Params = {
         asset,
         restrictions: [
@@ -562,6 +698,36 @@ describe('setTransferRestrictions procedure', () => {
           portfolios: [],
         },
       });
+    });
+  });
+
+  describe('prepareStorage', () => {
+    it('should retrieve current stats from the chain', async () => {
+      const convertedStat = { type: StatType.Count } as AssetStat;
+      const assetStatToStatSpy = jest
+        .spyOn(utilsConversionModule, 'assetStatToStat')
+        .mockReturnValue(convertedStat);
+
+      const rawStatType = dsMockUtils.createMockStatisticsStatType();
+      const rawStats = dsMockUtils.createMockBtreeSet([rawStatType]);
+      dsMockUtils.createQueryMock('statistics', 'activeAssetStats', {
+        returnValue: rawStats,
+      });
+
+      const proc = getProc();
+      const result = await prepareStorage.call(proc, { asset, restrictions: [] });
+
+      expect(result).toEqual({ currentStats: [convertedStat] });
+      expect(assetStatToStatSpy).toHaveBeenCalledWith(rawStatType, mockContext);
+
+      assetStatToStatSpy.mockRestore();
+    });
+  });
+
+  describe('setTransferRestrictions', () => {
+    it('should create a Procedure instance', () => {
+      const procedure = setTransferRestrictions();
+      expect(procedure).toBeInstanceOf(Procedure);
     });
   });
 });

--- a/src/api/procedures/setTransferRestrictions.ts
+++ b/src/api/procedures/setTransferRestrictions.ts
@@ -1,10 +1,7 @@
-import BigNumber from 'bignumber.js';
-
 import { FungibleAsset, PolymeshError, Procedure } from '~/internal';
 import {
-  ClaimCountRestrictionValue,
+  AssetStat,
   ClaimCountTransferRestrictionInput,
-  ClaimPercentageTransferRestriction,
   ClaimType,
   ErrorCode,
   TransferRestriction,
@@ -14,114 +11,182 @@ import {
 } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import {
+  assetStatToStat,
   assetToMeshAssetId,
   complianceConditionsToBtreeSet,
   transferRestrictionToPolymeshTransferCondition,
 } from '~/utils/conversion';
-import { assertStatIsSet, neededStatTypeForRestrictionInput } from '~/utils/internal';
+import { assertStatIsSet } from '~/utils/internal';
 
 export type Params = { asset: FungibleAsset } & TransferRestrictionParams;
+
+export interface SetTransferRestrictionsStorage {
+  currentStats: AssetStat[];
+}
 
 /**
  * @hidden
  * Checks if the input restrictions are valid
  */
-function assertInputValid(input: TransferRestrictionParams): void {
-  input.restrictions.forEach(restriction => {
-    const type = restriction.type;
-    if (type === TransferRestrictionType.ClaimCount) {
-      const seenJurisdictions = new Set<string>();
-      const seenClaimTypes = new Set<string>();
+/**
+ * Ensure claim-count restrictions do not contain duplicate identifiers.
+ */
+function ensureClaimCountRestrictionIsUnique(
+  restriction: ClaimCountTransferRestrictionInput,
+  seenJurisdictions: Set<string>,
+  seenClaimTypes: Set<ClaimType>
+): void {
+  const { claim } = restriction;
 
-      input.restrictions.forEach(rest => {
-        const { claim } = rest as ClaimCountTransferRestrictionInput;
+  /* istanbul ignore next */
+  if (!claim) {
+    return;
+  }
 
-        if (!claim) {
-          return;
-        }
+  if (claim.type === ClaimType.Jurisdiction) {
+    const key = claim.countryCode ?? 'none';
 
-        if (claim.type === ClaimType.Jurisdiction) {
-          // cannot add two claims with same country code restrictions will result in internal error
-          if (seenJurisdictions.has(claim.countryCode || 'none')) {
-            throw new PolymeshError({
-              code: ErrorCode.ValidationError,
-              message: 'Duplicate Jurisdiction CountryCode found in input',
-              data: { countryCode: claim.countryCode },
-            });
-          }
-          seenJurisdictions.add(claim.countryCode ?? 'none');
-        } else {
-          // cannot add two ClaimType.Accredited or ClaimType.Affiliate restrictions will result in internal error
-          if (seenClaimTypes.has(claim.type)) {
-            throw new PolymeshError({
-              code: ErrorCode.ValidationError,
-              message: 'Duplicate ClaimType found in input',
-              data: { claimType: claim.type },
-            });
-          }
-          seenClaimTypes.add(claim.type);
-        }
+    if (seenJurisdictions.has(key)) {
+      throw new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message: 'Duplicate Jurisdiction CountryCode found in input',
+        data: { countryCode: claim.countryCode },
       });
     }
+
+    seenJurisdictions.add(key);
+
+    return;
+  }
+
+  if (seenClaimTypes.has(claim.type)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Duplicate ClaimType found in input',
+      data: { claimType: claim.type },
+    });
+  }
+
+  seenClaimTypes.add(claim.type);
+}
+
+/**
+ * Ensure there are no duplicate claim-based restrictions in the provided input.
+ */
+function assertInputValid(input: TransferRestrictionParams): void {
+  const seenJurisdictions = new Set<string>();
+  const seenClaimTypes = new Set<ClaimType>();
+
+  for (const restriction of input.restrictions) {
+    if (restriction.type === TransferRestrictionType.ClaimCount) {
+      ensureClaimCountRestrictionIsUnique(
+        restriction as ClaimCountTransferRestrictionInput,
+        seenJurisdictions,
+        seenClaimTypes
+      );
+    }
+  }
+}
+
+type RestrictionInput = TransferRestrictionParams['restrictions'][number];
+
+/**
+ * Convert loose restriction input into a normalized transfer restriction.
+ */
+function toTransferRestriction(restriction: RestrictionInput): TransferRestriction {
+  if ('count' in restriction) {
+    return {
+      type: TransferRestrictionType.Count,
+      value: restriction.count,
+    };
+  }
+
+  if ('percentage' in restriction) {
+    return {
+      type: TransferRestrictionType.Percentage,
+      value: restriction.percentage,
+    };
+  }
+
+  if (restriction.type === TransferRestrictionType.ClaimCount) {
+    const { min, max, claim, issuer } = restriction;
+
+    return {
+      type: TransferRestrictionType.ClaimCount,
+      value: {
+        min,
+        max,
+        claim,
+        issuer,
+      },
+    };
+  }
+
+  if (restriction.type === TransferRestrictionType.ClaimPercentage) {
+    const { min, max, claim, issuer } = restriction;
+
+    return {
+      type: TransferRestrictionType.ClaimPercentage,
+      value: {
+        min,
+        max,
+        claim,
+        issuer,
+      },
+    };
+  }
+
+  /* istanbul ignore next */
+  throw new PolymeshError({
+    code: ErrorCode.UnexpectedError,
+    message: `Unexpected transfer restriction: "${JSON.stringify(
+      restriction
+    )}". Please report this to the Polymesh team`,
   });
 }
 
 /**
  * @hidden
  */
-export async function prepareSetTransferRestrictions(
-  this: Procedure<Params, void>,
+export function prepareSetTransferRestrictions(
+  this: Procedure<Params, void, SetTransferRestrictionsStorage>,
   args: Params
 ): Promise<TransactionSpec<void, ExtrinsicParams<'statistics', 'setAssetTransferCompliance'>>> {
   const {
     context: {
       polymeshApi: {
-        query,
         tx: { statistics },
       },
     },
     context,
+    storage: { currentStats },
   } = this;
   const { restrictions, asset } = args;
   const rawAssetId = assetToMeshAssetId(asset, context);
 
   assertInputValid(args);
 
-  const currentStats = await query.statistics.activeAssetStats(rawAssetId);
-
   const conditions = restrictions.map(restriction => {
-    let value: BigNumber | ClaimCountRestrictionValue | ClaimPercentageTransferRestriction;
-    if ('count' in restriction) {
-      value = restriction.count;
-    } else if ('percentage' in restriction) {
-      value = restriction.percentage;
-    } else {
-      value = restriction;
-    }
-
-    const condition = { type: restriction.type, value } as TransferRestriction;
-
-    const neededStat = neededStatTypeForRestrictionInput(restriction, context);
-
-    assertStatIsSet(currentStats, neededStat);
+    const condition = toTransferRestriction(restriction);
+    assertStatIsSet(currentStats, condition);
 
     return transferRestrictionToPolymeshTransferCondition(condition, context);
   });
 
   const rawConditions = complianceConditionsToBtreeSet(conditions, context);
 
-  return {
+  return Promise.resolve({
     transaction: statistics.setAssetTransferCompliance,
     args: [rawAssetId, rawConditions],
     resolver: undefined,
-  };
+  });
 }
 
 /**
  * @hidden
  */
 export function getAuthorization(
-  this: Procedure<Params, void>,
+  this: Procedure<Params, void, SetTransferRestrictionsStorage>,
   { asset }: Params
 ): ProcedureAuthorization {
   return {
@@ -136,5 +201,33 @@ export function getAuthorization(
 /**
  * @hidden
  */
-export const setTransferRestrictions = (): Procedure<Params, void> =>
-  new Procedure(prepareSetTransferRestrictions, getAuthorization);
+export async function prepareStorage(
+  this: Procedure<Params, void, SetTransferRestrictionsStorage>,
+  { asset }: Params
+): Promise<SetTransferRestrictionsStorage> {
+  const {
+    context: {
+      polymeshApi: {
+        query: { statistics },
+      },
+    },
+    context,
+  } = this;
+
+  const rawAssetId = assetToMeshAssetId(asset, context);
+  const rawCurrentStats = await statistics.activeAssetStats(rawAssetId);
+  const currentStats = [...rawCurrentStats].map(stat => assetStatToStat(stat, context));
+
+  return {
+    currentStats,
+  };
+}
+
+/**
+ * @hidden
+ */
+export const setTransferRestrictions = (): Procedure<
+  Params,
+  void,
+  SetTransferRestrictionsStorage
+> => new Procedure(prepareSetTransferRestrictions, getAuthorization, prepareStorage);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -84,6 +84,7 @@ export { launchOffering } from '~/api/procedures/launchOffering';
 export {
   setTransferRestrictions,
   Params as SetTransferRestrictionParams,
+  SetTransferRestrictionsStorage,
 } from '~/api/procedures/setTransferRestrictions';
 export { setAssetStats, SetAssetStatParams } from '~/api/procedures/setAssetStats';
 export {

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -27,6 +27,7 @@ import {
   MockWebSocket,
 } from '~/testUtils/mocks/dataSources';
 import {
+  AssetStat,
   Authorization,
   AuthorizationRequest,
   AuthorizationType,
@@ -43,6 +44,7 @@ import {
   ScopeType,
   StatType,
   SubCallback,
+  TransferRestriction,
   TransferRestrictionType,
   TxTags,
 } from '~/types';
@@ -2668,16 +2670,123 @@ describe('getCorporateActionWithDescription', () => {
 });
 
 describe('assertStatIsSet', () => {
-  it('should throw an error', () => {
-    const current = dsMockUtils.createMockBtreeSet<PolymeshPrimitivesStatisticsStatType>();
-    const needed = dsMockUtils.createMockStatisticsStatType();
+  const expectedError = new PolymeshError({
+    code: ErrorCode.UnmetPrerequisite,
+    message: 'The appropriate stat type for this restriction is not set',
+  });
 
-    const expectedError = new PolymeshError({
-      code: ErrorCode.UnmetPrerequisite,
-      message: 'The appropriate stat type for this restriction is not set',
-    });
+  it('should throw when no matching stat exists', () => {
+    const stats: AssetStat[] = [{ type: StatType.Count }];
+    const restriction: TransferRestriction = {
+      type: TransferRestrictionType.Percentage,
+      value: new BigNumber(10),
+    };
 
-    expect(() => assertStatIsSet(current, needed)).toThrow(expectedError);
+    expect(() => assertStatIsSet(stats, restriction)).toThrow(expectedError);
+  });
+
+  it('should not throw when a matching scoped stat exists', () => {
+    const issuer = entityMockUtils.getIdentityInstance({ did: 'issuerDid' });
+    const stats: AssetStat[] = [
+      {
+        type: StatType.ScopedCount,
+        claimIssuer: {
+          issuer,
+          claimType: ClaimType.Accredited,
+        },
+      },
+    ];
+    const restriction: TransferRestriction = {
+      type: TransferRestrictionType.ClaimCount,
+      value: {
+        min: new BigNumber(1),
+        claim: { type: ClaimType.Accredited, accredited: true },
+        issuer,
+      },
+    };
+
+    expect(() => assertStatIsSet(stats, restriction)).not.toThrow();
+  });
+
+  it('should not throw when a matching Count stat exists', () => {
+    const stats: AssetStat[] = [{ type: StatType.Count }];
+    const restriction: TransferRestriction = {
+      type: TransferRestrictionType.Count,
+      value: new BigNumber(10),
+    };
+
+    expect(() => assertStatIsSet(stats, restriction)).not.toThrow();
+  });
+
+  it('should not throw when a matching ClaimPercentage stat exists', () => {
+    const issuer = entityMockUtils.getIdentityInstance({ did: 'issuerDid' });
+    const stats: AssetStat[] = [
+      {
+        type: StatType.ScopedBalance,
+        claimIssuer: {
+          issuer,
+          claimType: ClaimType.Accredited,
+        },
+      },
+    ];
+    const restriction: TransferRestriction = {
+      type: TransferRestrictionType.ClaimPercentage,
+      value: {
+        min: new BigNumber(1),
+        max: new BigNumber(100),
+        claim: { type: ClaimType.Accredited, accredited: true },
+        issuer,
+      },
+    };
+
+    expect(() => assertStatIsSet(stats, restriction)).not.toThrow();
+  });
+
+  it('should throw when restriction type is not supported', () => {
+    const stats: AssetStat[] = [{ type: StatType.Count }];
+    const restriction = {
+      type: 'UnsupportedType' as unknown as TransferRestrictionType,
+      value: new BigNumber(10),
+    } as TransferRestriction;
+
+    expect(() => assertStatIsSet(stats, restriction)).toThrow(expectedError);
+  });
+
+  it('should throw when ClaimCount stat has wrong type or missing claimIssuer', () => {
+    const stats: AssetStat[] = [
+      { type: StatType.Count }, // Wrong type
+      { type: StatType.ScopedCount }, // Missing claimIssuer
+    ];
+    const issuer = entityMockUtils.getIdentityInstance({ did: 'issuerDid' });
+    const restriction: TransferRestriction = {
+      type: TransferRestrictionType.ClaimCount,
+      value: {
+        min: new BigNumber(1),
+        claim: { type: ClaimType.Accredited, accredited: true },
+        issuer,
+      },
+    };
+
+    expect(() => assertStatIsSet(stats, restriction)).toThrow(expectedError);
+  });
+
+  it('should throw when ClaimPercentage stat has wrong type or missing claimIssuer', () => {
+    const stats: AssetStat[] = [
+      { type: StatType.Balance }, // Wrong type
+      { type: StatType.ScopedBalance }, // Missing claimIssuer
+    ];
+    const issuer = entityMockUtils.getIdentityInstance({ did: 'issuerDid' });
+    const restriction: TransferRestriction = {
+      type: TransferRestrictionType.ClaimPercentage,
+      value: {
+        min: new BigNumber(1),
+        max: new BigNumber(100),
+        claim: { type: ClaimType.Accredited, accredited: true },
+        issuer,
+      },
+    };
+
+    expect(() => assertStatIsSet(stats, restriction)).toThrow(expectedError);
   });
 });
 

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -7,7 +7,7 @@ import {
   DropLast,
   ObsInnerType,
 } from '@polkadot/api/types';
-import { BTreeSet, Bytes, Option, StorageKey, u32 } from '@polkadot/types';
+import { Bytes, Option, StorageKey, u32 } from '@polkadot/types';
 import { EventRecord, RewardDestination } from '@polkadot/types/interfaces';
 import { BlockHash } from '@polkadot/types/interfaces/chain';
 import {
@@ -49,12 +49,15 @@ import { Claim as MiddlewareClaim, ClaimTypeEnum, Query } from '~/middleware/typ
 import { MiddlewareScope } from '~/middleware/typesV1';
 import {
   Asset,
+  AssetStat,
   AttestPrimaryKeyRotationAuthorizationData,
   Authorization,
   AuthorizationRequest,
   AuthorizationType,
   CaCheckpointType,
   Claim,
+  ClaimCountRestrictionValue,
+  ClaimPercentageRestrictionValue,
   ClaimType,
   Condition,
   ConditionType,
@@ -79,6 +82,7 @@ import {
   StatClaimIssuer,
   StatType,
   SubCallback,
+  TransferRestriction,
   TransferRestrictionType,
   TxTag,
   UnsubCallback,
@@ -1737,13 +1741,37 @@ export function neededStatTypeForRestrictionInput(
  * @hidden
  * @throws if stat is not found in the given set
  */
-export function assertStatIsSet(
-  currentStats: BTreeSet<PolymeshPrimitivesStatisticsStatType>,
-  neededStat: PolymeshPrimitivesStatisticsStatType
-): void {
-  const needStat = ![...currentStats].find(s => s.eq(neededStat));
+export function assertStatIsSet(currentStats: AssetStat[], restriction: TransferRestriction): void {
+  const matches = currentStats.some(stat => {
+    switch (restriction.type) {
+      case TransferRestrictionType.Count:
+        return stat.type === StatType.Count;
+      case TransferRestrictionType.Percentage:
+        return stat.type === StatType.Balance;
+      case TransferRestrictionType.ClaimCount: {
+        if (stat.type !== StatType.ScopedCount || !stat.claimIssuer) {
+          return false;
+        }
+        const { issuer, claim } = restriction.value as ClaimCountRestrictionValue;
+        return (
+          stat.claimIssuer.issuer.did === issuer.did && stat.claimIssuer.claimType === claim.type
+        );
+      }
+      case TransferRestrictionType.ClaimPercentage: {
+        if (stat.type !== StatType.ScopedBalance || !stat.claimIssuer) {
+          return false;
+        }
+        const { issuer, claim } = restriction.value as ClaimPercentageRestrictionValue;
+        return (
+          stat.claimIssuer.issuer.did === issuer.did && stat.claimIssuer.claimType === claim.type
+        );
+      }
+      default:
+        return false;
+    }
+  });
 
-  if (needStat) {
+  if (!matches) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
       message: 'The appropriate stat type for this restriction is not set',


### PR DESCRIPTION
### Description

fixes issue where sdk was not correctly comparing set asset stats required for enabling transfer restrictions resulting in user being unable to set scoped transfer restrictions 

