### PR TITLE
Add selfRegisterDid procedure and related tests

### DIFF
--- a/src/api/client/Identities.ts
+++ b/src/api/client/Identities.ts
@@ -14,12 +14,14 @@ import {
   revokeIdentityToCreatePortfolios,
   rotatePrimaryKey,
   rotatePrimaryKeyToSecondary,
+  selfRegisterDid,
 } from '~/internal';
 import {
   AllowIdentityToCreatePortfoliosParams,
   AttestPrimaryKeyRotationParams,
   CreateChildIdentitiesParams,
   CreateChildIdentityParams,
+  NoArgsProcedureMethod,
   ProcedureMethod,
   RegisterIdentityParams,
   RevokeIdentityToCreatePortfoliosParams,
@@ -43,6 +45,11 @@ export class Identities {
 
     this.registerIdentity = createProcedureMethod(
       { getProcedureAndArgs: args => [registerIdentity, args] },
+      context
+    );
+
+    this.selfRegisterDid = createProcedureMethod(
+      { getProcedureAndArgs: () => [selfRegisterDid, undefined], voidArgs: true },
       context
     );
 
@@ -115,17 +122,24 @@ export class Identities {
   }
 
   /**
-   * Register an Identity, possibly with a CDD claim
+   * Register an Identity
    *
-   * @note the transaction signer must be a CDD provider
+   * @note the transaction signer must be a DID Registrar
    * @note this may create {@link AuthorizationRequest | Authorization Requests} which have to be accepted by the `targetAccount`.
    *   An {@link api/entities/Account!Account | Account} or {@link Identity} can fetch its pending Authorization Requests by calling {@link api/entities/common/namespaces/Authorizations!Authorizations.getReceived | authorizations.getReceived}.
    *   Also, an Account or Identity can directly fetch the details of an Authorization Request by calling {@link api/entities/common/namespaces/Authorizations!Authorizations.getOne | authorizations.getOne}
    *
    * @note required role:
-   *   - Customer Due Diligence Provider
+   *   - DID Registrar
    */
   public registerIdentity: ProcedureMethod<RegisterIdentityParams, Identity>;
+
+  /**
+   * Register a new DID for the signing Account
+   *
+   * @throws if the signing Account is already linked to an Identity
+   */
+  public selfRegisterDid: NoArgsProcedureMethod<Identity>;
 
   /**
    * Get CDD Provider's attestation to change primary key
@@ -198,6 +212,8 @@ export class Identities {
 
   /**
    * Create a ChildIdentity instance from a DID
+   *
+   * @deprecated Child identities are no longer supported in chain v8
    *
    * @throws if there is no ChildIdentity with the passed DID
    */

--- a/src/api/client/__tests__/Identities.ts
+++ b/src/api/client/__tests__/Identities.ts
@@ -139,6 +139,20 @@ describe('Identities Class', () => {
     });
   });
 
