### PR TITLE
fix: support signers that return a signed transaction (Ledger generic app)

### DIFF
--- a/changelogs/v30.0.0-v30.1.0.md
+++ b/changelogs/v30.0.0-v30.1.0.md
@@ -1,0 +1,81 @@
+---
+title: SDK Changelog - v30.0.0 to v30.1.0
+description: Changes between Polymesh SDK v30.0.0 and v30.1.0. Includes bug fixes and dependency updates.
+sidebar_label: v30.0.0 → v30.1.0
+id: v30-to-v30-1
+tags:
+  - changelog
+  - sdk
+---
+
+This guide describes changes between **v30.0.0** and **v30.1.0** of `@polymeshassociation/polymesh-sdk`.
+
+---
+
+## Overview
+
+v30.1.0 is a **minor release** containing bug fixes and a dependency update. There are **no breaking changes** — upgrading is a drop-in replacement for v30.0.0.
+
+---
+
+## Dependency updates
+
+| Package                               | v30.0.0 | v30.1.0    |
+| ------------------------------------- | ------- | ---------- |
+| `@polymeshassociation/polymesh-types` | ^7.4.0  | **^7.5.0** |
+
+---
+
+## Bug fixes
+
+### Asset transaction history pagination
+
+`assetTransactionQuery` (used by `getTransactionHistory()` on assets) was missing its pagination parameters, so `size` and `start` were ignored and the full result set was always requested from middleware. Pagination now works as documented:
+
+```typescript
+const { data, next } = await asset.getTransactionHistory({
+  size: new BigNumber(25),
+  start: new BigNumber(0),
+});
+```
+
+---
+
+### Transaction status change events
+
+`onStatusChange` listeners were only notified for the `Unapproved`, `Running`, and terminal statuses — the intermediate `Future` and `InBlock` statuses introduced in v30.0.0 (and `Idle`) were skipped. All status transitions now emit a `StatusChange` event, so progress monitoring like the following works as expected:
+
+```typescript
+tx.onStatusChange(transaction => {
+  if (transaction.status === TransactionStatus.InBlock) {
+    console.log('Transaction included in block, awaiting finalization');
+  }
+});
+```
+
+---
+
+### WebSocket selection in Cloudflare Workers
+
+Environments that expose both a native `WebSocket` and Node.js compatibility flags (e.g. Cloudflare Workers with `nodejs_compat`) caused the SDK's chain version check to import the Node `ws` package and fail with `ws does not work in the browser`. The SDK now prefers the native `WebSocket` whenever it exists and only falls back to `ws` when it does not.
+
+---
+
+### `Account.getTypeInfo()` smart contract check removed
+
+`Account.getTypeInfo()` no longer queries the `contracts` pallet, which is not part of the Polymesh runtime. The method will no longer return `AccountKeyType.SmartContract` (the enum value remains for compatibility but is never returned).
+
+---
+
+### Documentation build
+
+`rimraf` was added as a dev dependency so the docs build works from a clean checkout (internal tooling fix, no runtime impact).
+
+---
+
+## Version compatibility matrix
+
+| SDK version | Chain v7 | Chain v8 | Middleware V2     | Polkadot.js |
+| ----------- | -------- | -------- | ----------------- | ----------- |
+| v30.0.0     | ✅       | ✅       | ≥ v19.6.0-alpha.2 | 16.5.2      |
+| v30.1.0     | ✅       | ✅       | ≥ v19.6.0-alpha.2 | 16.5.2      |

