### PR TITLE
fix: 🐛 correct v8 POLYX balance calculation and expose reserved/frozen

### DIFF
--- a/changelogs/v30.1.0-next.md
+++ b/changelogs/v30.1.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v30.1.0 to next release
-description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes Ledger signing support fixes.
+description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes Ledger signing support fixes and corrected POLYX balance calculations for chain v8.
 sidebar_label: v30.1.0 → next
 id: v30-1-to-next
 tags:
@@ -14,7 +14,7 @@ This guide describes **unreleased** changes since **v30.1.0** of `@polymeshassoc
 
 ## Overview
 
-This release fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app. There are **no breaking changes** and no code changes are required in consuming applications.
+This release fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app, and corrects the **POLYX balance calculation** for chain v8 accounts with staked (held) funds. No code changes are required in consuming applications, though note the clarified meaning of `locked` in `AccountBalance` described below.
 
 ---
 
@@ -39,3 +39,28 @@ The SDK now passes `withSignedTransaction: true` when signing, so signers that r
 - **Correct hash tracking** — because a rebuilt extrinsic can have a different hash than the one the SDK composed, the SDK now tracks the hash of the transaction actually submitted to the node. `txHash` on the transaction object always reflects the on-chain extrinsic.
 
 No migration steps are needed — transactions signed with Ledger devices simply work.
+
+### Correct POLYX balance calculation for chain v8 accounts with holds
+
+On chain v8, funds bonded for staking moved from locks on the `free` balance to **holds** tracked in `reserved`, and the single `frozen` value can legitimately exceed `free` (frozen funds may overlap with held funds). The SDK still calculated the spendable balance with the pre-v8 formula `free - frozen`, which produced **negative free balances** for staking accounts .
+
+`Account.getBalance` (and `accountBalance` internally) now follows the chain's rules:
+
+```bash
+free = chain free - max(frozen - reserved, existential deposit)
+```
+
+clamped at zero, with the existential deposit (`0.000001 POLYX`) read from the chain rather than hardcoded.
+
+**Field semantics (clarified):**
+
+- `free` — balance **guaranteed to be spendable** on transfers and fees. The existential deposit is always excluded, so a transaction paying up to `free` will never fail for balance reasons.
+- `locked` — everything unavailable: funds on hold (e.g. bonded for staking), frozen funds not covered by holds (e.g. vesting) and the existential deposit. Always equal to `total - free`. **Note:** previously this only reflected the chain's `frozen` value; it now also includes `reserved` funds, so staking accounts will report a larger `locked` value than before — this is the correct interpretation under v8 semantics.
+- `total` — all funds owned by the Account: `free + locked` (the chain's `free + reserved`).
+
+**New fields** on `AccountBalance` expose the underlying chain values for applications that want to present more detail:
+
+- `reserved` — funds placed on hold by the protocol (e.g. POLYX bonded for staking), released when e.g. unbonded and withdrawn.
+- `frozen` — the minimum balance (out of `total`) that must remain in the Account due to freezes/locks (e.g. vesting). May overlap with `reserved`: vested POLYX that is also bonded counts towards both. On v7 chains this is `max(miscFrozen, feeFrozen)`.
+
+These additions are backwards compatible for code that reads balances. Validations that consume `free` (`transferPolyx`, `bondPolyx`, transaction fee checks) now use the corrected value, so they no longer reject valid transactions for staking-heavy accounts.

--- a/src/api/client/__tests__/Network.ts
+++ b/src/api/client/__tests__/Network.ts
@@ -151,6 +151,8 @@ describe('Network Class', () => {
         free: new BigNumber(500000),
         locked: new BigNumber(0),
         total: new BigNumber(500000),
+        reserved: new BigNumber(0),
+        frozen: new BigNumber(0),
       };
       entityMockUtils.configureMocks({ accountOptions: { getBalance: fakeBalance } });
     });

--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -20,7 +20,6 @@ import {
 import { Mocked } from '~/testUtils/types';
 import {
   AccountBalance,
-  Balance,
   ErrorCode,
   ModuleName,
   MultiSigTx,
@@ -113,6 +112,8 @@ describe('Account class', () => {
         free: new BigNumber(100),
         locked: new BigNumber(10),
         total: new BigNumber(110),
+        reserved: new BigNumber(0),
+        frozen: new BigNumber(0),
       };
     });
 
@@ -132,7 +133,7 @@ describe('Account class', () => {
       const callback = jest.fn();
 
       context.accountBalance = jest.fn();
-      context.accountBalance.mockImplementation((_, cbFunc: (balance: Balance) => void) => {
+      context.accountBalance.mockImplementation((_, cbFunc: (balance: AccountBalance) => void) => {
         cbFunc(fakeResult);
         return unsubCallback;
       });

--- a/src/api/entities/Account/types.ts
+++ b/src/api/entities/Account/types.ts
@@ -6,11 +6,11 @@ import { EventIdentifier } from '~/types';
 
 export interface Balance {
   /**
-   * balance available for transferring and paying fees
+   * balance available for transferring
    */
   free: BigNumber;
   /**
-   * unavailable balance, either bonded for staking or locked for some other purpose
+   * unavailable balance, locked for some purpose (e.g. pending settlement instructions)
    */
   locked: BigNumber;
   /**
@@ -19,7 +19,44 @@ export interface Balance {
   total: BigNumber;
 }
 
-export type AccountBalance = Balance;
+/**
+ * POLYX balance of an Account
+ */
+export interface AccountBalance {
+  /**
+   * balance that is guaranteed to be spendable on transfers and transaction fees. Calculated according
+   *   to the chain's rules as `chain free - max(frozen - reserved, existential deposit)`
+   *
+   * @note this differs from the chain's raw `free` value, which still includes frozen funds. The
+   *   existential deposit (0.000001 POLYX) is always treated as unspendable, so this value is a
+   *   lower bound on what the Account can spend without risk of the transaction failing
+   */
+  free: BigNumber;
+  /**
+   * balance that is unavailable for spending. Made up of funds on hold (`reserved`, e.g. bonded for
+   *   staking), frozen funds not covered by holds (`frozen`) and the existential
+   *   deposit. Always equal to `total - free`
+   */
+  locked: BigNumber;
+  /**
+   * total balance owned by the Account, including unavailable funds. Equal to the chain's
+   *   `free + reserved`, and to `free + locked` as returned here
+   */
+  total: BigNumber;
+  /**
+   * balance placed on hold by the protocol, e.g. POLYX bonded for staking. Held funds are not part
+   *   of the chain's `free` balance and cannot be spent until released (e.g. unbonded and withdrawn).
+   *   Corresponds to the chain's raw `reserved` value
+   */
+  reserved: BigNumber;
+  /**
+   * minimum balance (out of `total`) that must remain in the Account due to freezes/locks.
+   *   Frozen funds may overlap with `reserved` funds. Corresponds to the chain's raw `frozen` value
+   *
+   * @note on v7 chains this is the maximum of the chain's `miscFrozen` and `feeFrozen` values
+   */
+  frozen: BigNumber;
+}
 
 /**
  * Distinguishes MultiSig and Smart Contract accounts

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -379,32 +379,50 @@ export class Context {
       data: { free: rawFree, miscFrozen, feeFrozen, reserved: rawReserved },
     }: AccountInfo): AccountBalance => {
       /*
-       * The chain's "free" balance is the balance that isn't locked. Here we calculate it so
-       * the free balance is what the Account is able to spend
+       * On v7 chains, frozen funds are carved out of the chain's "free" balance, so the spendable
+       * balance is the free balance minus the largest freeze, minus anything reserved
        */
       const reserved = balanceToBigNumber(rawReserved);
       const total = balanceToBigNumber(rawFree).plus(reserved);
-      const locked = BigNumber.max(balanceToBigNumber(miscFrozen), balanceToBigNumber(feeFrozen));
+      const frozen = BigNumber.max(balanceToBigNumber(miscFrozen), balanceToBigNumber(feeFrozen));
+      const free = total.minus(frozen).minus(reserved);
       return {
         total,
-        locked,
-        free: total.minus(locked).minus(reserved),
+        locked: total.minus(free),
+        free,
+        reserved,
+        frozen,
       };
     };
 
     const v8AssembleResult = ({ data }: FrameSystemAccountInfo): AccountBalance => {
-      const { free: rawFree, frozen: feeFrozen, reserved: rawReserved } = data;
+      const { free: rawFree, frozen: rawFrozen, reserved: rawReserved } = data;
+      const {
+        consts: {
+          balances: { existentialDeposit },
+        },
+      } = this.polymeshApi;
       /*
-       * The chain's "free" balance is the balance that isn't locked. Here we calculate it so
-       * the free balance is what the Account is able to spend
+       * The chain's "free" balance still includes frozen funds, while funds on hold (e.g. bonded
+       * for staking) are tracked in "reserved". Frozen funds can overlap with funds on hold, so
+       * the spendable balance is calculated as per the chain's rules:
+       *   transferable = free - max(frozen - reserved, ED)
        */
       const reserved = balanceToBigNumber(rawReserved);
-      const total = balanceToBigNumber(rawFree).plus(reserved);
-      const locked = balanceToBigNumber(feeFrozen);
+      const chainFree = balanceToBigNumber(rawFree);
+      const total = chainFree.plus(reserved);
+      const frozen = balanceToBigNumber(rawFrozen);
+      const untouchable = BigNumber.max(
+        frozen.minus(reserved),
+        balanceToBigNumber(existentialDeposit)
+      );
+      const free = BigNumber.max(chainFree.minus(untouchable), 0);
       return {
         total,
-        locked,
-        free: total.minus(locked).minus(reserved),
+        locked: total.minus(free),
+        free,
+        reserved,
+        frozen,
       };
     };
 

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -380,6 +380,13 @@ describe('Context class', () => {
     const free = new BigNumber(100);
     const reserved = new BigNumber(40);
     const frozen = new BigNumber(25);
+    const existentialDeposit = new BigNumber(1);
+
+    beforeEach(() => {
+      dsMockUtils.setConstMock('balances', 'existentialDeposit', {
+        returnValue: dsMockUtils.createMockBalance(existentialDeposit),
+      });
+    });
 
     it('should throw if there is no signing Account and no Account is passed', async () => {
       const context = await Context.create({
@@ -413,9 +420,11 @@ describe('Context class', () => {
 
       const result = await context.accountBalance();
       expect(result).toEqual({
-        free: free.minus(frozen).shiftedBy(-6),
-        locked: frozen.shiftedBy(-6),
+        free: free.minus(existentialDeposit).shiftedBy(-6),
+        locked: reserved.plus(existentialDeposit).shiftedBy(-6),
         total: free.plus(reserved).shiftedBy(-6),
+        reserved: reserved.shiftedBy(-6),
+        frozen: frozen.shiftedBy(-6),
       });
     });
 
@@ -439,9 +448,71 @@ describe('Context class', () => {
 
       const result = await context.accountBalance('someAddress');
       expect(result).toEqual({
-        free: free.minus(frozen).shiftedBy(-6),
-        locked: frozen.shiftedBy(-6),
+        free: free.minus(existentialDeposit).shiftedBy(-6),
+        locked: reserved.plus(existentialDeposit).shiftedBy(-6),
         total: free.plus(reserved).shiftedBy(-6),
+        reserved: reserved.shiftedBy(-6),
+        frozen: frozen.shiftedBy(-6),
+      });
+    });
+
+    it('should deduct the frozen amount not covered by the reserved balance from the free balance', async () => {
+      const frozenOverReserved = new BigNumber(75);
+      const returnValue = dsMockUtils.createMockAccountInfo({
+        nonce: dsMockUtils.createMockIndex(),
+        refcount: dsMockUtils.createMockRefCount(),
+        data: dsMockUtils.createMockAccountData({
+          free,
+          reserved,
+          frozen: frozenOverReserved,
+        }),
+      });
+
+      dsMockUtils.createQueryMock('system', 'account', { returnValue });
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      const result = await context.accountBalance('someAddress');
+      expect(result).toEqual({
+        free: free.minus(frozenOverReserved.minus(reserved)).shiftedBy(-6),
+        locked: reserved.plus(frozenOverReserved.minus(reserved)).shiftedBy(-6),
+        total: free.plus(reserved).shiftedBy(-6),
+        reserved: reserved.shiftedBy(-6),
+        frozen: frozenOverReserved.shiftedBy(-6),
+      });
+    });
+
+    it('should return a zero free balance for a fully staked Account', async () => {
+      const stakedFree = new BigNumber(1);
+      const stakedReserved = new BigNumber(150909701126);
+      const stakedFrozen = new BigNumber(133054349116);
+      const returnValue = dsMockUtils.createMockAccountInfo({
+        nonce: dsMockUtils.createMockIndex(),
+        refcount: dsMockUtils.createMockRefCount(),
+        data: dsMockUtils.createMockAccountData({
+          free: stakedFree,
+          reserved: stakedReserved,
+          frozen: stakedFrozen,
+        }),
+      });
+
+      dsMockUtils.createQueryMock('system', 'account', { returnValue });
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      const result = await context.accountBalance('someAddress');
+      expect(result).toEqual({
+        free: new BigNumber(0),
+        locked: stakedFree.plus(stakedReserved).shiftedBy(-6),
+        total: stakedFree.plus(stakedReserved).shiftedBy(-6),
+        reserved: stakedReserved.shiftedBy(-6),
+        frozen: stakedFrozen.shiftedBy(-6),
       });
     });
 
@@ -474,9 +545,11 @@ describe('Context class', () => {
 
       expect(result).toEqual(unsubCallback);
       expect(callback).toHaveBeenCalledWith({
-        free: free.minus(frozen).shiftedBy(-6),
-        locked: frozen.shiftedBy(-6),
+        free: free.minus(existentialDeposit).shiftedBy(-6),
+        locked: reserved.plus(existentialDeposit).shiftedBy(-6),
         total: free.plus(reserved).shiftedBy(-6),
+        reserved: reserved.shiftedBy(-6),
+        frozen: frozen.shiftedBy(-6),
       });
     });
   });

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -450,7 +450,7 @@ interface TxMockData {
 interface ContextOptions {
   did?: string;
   withSigningManager?: boolean;
-  balance?: AccountBalance;
+  balance?: Partial<AccountBalance>;
   subsidy?: SubsidyWithAllowance;
   hasRoles?: boolean;
   checkRoles?: CheckRolesResult;
@@ -704,6 +704,8 @@ const defaultContextOptions: ContextOptions = {
     free: new BigNumber(100),
     locked: new BigNumber(10),
     total: new BigNumber(110),
+    reserved: new BigNumber(0),
+    frozen: new BigNumber(0),
   },
   hasRoles: true,
   checkRoles: {
@@ -1844,7 +1846,7 @@ export function throwOnApiCreation(error?: unknown): void {
  *
  * @param balance - new account balance
  */
-export function setContextAccountBalance(balance: AccountBalance): void {
+export function setContextAccountBalance(balance: Partial<AccountBalance>): void {
   mockInstanceContainer.contextInstance.accountBalance.mockResolvedValue(balance as any);
 }
 

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -243,7 +243,7 @@ interface AccountOptions extends EntityOptions {
   address?: string;
   key?: string;
   isFrozen?: EntityGetter<boolean>;
-  getBalance?: EntityGetter<AccountBalance>;
+  getBalance?: EntityGetter<Partial<AccountBalance>>;
   getIdentity?: EntityGetter<Identity | null>;
   getTransactionHistory?: EntityGetter<ExtrinsicData[]>;
   hasPermissions?: EntityGetter<boolean>;
@@ -914,6 +914,8 @@ const MockAccountClass = createMockEntityClass<AccountOptions>(
       free: new BigNumber(100),
       locked: new BigNumber(10),
       total: new BigNumber(110),
+      reserved: new BigNumber(0),
+      frozen: new BigNumber(0),
     },
     getTransactionHistory: [],
     getIdentity: getIdentityInstance(),
@@ -2212,6 +2214,8 @@ const MockMultiSigClass = createMockEntityClass<MultiSigOptions>(
       free: new BigNumber(100),
       locked: new BigNumber(10),
       total: new BigNumber(110),
+      reserved: new BigNumber(0),
+      frozen: new BigNumber(0),
     },
     getTransactionHistory: [],
     getIdentity: getIdentityInstance(),


### PR DESCRIPTION
### Description

Fixes the POLYX unlocked/free balance calculation for chain v8 accounts and extends `AccountBalance` with the underlying chain values.

On chain v8, staking bonds moved from locks on `free` to holds tracked in reserved, so `frozen` can exceed `free`. The SDK still used the pre-v8 formula `free - frozen`, producing negative free balances for staking accounts.

- `free` is now calculated per the chain's rules: `chain free - max(frozen - reserved, existential deposit)`, clamped at zero, with the ED read from chain consts
- `locked` is now always `total - free`, so it correctly includes funds on hold (bonded POLYX), which it previously omitted
- New `reserved` and `frozen` fields on AccountBalance expose the raw chain values, with JSDoc clarifying what each field represents
- Validations consuming `free` (`transferPolyx`, `bondPolyx`, fee checks) no longer reject valid transactions for staking-heavy accounts
- Added test coverage for frozen > reserved (vesting-style) and fully staked accounts; changelog updated

Note:

- `locked` now includes `reserved` funds — staking accounts report a larger `locked` than before (correct under v8 semantics)
- `AccountBalance` is now a standalone interface with two new required fields; code that constructs `AccountBalance` objects (e.g. test fixtures) must add `reserved` and `frozen`

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
