### PR TITLE
### Implement mandatory receiver affirmation procedures

### DIFF
--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -34,6 +34,7 @@ import {
   PermissionedAccount,
   Permissions,
   PortfolioCustodianRole,
+  ReceiverAffirmationRequirement,
   Role,
   RoleType,
   TickerOwnerRole,
@@ -1489,6 +1490,62 @@ describe('Identity class', () => {
       const result = await identity.isAssetPreApproved(assetId);
 
       expect(result).toBeTruthy();
+    });
+  });
+
+  describe('method: isMandatoryReceiverAffirmationEnabled', () => {
+    it('should return true when mandatory receiver affirmation is enabled', async () => {
+      const did = 'someDid';
+      const rawDid = dsMockUtils.createMockIdentityId(did);
+      const mockContext = dsMockUtils.getContextInstance();
+      const identity = new Identity({ did }, mockContext);
+
+      when(stringToIdentityIdSpy).calledWith(did, mockContext).mockReturnValue(rawDid);
+
+      dsMockUtils
+        .createQueryMock('settlement', 'mandatoryReceiverAffirmation')
+        .mockResolvedValue(dsMockUtils.createMockBool(true));
+
+      const result = await identity.isMandatoryReceiverAffirmationEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when mandatory receiver affirmation is disabled', async () => {
+      const did = 'someDid';
+      const rawDid = dsMockUtils.createMockIdentityId(did);
+      const mockContext = dsMockUtils.getContextInstance();
+      const identity = new Identity({ did }, mockContext);
+
+      when(stringToIdentityIdSpy).calledWith(did, mockContext).mockReturnValue(rawDid);
+
+      dsMockUtils
+        .createQueryMock('settlement', 'mandatoryReceiverAffirmation')
+        .mockResolvedValue(dsMockUtils.createMockBool(false));
+
+      const result = await identity.isMandatoryReceiverAffirmationEnabled();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('method: setMandatoryReceiverAffirmation', () => {
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const did = 'someDid';
+      const mockContext = dsMockUtils.getContextInstance();
+      const identity = new Identity({ did }, mockContext);
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      const args = { requirement: ReceiverAffirmationRequirement.Required };
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args: { ...args, did }, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const result = await identity.setMandatoryReceiverAffirmation(args);
+
+      expect(result).toBe(expectedTransaction);
     });
   });
 

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -24,6 +24,7 @@ import {
   Nft,
   NftCollection,
   PolymeshError,
+  setMandatoryReceiverAffirmation,
   TickerReservation,
   Venue,
 } from '~/internal';
@@ -48,6 +49,7 @@ import {
   PaginationOptions,
   PermissionedAccount,
   ProcedureMethod,
+  ReceiverAffirmationRequirement,
   ResultSet,
   Role,
   SubCallback,
@@ -142,6 +144,13 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
     this.unlinkChild = createProcedureMethod(
       {
         getProcedureAndArgs: args => [unlinkChildIdentity, args],
+      },
+      context
+    );
+
+    this.setMandatoryReceiverAffirmation = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [setMandatoryReceiverAffirmation, { ...args, did: this.did }],
       },
       context
     );
@@ -1178,6 +1187,39 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
 
     return boolToBoolean(rawIsApproved);
   }