--- a/changelogs/v30.1.0-next.md
+++ b/changelogs/v30.1.0-next.md
@@ -1,0 +1,41 @@
+---
+title: SDK Changelog - v30.1.0 to next release
+description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes Ledger signing support fixes.
+sidebar_label: v30.1.0 → next
+id: v30-1-to-next
+tags:
+  - changelog
+  - sdk
+---
+
+This guide describes **unreleased** changes since **v30.1.0** of `@polymeshassociation/polymesh-sdk`. These will be included in the next release.
+
+---
+
+## Overview
+
+This release fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app. There are **no breaking changes** and no code changes are required in consuming applications.
+
+---
+
+## Bug fixes
+
+### Support signers that return a signed transaction (Ledger generic app)
+
+Signing any transaction with a Ledger device via the Polkadot Generic Ledger app failed with:
+
+```
+The `signedTransaction` field may not be submitted when `withSignedTransaction` is disabled
+```
+
+The generic Ledger app requires the `CheckMetadataHash` signed extension, which means the wallet must rebuild the transaction (setting `mode` and `metadataHash`) before the device will sign it. The wallet then returns the rebuilt extrinsic in `SignerResult.signedTransaction`, which the Polkadot API rejects unless the caller opts in.
+
+The SDK now passes `withSignedTransaction: true` when signing, so signers that return a rebuilt `signedTransaction` are accepted and the rebuilt extrinsic is what gets submitted to the chain.
+
+**Details:**
+
+- **No impact on other signers** — software wallets and local keypairs return only a signature and behave exactly as before; the option merely permits the `signedTransaction` field, it does not request it.
+- **Call data is protected** — the SDK also sets `allowCallDataAlteration: false`, so a returned `signedTransaction` may only alter signed extensions (e.g. `mode`, `metadataHash`, era, nonce, tip). Any submission where the signer changed the transaction call itself is rejected with an error.
+- **Correct hash tracking** — because a rebuilt extrinsic can have a different hash than the one the SDK composed, the SDK now tracks the hash of the transaction actually submitted to the node. `txHash` on the transaction object always reflects the on-chain extrinsic.
+
+No migration steps are needed — transactions signed with Ledger devices simply work.

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -2,6 +2,7 @@
 import { EventEmitter } from 'events';
 
 import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { SignerOptions } from '@polkadot/api-base/types';
 import { ISubmittableResult, Signer as PolkadotSigner } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
@@ -397,86 +398,98 @@ export abstract class PolymeshTransactionBase<
 
     const txWithArgs = this.composeTx();
 