+  describe('method: selfRegisterDid', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Identity>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args: undefined, transformer: undefined }, context, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await identities.selfRegisterDid();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
   describe('method: createPortfolio', () => {
     it('should prepare the procedure and return the resulting transaction', async () => {
       const args = { name: 'someName' };

--- a/src/api/procedures/__tests__/selfRegisterDid.ts
+++ b/src/api/procedures/__tests__/selfRegisterDid.ts
@@ -1,0 +1,124 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+
+import {
+  createSelfRegisterDidResolver,
+  getAuthorization,
+  prepareSelfRegisterDid,
+} from '~/api/procedures/selfRegisterDid';
+import { Context, Identity, PolymeshError, Procedure } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { ErrorCode } from '~/types';
+import { PolymeshTx } from '~/types/internal';
+import * as utilsInternalModule from '~/utils/internal';
+
+describe('selfRegisterDid procedure', () => {
+  let mockContext: Mocked<Context>;
+  let selfRegisterDidTransaction: PolymeshTx<unknown[]>;
+  let proc: Procedure<void, Identity, Record<string, unknown>>;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance({ isV7: false });
+    selfRegisterDidTransaction = dsMockUtils.createTxMock('identity', 'selfRegisterDid');
+    proc = procedureMockUtils.getInstance<void, Identity>(mockContext);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should return a selfRegisterDid transaction spec', async () => {
+    const actingAccount = entityMockUtils.getAccountInstance({ getIdentity: null });
+
+    mockContext.getActingAccount.mockResolvedValue(actingAccount);
+
+    const result = await prepareSelfRegisterDid.call(proc);
+
+    expect(result).toEqual({
+      transaction: selfRegisterDidTransaction,
+      resolver: expect.any(Function),
+    });
+  });
+
+  it('should throw if called for chain v7', () => {
+    mockContext = dsMockUtils.getContextInstance({ isV7: true });
+    proc = procedureMockUtils.getInstance<void, Identity>(mockContext);
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.NotSupported,
+      message: 'selfRegisterDid is only supported in chain v8',
+    });
+
+    return expect(prepareSelfRegisterDid.call(proc)).rejects.toThrow(expectedError);
+  });
+
+  it('should throw if the signing Account already has an Identity', () => {
+    const actingAccount = entityMockUtils.getAccountInstance({
+      getIdentity: entityMockUtils.getIdentityInstance(),
+    });
+
+    mockContext.getActingAccount.mockResolvedValue(actingAccount);
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message: 'The signing Account already has an Identity',
+    });
+
+    return expect(prepareSelfRegisterDid.call(proc)).rejects.toThrow(expectedError);
+  });
+
+  describe('getAuthorization', () => {
+    it('should return signer permissions bypass', () => {
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(boundFunc()).toEqual({
+        signerPermissions: true,
+      });
+    });
+  });
+});
+
+describe('createSelfRegisterDidResolver', () => {
+  const filterEventRecordsSpy = jest.spyOn(utilsInternalModule, 'filterEventRecords');
+  const did = 'someDid';
+  const rawDid = dsMockUtils.createMockIdentityId(did);
+
+  beforeAll(() => {
+    entityMockUtils.initMocks({
+      identityOptions: {
+        did,
+      },
+    });
+  });
+
+  beforeEach(() => {
+    filterEventRecordsSpy.mockReturnValue([
+      dsMockUtils.createMockIEvent([rawDid, 'accountId', 'signingItem']),
+    ]);
+  });
+
+  afterEach(() => {
+    filterEventRecordsSpy.mockReset();
+  });
+
+  it('should return the new Identity', () => {
+    const fakeContext = {} as Context;
+
+    const result = createSelfRegisterDidResolver(fakeContext)({} as ISubmittableResult);
+
+    expect(result.did).toEqual(did);
+  });
+});

--- a/src/api/procedures/selfRegisterDid.ts
+++ b/src/api/procedures/selfRegisterDid.ts
@@ -1,0 +1,74 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+
+import { Context, Identity, PolymeshError, Procedure } from '~/internal';
+import { ErrorCode } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { identityIdToString } from '~/utils/conversion';
+import { filterEventRecords } from '~/utils/internal';
+
+/**
+ * @hidden
+ */
+export const createSelfRegisterDidResolver =
+  (context: Context) =>
+  (receipt: ISubmittableResult): Identity => {
+    const [record] = filterEventRecords(receipt, 'identity', 'DidCreated');
+
+    const { data } = record!;
+
+    const did = identityIdToString(data[0]);
+
+    return new Identity({ did }, context);
+  };
+
+/**
+ * @hidden
+ */
+export async function prepareSelfRegisterDid(
+  this: Procedure<void, Identity>
+): Promise<TransactionSpec<Identity, ExtrinsicParams<'identity', 'selfRegisterDid'>>> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    context,
+  } = this;
+
+  if (context.isV7) {
+    throw new PolymeshError({
+      code: ErrorCode.NotSupported,
+      message: 'selfRegisterDid is only supported in chain v8',
+    });
+  }
+
+  const actingAccount = await context.getActingAccount();
+
+  const identityExists = await actingAccount.getIdentity();
+
+  if (identityExists) {
+    throw new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message: 'The signing Account already has an Identity',
+    });
+  }
+
+  return {
+    transaction: tx.identity.selfRegisterDid,
+    resolver: createSelfRegisterDidResolver(context),
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(): ProcedureAuthorization {
+  return {
+    signerPermissions: true,
+  };
+}
+
+/**
+ * @hidden
+ */
+export const selfRegisterDid = (): Procedure<void, Identity> =>
+  new Procedure(prepareSelfRegisterDid, getAuthorization);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -45,6 +45,7 @@ export {
   Params as ModifyAssetTrustedClaimIssuersParams,
 } from '~/api/procedures/modifyAssetTrustedClaimIssuers';
 export { registerIdentity } from '~/api/procedures/registerIdentity';
+export { selfRegisterDid } from '~/api/procedures/selfRegisterDid';
 export { createChildIdentity } from '~/api/procedures/createChildIdentity';
 export { createChildIdentities } from '~/api/procedures/createChildIdentities';
 export { attestPrimaryKeyRotation } from '~/api/procedures/attestPrimaryKeyRotation';


### PR DESCRIPTION
### Description

Introduce the `selfRegisterDid` procedure to allow accounts to register a new DID. This includes the implementation of the procedure and corresponding tests to ensure functionality.

### Breaking Changes

No breaking changes.

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?

