### PR TITLE
fix: 🐛 correct v8 off-chain settl. receipt expiry & encoding

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -1,9 +1,10 @@
-import { Option, StorageKey, u64 } from '@polkadot/types';
+import { Bytes, Option, StorageKey, u64 } from '@polkadot/types';
 import {
   PolymeshPrimitivesIdentityIdPortfolioId,
   PolymeshPrimitivesSettlementInstructionStatus,
   PolymeshPrimitivesSettlementLeg,
 } from '@polkadot/types/lookup';
+import { stringToU8a, u8aConcat } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -2683,6 +2684,13 @@ describe('Instruction class', () => {
       jest
         .spyOn(utilsConversionModule, 'dateToMoment')
         .mockReturnValue(dsMockUtils.createMockMoment(new BigNumber(1000)));
+
+      const label = stringToU8a('Polymesh Settlement Receipt');
+      when(context.createType)
+        .calledWith('Bytes', 'Polymesh Settlement Receipt')
+        .mockReturnValue({
+          toU8a: () => u8aConcat(new Uint8Array([label.length << 2]), label),
+        } as unknown as Bytes);
     });
 
     it('should throw an error for an invalid leg ID', () => {
@@ -2761,10 +2769,12 @@ describe('Instruction class', () => {
         ),
       });
 
+      const expiresAt = new Date();
+
       let result = await instruction.generateOffChainAffirmationReceipt({
         legId,
         uid,
-        expiresAt: new Date(),
+        expiresAt,
       });
 
       expect(result).toEqual({
@@ -2778,10 +2788,12 @@ describe('Instruction class', () => {
           value: '0xsignature',
         },
         metadata: undefined,
+        expiresAt,
       });
 
       const signer = 'someSigner';
       const metadata = 'some metadata';
+      const otherExpiresAt = new Date();
 
       result = await instruction.generateOffChainAffirmationReceipt({
         legId,
@@ -2789,7 +2801,7 @@ describe('Instruction class', () => {
         signer,
         signerKeyRingType: SignerKeyRingType.Ed25519,
         metadata,
-        expiresAt: new Date(),
+        expiresAt: otherExpiresAt,
       });
 
       expect(result).toEqual({
@@ -2801,6 +2813,7 @@ describe('Instruction class', () => {
           value: '0xsignature',
         },
         metadata,
+        expiresAt: otherExpiresAt,
       });
 
       expect(context.getSignature).toHaveBeenCalledWith({

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -2,7 +2,7 @@ import {
   PolymeshPrimitivesSettlementInstructionStatus,
   PolymeshPrimitivesSettlementLeg,
 } from '@polkadot/types/lookup';
-import { hexAddPrefix, hexStripPrefix, stringToHex } from '@polkadot/util';
+import { hexAddPrefix, hexStripPrefix, stringToHex, u8aToHex } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 
 import {
@@ -88,6 +88,7 @@ import {
   middlewareInstructionToInstructionEndCondition,
   middlewareLegToLeg,
   momentToDate,
+  stringToBytes,
   tickerToString,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -1362,9 +1363,13 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
     } else {
       payloadStrings = [
         stringToHex('<Bytes>'),
+        context.polymeshApi.genesisHash.toHex(),
         rawUid.toHex(true),
-        stringToHex('Polymesh Settlement Receipt'),
-        dateToMoment(expiresAt!, context).toHex(),
+        // the chain encodes the label as a SCALE `&[u8]`, which is length
+        // prefixed - `Bytes.toHex()` strips that prefix, so `toU8a()` (the
+        // full wire encoding) has to be used instead
+        u8aToHex(stringToBytes('Polymesh Settlement Receipt', context).toU8a()),
+        dateToMoment(expiresAt!, context).toHex(true),
         rawId.toHex(true),
         rawLegId.toHex(true),
         senderIdentity.toHex(),
@@ -1391,6 +1396,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
         value: signatureValue,
       },
       metadata,
+      expiresAt,
     };
   }
 }

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1213,6 +1213,10 @@ export interface OffChainAffirmationReceipt {
    * (optional) Metadata value that can be used to attach messages to the receipt
    */
   metadata: string | undefined;
+  /**
+   * Timestamp at which the receipt expires. Mandatory from chain 8.x onwards
+   */
+  expiresAt?: Date | undefined;
 }
 
 export type AffirmInstructionParams = {

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -12014,12 +12014,14 @@ describe('signatureToMeshRuntimeMultiSignature', () => {
 
     const signature = 'someSignature';
 
-    const fakeSignature = 'fakeSignature' as unknown as U8aFixed;
+    const fakeEcdsaSignature = 'fakeEcdsaSignature' as unknown as U8aFixed;
+    const fakeOtherSignature = 'fakeOtherSignature' as unknown as U8aFixed;
 
-    when(context.createType).calledWith('U8aFixed', signature).mockReturnValue(fakeSignature);
+    when(context.createType).calledWith('[u8;65]', signature).mockReturnValue(fakeEcdsaSignature);
+    when(context.createType).calledWith('[u8;64]', signature).mockReturnValue(fakeOtherSignature);
 
     when(context.createType)
-      .calledWith('SpRuntimeMultiSignature', { Ecdsa: fakeSignature })
+      .calledWith('SpRuntimeMultiSignature', { Ecdsa: fakeEcdsaSignature })
       .mockReturnValue(fakeResult);
 
     let result = signatureToMeshRuntimeMultiSignature(SignerKeyRingType.Ecdsa, signature, context);
@@ -12027,7 +12029,7 @@ describe('signatureToMeshRuntimeMultiSignature', () => {
     expect(result).toEqual(fakeResult);
 
     when(context.createType)
-      .calledWith('SpRuntimeMultiSignature', { Ed25519: fakeSignature })
+      .calledWith('SpRuntimeMultiSignature', { Ed25519: fakeOtherSignature })
       .mockReturnValue(fakeResult);
 
     result = signatureToMeshRuntimeMultiSignature(SignerKeyRingType.Ed25519, signature, context);
@@ -12035,7 +12037,7 @@ describe('signatureToMeshRuntimeMultiSignature', () => {
     expect(result).toEqual(fakeResult);
 
     when(context.createType)
-      .calledWith('SpRuntimeMultiSignature', { Sr25519: fakeSignature })
+      .calledWith('SpRuntimeMultiSignature', { Sr25519: fakeOtherSignature })
       .mockReturnValue(fakeResult);
 
     result = signatureToMeshRuntimeMultiSignature(SignerKeyRingType.Sr25519, signature, context);
@@ -12150,8 +12152,8 @@ describe('receiptDetailsToMeshReceiptDetails', () => {
     dsMockUtils.cleanup();
   });
 
-  it('should create receipt details', () => {
-    const context = dsMockUtils.getContextInstance();
+  it('should create receipt details on a v7 chain without expiresAt', () => {
+    const context = dsMockUtils.getContextInstance({ isV7: true });
     const instructionId = new BigNumber(1);
     const receipt: OffChainAffirmationReceipt = {
       uid: new BigNumber(1),
@@ -12189,6 +12191,69 @@ describe('receiptDetailsToMeshReceiptDetails', () => {
     const result = receiptDetailsToMeshReceiptDetails([receipt], instructionId, context);
 
     expect(result).toEqual(fakeResult);
+  });
+
+  it('should create receipt details on a v8 chain with expiresAt forwarded', () => {
+    const context = dsMockUtils.getContextInstance({ isV7: false });
+    const instructionId = new BigNumber(1);
+    const expiresAt = new Date('2030/01/01');
+    const receipt: OffChainAffirmationReceipt = {
+      uid: new BigNumber(1),
+      legId: new BigNumber(0),
+      signer: '5EYCAe5ijAx5xEfZdpCna3grUpY1M9M5vLUH5vpmwV1EnaYR',
+      signature: {
+        type: SignerKeyRingType.Sr25519,
+        value: '0xsomevalue',
+      },
+      metadata: 'Random metadata',
+      expiresAt,
+    };
+    const fakeKey = 'fakeKey' as unknown as PolymeshPrimitivesSettlementReceiptDetails;
+    const fakeResult =
+      'fakeMetadataKeys' as unknown as Vec<PolymeshPrimitivesSettlementReceiptDetails>;
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesSettlementReceiptDetails', {
+        uid: bigNumberToU64(receipt.uid, context),
+        instructionId: bigNumberToU64(instructionId, context),
+        legId: bigNumberToU64(receipt.legId, context),
+        signer: stringToAccountId(receipt.signer as string, context),
+        signature: signatureToMeshRuntimeMultiSignature(
+          receipt.signature.type,
+          receipt.signature.value,
+          context
+        ),
+        expiresAt: dateToMoment(expiresAt, context),
+        metadata: offChainMetadataToMeshReceiptMetadata(receipt.metadata as string, context),
+      })
+      .mockReturnValue(fakeKey);
+
+    when(context.createType)
+      .calledWith('Vec<PolymeshPrimitivesSettlementReceiptDetails>', [fakeKey])
+      .mockReturnValue(fakeResult);
+
+    const result = receiptDetailsToMeshReceiptDetails([receipt], instructionId, context);
+
+    expect(result).toEqual(fakeResult);
+  });
+
+  it('should throw an error if expiresAt is missing on a v8 chain', () => {
+    const context = dsMockUtils.getContextInstance({ isV7: false });
+    const instructionId = new BigNumber(1);
+    const receipt: OffChainAffirmationReceipt = {
+      uid: new BigNumber(1),
+      legId: new BigNumber(0),
+      signer: '5EYCAe5ijAx5xEfZdpCna3grUpY1M9M5vLUH5vpmwV1EnaYR',
+      signature: {
+        type: SignerKeyRingType.Sr25519,
+        value: '0xsomevalue',
+      },
+      metadata: 'Random metadata',
+    };
+
+    expect(() => receiptDetailsToMeshReceiptDetails([receipt], instructionId, context)).toThrow(
+      '`expiresAt` is mandatory from chain 8.x'
+    );
   });
 });
 

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -5726,8 +5726,13 @@ export function signatureToMeshRuntimeMultiSignature(
       // assume sr 25519
       rawValue = context.createType('SpCoreSr25519Signature', value);
     }
+  } else if (type === SignerKeyRingType.Ecdsa) {
+    // Ecdsa signatures are 65 bytes (64 byte signature + 1 byte recovery ID)
+    rawValue = context.createType('[u8;65]', value);
   } else {
-    rawValue = context.createType('U8aFixed', value);
+    // Ed25519 and Sr25519 signatures are both 64 bytes. A bare 'U8aFixed' does
+    // not resolve against chain v8's metadata-derived type registry.
+    rawValue = context.createType('[u8;64]', value);
   }
 
   return context.createType('SpRuntimeMultiSignature', {
@@ -5767,18 +5772,28 @@ export function receiptDetailsToMeshReceiptDetails(
   context: Context
 ): Vec<PolymeshPrimitivesSettlementReceiptDetails> {
   const rawInstructionId = bigNumberToU64(instructionId, context);
-  const rawReceiptDetails = receiptDetails.map(({ legId, uid, signer, signature, metadata }) => {
-    const { address: signerAddress } = asAccount(signer, context);
+  const rawReceiptDetails = receiptDetails.map(
+    ({ legId, uid, signer, signature, metadata, expiresAt }) => {
+      const { address: signerAddress } = asAccount(signer, context);
 
-    return context.createType('PolymeshPrimitivesSettlementReceiptDetails', {
-      uid: bigNumberToU64(uid, context),
-      instructionId: rawInstructionId,
-      legId: bigNumberToU64(legId, context),
-      signer: stringToAccountId(signerAddress, context),
-      signature: signatureToMeshRuntimeMultiSignature(signature.type, signature.value, context),
-      metadata: optionize(offChainMetadataToMeshReceiptMetadata)(metadata, context),
-    });
-  });
+      if (!expiresAt && !context.isV7) {
+        throw new PolymeshError({
+          code: ErrorCode.UnmetPrerequisite,
+          message: '`expiresAt` is mandatory from chain 8.x',
+        });
+      }
+
+      return context.createType('PolymeshPrimitivesSettlementReceiptDetails', {
+        uid: bigNumberToU64(uid, context),
+        instructionId: rawInstructionId,
+        legId: bigNumberToU64(legId, context),
+        signer: stringToAccountId(signerAddress, context),
+        signature: signatureToMeshRuntimeMultiSignature(signature.type, signature.value, context),
+        ...(!context.isV7 && { expiresAt: dateToMoment(expiresAt!, context) }),
+        metadata: optionize(offChainMetadataToMeshReceiptMetadata)(metadata, context),
+      });
+    }
+  );
 
   return context.createType('Vec<PolymeshPrimitivesSettlementReceiptDetails>', rawReceiptDetails);
 }


### PR DESCRIPTION
### Description

- forward `expiresAt` into the returned `OffChainAffirmationReceipt` and the raw on-chain receipt details; it was computed and signed into the off-chain payload but dropped before reaching `affirmWithReceipts(WithCount)`
- include the chain's `genesis_hash` and length-prefix the receipt label in the v8 signed payload to match the runtime's `ChainScopedMessage` encoding
- fix byte order of the signed `expiresAt` value (missing little-endian flag)
- use correctly sized byte arrays (`[u8;64]`/`[u8;65]`) instead of a bare `U8aFixed`, which does not resolve against a v8 chain's metadata registry, in `signatureToMeshRuntimeMultiSignature`

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