+    const signerOptions = {
+      nonce,
+      /*
+       * allows signers (e.g. Ledger devices signing via the generic app) to return a modified
+       *   `signedTransaction`, which is required when signed extensions like `CheckMetadataHash` alter the payload
+       */
+      withSignedTransaction: true,
+      /*
+       * a returned `signedTransaction` may only alter signed extensions (e.g. `mode`, `metadataHash`).
+       *   The API will reject any submission where the signer changed the call data itself
+       */
+      allowCallDataAlteration: false,
+      ...(signer && { signer }),
+      ...(era !== undefined ? { era } : {}),
+    };
+
     if (context.supportsSubscription()) {
       return new Promise((resolve, reject) => {
         let settingBlockData = Promise.resolve();
-        const gettingUnsub = txWithArgs.signAndSend(
-          signingAddress,
-          { nonce, ...(signer && { signer }), ...(era !== undefined ? { era } : {}) },
-          receipt => {
-            const { status } = receipt;
-            let isLastCallback = false;
-            let unsubscribing = Promise.resolve();
-            let extrinsicFailedEvent;
+        const gettingUnsub = txWithArgs.signAndSend(signingAddress, signerOptions, receipt => {
+          const { status } = receipt;
+          let isLastCallback = false;
+          let unsubscribing = Promise.resolve();
+          let extrinsicFailedEvent;
 
-            if (status.isFuture) {
-              this.updateStatus(TransactionStatus.Future);
-            } else if (receipt.isCompleted) {
-              // isCompleted implies status is one of: isFinalized, isInBlock or isError
-              if (receipt.isInBlock) {
-                const inBlockHash = status.asInBlock;
-                /*
-                 * this must be done to ensure that the block hash and number are set before the success event
-                 *   is emitted, and at the same time. We do not resolve or reject the containing promise until this
-                 *   one resolves
-                 */
-                settingBlockData = defusePromise(
-                  this.context.polymeshApi.rpc.chain.getBlock(inBlockHash).then(({ block }) => {
-                    this.blockHash = hashToString(inBlockHash);
-                    this.blockNumber = u32ToBigNumber(block.header.number.unwrap());
-
-                    // we know that the index has to be set by the time the transaction is included in a block
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    this.txIndex = new BigNumber(receipt.txIndex!);
-                    this.updateStatus(TransactionStatus.InBlock);
-                  })
-                );
-
-                // if the extrinsic failed due to an on-chain error, we should handle it in a special way
-                [extrinsicFailedEvent] = filterEventRecords(
-                  receipt,
-                  'system',
-                  'ExtrinsicFailed',
-                  true
-                );
-                // extrinsic failed so we can unsubscribe
-                isLastCallback = !!extrinsicFailedEvent;
-              } else {
-                // isFinalized || isError so we know we can unsubscribe
-                isLastCallback = true;
-              }
-
-              if (isLastCallback) {
-                unsubscribing = gettingUnsub.then((unsub: UnsubCallback) => {
-                  unsub();
-                });
-              }
-
+          if (status.isFuture) {
+            this.updateStatus(TransactionStatus.Future);
+          } else if (receipt.isCompleted) {
+            // isCompleted implies status is one of: isFinalized, isInBlock or isError
+            if (receipt.isInBlock) {
+              const inBlockHash = status.asInBlock;
               /*
-               * Promise chain that handles all sub-promises in this pass through the signAndSend callback.
-               * Primarily for consistent error handling
+               * this must be done to ensure that the block hash and number are set before the success event
+               *   is emitted, and at the same time. We do not resolve or reject the containing promise until this
+               *   one resolves
                */
-              let finishing = Promise.resolve();
+              settingBlockData = defusePromise(
+                this.context.polymeshApi.rpc.chain.getBlock(inBlockHash).then(({ block }) => {
+                  this.blockHash = hashToString(inBlockHash);
+                  this.blockNumber = u32ToBigNumber(block.header.number.unwrap());
 
-              if (extrinsicFailedEvent) {
-                const { data } = extrinsicFailedEvent;
+                  // we know that the index has to be set by the time the transaction is included in a block
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  this.txIndex = new BigNumber(receipt.txIndex!);
+                  this.updateStatus(TransactionStatus.InBlock);
+                })
+              );
 
-                finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
-                  const error = handleExtrinsicFailure(data[0]);
-                  reject(error);
-                });
-              } else if (receipt.isFinalized) {
-                finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
-                  this.handleExtrinsicSuccess(resolve, reject, receipt);
-                });
-              } else if (receipt.isError) {
-                reject(new PolymeshError({ code: ErrorCode.TransactionAborted }));
-              }
-
-              finishing.catch((err: Error) => reject(err));
+              // if the extrinsic failed due to an on-chain error, we should handle it in a special way
+              [extrinsicFailedEvent] = filterEventRecords(
+                receipt,
+                'system',
+                'ExtrinsicFailed',
+                true
+              );
+              // extrinsic failed so we can unsubscribe
+              isLastCallback = !!extrinsicFailedEvent;
+            } else {
+              // isFinalized || isError so we know we can unsubscribe
+              isLastCallback = true;
             }
+
+            if (isLastCallback) {
+              unsubscribing = gettingUnsub.then((unsub: UnsubCallback) => {
+                unsub();
+              });
+            }
+
+            /*
+             * Promise chain that handles all sub-promises in this pass through the signAndSend callback.
+             * Primarily for consistent error handling
+             */
+            let finishing = Promise.resolve();
+
+            if (extrinsicFailedEvent) {
+              const { data } = extrinsicFailedEvent;
+
+              finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
+                const error = handleExtrinsicFailure(data[0]);
+                reject(error);
+              });
+            } else if (receipt.isFinalized) {
+              finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
+                this.handleExtrinsicSuccess(resolve, reject, receipt);
+              });
+            } else if (receipt.isError) {
+              reject(new PolymeshError({ code: ErrorCode.TransactionAborted }));
+            }
+
+            finishing.catch((err: Error) => reject(err));
           }