+
+  /**
+   * Returns whether or not this Identity has opted in to mandatory receiver affirmation.
+   * When `true`, the identity must explicitly affirm incoming asset transfer in settlements
+   * unless an asset level or portfolio level exemption applies.
+   */
+  public async isMandatoryReceiverAffirmationEnabled(): Promise<boolean> {
+    const {
+      context,
+      context: {
+        polymeshApi: {
+          query: { settlement },
+        },
+      },
+    } = this;
+
+    const rawDid = stringToIdentityId(this.did, context);
+
+    const rawValue = await settlement.mandatoryReceiverAffirmation(rawDid);
+
+    return boolToBoolean(rawValue);
+  }
+
+  /**
+   * Enable or disable mandatory receiver affirmation for incoming settlement transfers.
+   * When enabled (`ReceiverAffirmationRequirement.Required`), the signing identity must explicitly affirm
+   * any incoming asset transfer unless an asset level or portfolio level exemption applies.
+   * When disabled (`ReceiverAffirmationRequirement.Automatic`), all incoming transfers are auto-affirmed.
+   */
+  public setMandatoryReceiverAffirmation: ProcedureMethod<
+    { requirement: ReceiverAffirmationRequirement },
+    void
+  >;
 
   /**
    * Returns the list of MultiSig accounts along with their signatories this identity has responsibility for.

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -100,6 +100,11 @@ export enum AffirmationStatus {
   Rejected = 'Rejected',
 }
 
+export enum ReceiverAffirmationRequirement {
+  Automatic = 'Automatic',
+  Required = 'Required',
+}
+
 export interface InstructionAffirmation {
   party: Identity | Account;
   status: AffirmationStatus;

--- a/src/api/procedures/__tests__/setMandatoryReceiverAffirmation.ts
+++ b/src/api/procedures/__tests__/setMandatoryReceiverAffirmation.ts
@@ -1,0 +1,205 @@
+import { PolymeshPrimitivesSettlementAffirmationRequirement } from '@polkadot/types/lookup';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareSetMandatoryReceiverAffirmation,
+  prepareStorage,
+  Storage,
+} from '~/api/procedures/setMandatoryReceiverAffirmation';
+import { Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { Identity, ReceiverAffirmationRequirement, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Identity',
+  require('~/testUtils/mocks/entities').mockIdentityModule('~/api/entities/Identity')
+);
+
+describe('setMandatoryReceiverAffirmation procedure', () => {
+  let mockContext: Mocked<Context>;
+  let mockSigningIdentity: Mocked<Identity>;
+  let affirmationRequirementToMeshSpy: jest.SpyInstance;
+  let rawAutomatic: PolymeshPrimitivesSettlementAffirmationRequirement;
+  let rawRequired: PolymeshPrimitivesSettlementAffirmationRequirement;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    affirmationRequirementToMeshSpy = jest.spyOn(
+      utilsConversionModule,
+      'affirmationRequirementToMesh'
+    );
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance({ isV7: false });
+    mockSigningIdentity = entityMockUtils.getIdentityInstance({ did: 'someDid' });
+    mockContext.getSigningIdentity.mockResolvedValue(mockSigningIdentity);
+
+    rawAutomatic = dsMockUtils.createMockAffirmationRequirement('Automatic');
+    rawRequired = dsMockUtils.createMockAffirmationRequirement('Required');
+
+    when(affirmationRequirementToMeshSpy)
+      .calledWith(ReceiverAffirmationRequirement.Automatic, mockContext)
+      .mockReturnValue(rawAutomatic);
+    when(affirmationRequirementToMeshSpy)
+      .calledWith(ReceiverAffirmationRequirement.Required, mockContext)
+      .mockReturnValue(rawRequired);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw a NotSupported error when called on a v7 chain', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      identity: mockSigningIdentity,
+    });
+    mockContext.isV7 = true;
+
+    return expect(
+      prepareSetMandatoryReceiverAffirmation.call(proc, {
+        did: 'someDid',
+        requirement: ReceiverAffirmationRequirement.Required,
+      })
+    ).rejects.toThrow('setMandatoryReceiverAffirmation is not supported on v7 chains');
+  });
+
+  it('should throw a NoDataChange error when setting Required and it is already Required', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      identity: mockSigningIdentity,
+    });
+
+    dsMockUtils
+      .createQueryMock('settlement', 'mandatoryReceiverAffirmation')
+      .mockResolvedValue(dsMockUtils.createMockBool(true));
+
+    return expect(
+      prepareSetMandatoryReceiverAffirmation.call(proc, {
+        did: 'someDid',
+        requirement: ReceiverAffirmationRequirement.Required,
+      })
+    ).rejects.toThrow('The signing identity already requires mandatory receiver affirmation');
+  });
+
+  it('should throw a NoDataChange error when setting Automatic and it is already Automatic', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      identity: mockSigningIdentity,
+    });
+
+    dsMockUtils
+      .createQueryMock('settlement', 'mandatoryReceiverAffirmation')
+      .mockResolvedValue(dsMockUtils.createMockBool(false));
+
+    return expect(
+      prepareSetMandatoryReceiverAffirmation.call(proc, {
+        did: 'someDid',
+        requirement: ReceiverAffirmationRequirement.Automatic,
+      })
+    ).rejects.toThrow('The signing identity already has automatic receiver affirmation');
+  });
+
+  it('should return a setMandatoryReceiverAffirmation transaction spec when switching to Required', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      identity: mockSigningIdentity,
+    });
+
+    dsMockUtils
+      .createQueryMock('settlement', 'mandatoryReceiverAffirmation')
+      .mockResolvedValue(dsMockUtils.createMockBool(false));
+
+    const transaction = dsMockUtils.createTxMock('settlement', 'setMandatoryReceiverAffirmation');
+
+    const result = await prepareSetMandatoryReceiverAffirmation.call(proc, {
+      did: 'someDid',
+      requirement: ReceiverAffirmationRequirement.Required,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawRequired],
+      resolver: undefined,
+    });
+  });
+
+  it('should return a setMandatoryReceiverAffirmation transaction spec when switching to Automatic', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      identity: mockSigningIdentity,
+    });
+
+    dsMockUtils
+      .createQueryMock('settlement', 'mandatoryReceiverAffirmation')
+      .mockResolvedValue(dsMockUtils.createMockBool(true));
+
+    const transaction = dsMockUtils.createTxMock('settlement', 'setMandatoryReceiverAffirmation');
+
+    const result = await prepareSetMandatoryReceiverAffirmation.call(proc, {
+      did: 'someDid',
+      requirement: ReceiverAffirmationRequirement.Automatic,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawAutomatic],
+      resolver: undefined,
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return a signerPermissions error when the signing identity does not match the did', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        identity: mockSigningIdentity,
+      });
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(
+        boundFunc({ did: 'differentDid', requirement: ReceiverAffirmationRequirement.Required })
+      ).toEqual({
+        signerPermissions:
+          'Only a signing key linked to the Identity can set its mandatory receiver affirmation',
+      });
+    });
+
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        identity: mockSigningIdentity,
+      });
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(
+        boundFunc({ did: 'someDid', requirement: ReceiverAffirmationRequirement.Required })
+      ).toEqual({
+        permissions: {
+          transactions: [TxTags.settlement.SetMandatoryReceiverAffirmation],
+          assets: [],
+          portfolios: [],
+        },
+      });
+    });
+  });
+
+  describe('prepareStorage', () => {
+    it('should return the signing identity', async () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        identity: mockSigningIdentity,
+      });
+      const boundFunc = prepareStorage.bind(proc);
+
+      const result = await boundFunc();
+
+      expect(result).toEqual({ identity: mockSigningIdentity });
+    });
+  });
+});

--- a/src/api/procedures/setMandatoryReceiverAffirmation.ts
+++ b/src/api/procedures/setMandatoryReceiverAffirmation.ts
@@ -1,0 +1,114 @@
+import { PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, Identity, ReceiverAffirmationRequirement, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { affirmationRequirementToMesh, stringToIdentityId } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export interface Params {
+  did: string;
+  requirement: ReceiverAffirmationRequirement;
+}
+
+/**
+ * @hidden
+ */
+export interface Storage {
+  identity: Identity;
+}
+
+/**
+ * @hidden
+ */
+export async function prepareSetMandatoryReceiverAffirmation(
+  this: Procedure<Params, void, Storage>,
+  args: Params
+): Promise<
+  TransactionSpec<void, ExtrinsicParams<'settlement', 'setMandatoryReceiverAffirmation'>>
+> {
+  const {
+    context: {
+      polymeshApi: { tx, query },
+    },
+    context,
+  } = this;
+  const { did, requirement } = args;
+
+  if (context.isV7) {
+    throw new PolymeshError({
+      code: ErrorCode.NotSupported,
+      message: 'setMandatoryReceiverAffirmation is not supported on v7 chains',
+    });
+  }
+
+  const rawDid = stringToIdentityId(did, context);
+
+  const rawCurrentValue = await query.settlement.mandatoryReceiverAffirmation(rawDid);
+  const currentRequirement = rawCurrentValue.isTrue
+    ? ReceiverAffirmationRequirement.Required
+    : ReceiverAffirmationRequirement.Automatic;
+
+  if (requirement === currentRequirement) {
+    throw new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message:
+        requirement === ReceiverAffirmationRequirement.Required
+          ? 'The signing identity already requires mandatory receiver affirmation'
+          : 'The signing identity already has automatic receiver affirmation',
+      data: { identity: did },
+    });
+  }
+
+  const rawRequirement = affirmationRequirementToMesh(requirement, context);
+
+  return {
+    transaction: tx.settlement.setMandatoryReceiverAffirmation,
+    args: [rawRequirement],
+    resolver: undefined,
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void, Storage>,
+  { did }: Params
+): ProcedureAuthorization {
+  const {
+    storage: { identity },
+  } = this;
+
+  if (identity.did !== did) {
+    return {
+      signerPermissions:
+        'Only a signing key linked to the Identity can set its mandatory receiver affirmation',
+    };
+  }
+
+  return {
+    permissions: {
+      transactions: [TxTags.settlement.SetMandatoryReceiverAffirmation],
+      assets: [],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export async function prepareStorage(this: Procedure<Params, void, Storage>): Promise<Storage> {
+  const { context } = this;
+
+  const identity = await context.getSigningIdentity();
+
+  return { identity };
+}
+
+/**
+ * @hidden
+ */
+export const setMandatoryReceiverAffirmation = (): Procedure<Params, void, Storage> =>
+  new Procedure(prepareSetMandatoryReceiverAffirmation, getAuthorization, prepareStorage);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -179,6 +179,7 @@ export { setMultiSigAdmin } from '~/api/procedures/setMultiSigAdmin';
 export { setVenueFiltering } from '~/api/procedures/setVenueFiltering';
 export { registerCustomClaimType } from '~/api/procedures/registerCustomClaimType';
 export { toggleAssetPreApproval } from '~/api/procedures/toggleAssetPreApproval';
+export { setMandatoryReceiverAffirmation } from '~/api/procedures/setMandatoryReceiverAffirmation';
 export { allowIdentityToCreatePortfolios } from '~/api/procedures/allowIdentityToCreatePortfolios';
 export { revokeIdentityToCreatePortfolios } from '~/api/procedures/revokeIdentityToCreatePortfolios';
 export { rotatePrimaryKeyToSecondary } from '~/api/procedures/rotatePrimaryKeyToSecondary';

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -129,6 +129,7 @@ import {
   PolymeshPrimitivesSecondaryKeyPalletPermissions,
   PolymeshPrimitivesSecondaryKeyPermissions,
   PolymeshPrimitivesSecondaryKeySignatory,
+  PolymeshPrimitivesSettlementAffirmationRequirement,
   PolymeshPrimitivesSettlementAffirmationStatus,
   PolymeshPrimitivesSettlementAssetCount,
   PolymeshPrimitivesSettlementInstruction,
@@ -3443,6 +3444,16 @@ export const createMockSettlementType = (
     | { SettleManual: u32 }
 ): MockCodec<PolymeshPrimitivesSettlementSettlementType> => {
   return createMockEnum<PolymeshPrimitivesSettlementSettlementType>(settlementType);
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
+export const createMockAffirmationRequirement = (
+  requirement?: 'Automatic' | 'Required'
+): MockCodec<PolymeshPrimitivesSettlementAffirmationRequirement> => {
+  return createMockEnum<PolymeshPrimitivesSettlementAffirmationRequirement>(requirement);
 };
 
 /**

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -178,6 +178,7 @@ import {
   PermissionType,
   PortfolioMovement,
   ProposalStatus,
+  ReceiverAffirmationRequirement,
   Scope,
   ScopeType,
   SecurityIdentifierType,
@@ -206,6 +207,7 @@ import {
   accountIdToString,
   activeEraStakingToActiveEraInfo,
   addressToKey,
+  affirmationRequirementToMesh,
   agentGroupToPermissionGroup,
   agentGroupToPermissionGroupIdentifier,
   assetComplianceReportToCompliance,
@@ -6915,6 +6917,51 @@ describe('transactionToTxTag', () => {
 
     const result = transactionToTxTag(tx);
     expect(result).toEqual(fakeResult);
+  });
+});
+
+describe('affirmationRequirementToMesh', () => {
+  let mockContext: Mocked<Context>;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should convert an ReceiverAffirmationRequirement to a polkadot ReceiverAffirmationRequirement', () => {
+    const automaticResult = dsMockUtils.createMockAffirmationRequirement('Automatic');
+    const requiredResult = dsMockUtils.createMockAffirmationRequirement('Required');
+
+    when(mockContext.createType)
+      .calledWith(
+        'PolymeshPrimitivesSettlementAffirmationRequirement',
+        ReceiverAffirmationRequirement.Automatic
+      )
+      .mockReturnValue(automaticResult);
+    when(mockContext.createType)
+      .calledWith(
+        'PolymeshPrimitivesSettlementAffirmationRequirement',
+        ReceiverAffirmationRequirement.Required
+      )
+      .mockReturnValue(requiredResult);
+
+    expect(
+      affirmationRequirementToMesh(ReceiverAffirmationRequirement.Automatic, mockContext)
+    ).toBe(automaticResult);
+    expect(affirmationRequirementToMesh(ReceiverAffirmationRequirement.Required, mockContext)).toBe(
+      requiredResult
+    );
   });
 });
 

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -73,6 +73,7 @@ import {
   PolymeshPrimitivesSecondaryKeyExtrinsicPermissions,
   PolymeshPrimitivesSecondaryKeyPermissions,
   PolymeshPrimitivesSecondaryKeySignatory,
+  PolymeshPrimitivesSettlementAffirmationRequirement,
   PolymeshPrimitivesSettlementAffirmationStatus,
   PolymeshPrimitivesSettlementAssetCount,
   PolymeshPrimitivesSettlementInstructionStatus,
@@ -278,6 +279,7 @@ import {
   PortfolioId,
   PortfolioLike,
   ProposalStatus,
+  ReceiverAffirmationRequirement,
   Requirement,
   RequirementCompliance,
   Scope,
@@ -3381,6 +3383,16 @@ export function meshInstructionStatusToInstructionStatus(
   }
 
   return InternalInstructionStatus.Unknown;
+}
+
+/**
+ * @hidden
+ */
+export function affirmationRequirementToMesh(
+  requirement: ReceiverAffirmationRequirement,
+  context: Context
+): PolymeshPrimitivesSettlementAffirmationRequirement {
+  return context.createType('PolymeshPrimitivesSettlementAffirmationRequirement', requirement);
 }
 
 /**


### PR DESCRIPTION


<!-- Introduce mandatory receiver affirmation procedures, allowing identities to require explicit affirmation for incoming asset transfers. This includes related tests to ensure functionality. -->



### Breaking Changes



<!-- No breaking changes. -->



### JIRA Link



<!-- No JIRA issue referenced. -->



### Checklist



- [ ] Updated the Readme.md (if required) ?

