### PR TITLE
refactor: 💡 rename release.config.js to .releaserc.js

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -9,7 +9,7 @@ module.exports = {
     {
       name: 'next-bc-+([0-9])',
       prerelease: true,
-      channel: 'next'
+      channel: 'next',
     },
     {
       name: 'v26',


### PR DESCRIPTION
### Description

Based on suggestion here - https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0, renamed the release.config.js to .releaserc.js

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