-        );
+        });
 
         gettingUnsub
           .then(() => {
@@ -489,50 +502,68 @@ export abstract class PolymeshTransactionBase<
           });
       });
     } else {
-      const startingBlock = await context.getLatestBlock();
-
-      await txWithArgs
-        .signAndSend(signingAddress, {
-          nonce,
-          ...(signer && { signer }),
-          ...(era !== undefined ? { era } : {}),
-        })
-        .then(() => {
-          this.setIsRunningStatus(txWithArgs.hash.toString());
-        })
-        .catch((err: Error) => {
-          const error = handleTransactionSubmissionError(err);
-
-          throw new PolymeshError(error);
-        });
-
-      const finalizedReceipt = await pollForTransactionFinalization(
-        txWithArgs.hash,
-        startingBlock,
-        context
-      );
-
-      this.blockHash = hashToString(finalizedReceipt.status.asFinalized);
-      this.blockNumber = u32ToBigNumber(finalizedReceipt.blockNumber!);
-      this.txIndex = new BigNumber(finalizedReceipt.txIndex!);
-
-      // if the extrinsic failed due to an on-chain error, we should handle it in a special way
-      const [extrinsicFailedEvent] = filterEventRecords(
-        finalizedReceipt,
-        'system',
-        'ExtrinsicFailed',
-        true
-      );
-
-      if (extrinsicFailedEvent) {
-        const { data } = extrinsicFailedEvent;
-        const error = handleExtrinsicFailure(data[0]);
-
-        throw error;
-      }
-
-      return finalizedReceipt;
+      return this.runViaPolling(txWithArgs, signerOptions);
     }
+  }
+
+  /**
+   * @hidden
+   *
+   * Sign and submit the transaction, then poll for its finalization. Used when the
+   *   node connection does not support subscriptions
+   */
+  private async runViaPolling(
+    txWithArgs: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    signerOptions: Partial<SignerOptions>
+  ): Promise<ISubmittableResult> {
+    const { signingAddress, context } = this;
+
+    const startingBlock = await context.getLatestBlock();
+
+    /*
+     * the resolved hash is used instead of `txWithArgs.hash` because a signer may return a modified
+     *   `signedTransaction` (e.g. Ledger devices signing via the generic app), in which case the
+     *   submitted extrinsic's hash can differ from the locally composed one
+     */
+    const submittedTxHash = await txWithArgs
+      .signAndSend(signingAddress, signerOptions)
+      .then(txHash => {
+        this.setIsRunningStatus(txHash.toString());
+
+        return txHash;
+      })
+      .catch((err: Error) => {
+        const error = handleTransactionSubmissionError(err);
+
+        throw new PolymeshError(error);
+      });
+
+    const finalizedReceipt = await pollForTransactionFinalization(
+      submittedTxHash,
+      startingBlock,
+      context
+    );
+
+    this.blockHash = hashToString(finalizedReceipt.status.asFinalized);
+    this.blockNumber = u32ToBigNumber(finalizedReceipt.blockNumber!);
+    this.txIndex = new BigNumber(finalizedReceipt.txIndex!);
+
+    // if the extrinsic failed due to an on-chain error, we should handle it in a special way
+    const [extrinsicFailedEvent] = filterEventRecords(
+      finalizedReceipt,
+      'system',
+      'ExtrinsicFailed',
+      true
+    );
+
+    if (extrinsicFailedEvent) {
+      const { data } = extrinsicFailedEvent;
+      const error = handleExtrinsicFailure(data[0]);
+
+      throw error;
+    }
+
+    return finalizedReceipt;
   }
 
   /**

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -726,7 +726,11 @@ describe('Polymesh Transaction Base class', () => {
       await tx.run();
       expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
         txSpec.signingAddress,
-        expect.objectContaining({ era: 0 }),
+        expect.objectContaining({
+          era: 0,
+          withSignedTransaction: true,
+          allowCallDataAlteration: false,
+        }),
         expect.any(Function)
       );
     });
@@ -810,7 +814,12 @@ describe('Polymesh Transaction Base class', () => {
       const result = await tx.run();
       expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
         txSpec.signingAddress,
-        expect.objectContaining({ nonce: -1, signer: 'signer' })
+        expect.objectContaining({
+          nonce: -1,
+          signer: 'signer',
+          withSignedTransaction: true,
+          allowCallDataAlteration: false,
+        })
       );
 
       expect(tx.blockHash).toEqual('blockHash');
@@ -891,7 +900,13 @@ describe('Polymesh Transaction Base class', () => {
       await tx.run();
       expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
         txSpec.signingAddress,
-        expect.objectContaining({ nonce: -1, signer: 'signer', era: 0 })
+        expect.objectContaining({
+          nonce: -1,
+          signer: 'signer',
+          era: 0,
+          withSignedTransaction: true,
+          allowCallDataAlteration: false,
+        })
       );
     });
 

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -441,7 +441,8 @@ let errorMock: jest.Mock;
 type StatusCallback = (receipt: ISubmittableResult) => void;
 
 interface TxMockData {
-  statusCallback: StatusCallback;
+  // not set when the transaction was submitted via the promise (no callback) form of `signAndSend`
+  statusCallback?: StatusCallback;
   unsubCallback: UnsubCallback;
   status: MockTxStatus;
   resolved: boolean;
@@ -1387,7 +1388,7 @@ export function createTxMock<
     meta = { args: [] },
   } = opts;
 
-  const mockHandleSend = (cb: StatusCallback): Promise<unknown> => {
+  const mockHandleSend = (cb?: StatusCallback): Promise<unknown> => {
     if (autoResolve === MockTxStatus.Rejected) {
       return Promise.reject(new Error('Cancelled'));
     }
@@ -1402,11 +1403,12 @@ export function createTxMock<
       status: null as unknown as MockTxStatus,
     });
 
-    if (autoResolve) {
+    if (autoResolve && cb) {
       process.nextTick(() => cb(statusToReceipt(autoResolve)));
     }
 
-    return new Promise(resolve => setImmediate(() => resolve(unsubCallback)));
+    // when no status callback is passed (promise form), `signAndSend` resolves with the submitted tx hash
+    return new Promise(resolve => setImmediate(() => resolve(cb ? unsubCallback : tx)));
   };
 
   const mockSend = jest.fn().mockImplementation((cb: StatusCallback) => {
@@ -1801,7 +1803,7 @@ export function updateTxStatus<
     });
   }
 
-  txMockData.statusCallback(statusToReceipt(status, failReason));
+  txMockData.statusCallback?.(statusToReceipt(status, failReason));
 }
 
 /**


### PR DESCRIPTION
### 📝 Description

Signing any transaction with a Ledger device via the Polkadot Generic Ledger app fails with:

> The `signedTransaction` field may not be submitted when `withSignedTransaction` is disabled

The generic Ledger app requires the `CheckMetadataHash` signed extension, so the wallet must rebuild the transaction (setting `mode` and injecting `metadataHash`) before the device will sign it. The wallet returns the rebuilt extrinsic in `SignerResult.signedTransaction`, which `@polkadot/api` rejects unless the caller opts in — and the SDK never did. Software signers were unaffected since they return only a signature, which is why this surfaced specifically with Ledger.

### 🔧 Changes

**Fix (`PolymeshTransactionBase`):**

- Pass `withSignedTransaction: true` to `signAndSend` in both the subscription and polling submission paths, so signers may return a rebuilt `signedTransaction` and the rebuilt extrinsic is what gets submitted
- Pass `allowCallDataAlteration: false` so a returned `signedTransaction` may only alter signed extensions (`mode`, `metadataHash`, era, nonce, tip) — any change to the call data itself is rejected by the API
- The polling path now tracks the hash resolved from submission instead of the locally composed `txWithArgs.hash`, since a rebuilt extrinsic can hash differently; `txHash` always reflects the on-chain extrinsic
- Extracted the polling path into `runViaPolling` (keeps `internalRun` within lint limits)

**Tests:**

- Assertions verify both new signer options in subscription and polling paths
- `signAndSend` mock now resolves with the tx hash in promise (no-callback) form, matching real `@polkadot/api` behavior

**Changelogs:**

- Add `changelogs/v30.0.0-v30.1.0.md` covering the published v30.1.0 release
- Add `changelogs/v30.1.0-next.md` documenting this fix for the next release (rename once the release version is known)

### ⚠️ Impact

- No breaking changes; no action needed in consuming applications
- No behavior change for software wallets or local keypairs — the option permits the `signedTransaction` field, it does not request it
- Fixes all Ledger generic-app signing through the SDK (the originally reported multisig proposal case was incidental — any transaction hit this)

### ✅ Verification

- Full unit suite passes (207 suites / 2491 tests), lint and tsc clean


### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
