### PR TITLE
feat: 🎸 add ticker registration config, funding round issuance getters, and dynamic ticker length validation

### DIFF
--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -26,6 +26,7 @@ import {
   ReserveTickerParams,
   ResultSet,
   SubCallback,
+  TickerRegistrationConfig,
   TickerReservationStatus,
   TransferFundsParams,
   UnsubCallback,
@@ -36,6 +37,7 @@ import {
   meshMetadataSpecToMetadataSpec,
   stringToIdentityId,
   tickerToString,
+  u8ToBigNumber,
   u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -525,4 +527,28 @@ export class Assets {
    * @note To transfer between asset holders owned by separate DID use settlement instructions
    */
   public transferFunds: ProcedureMethod<TransferFundsParams, void>;
+
+  /**
+   * Gets the chain-wide rules used to validate ticker registrations
+   */
+  public async getTickerRegistrationConfig(): Promise<TickerRegistrationConfig> {
+    const {
+      context: {
+        polymeshApi: {
+          query: {
+            asset: { tickerConfig },
+          },
+        },
+      },
+    } = this;
+
+    const { maxTickerLength, registrationLength } = await tickerConfig();
+
+    return {
+      maxTickerLength: u8ToBigNumber(maxTickerLength),
+      registrationLength: registrationLength.isSome
+        ? u64ToBigNumber(registrationLength.unwrap())
+        : null,
+    };
+  }
 }

--- a/src/api/client/__tests__/Assets.ts
+++ b/src/api/client/__tests__/Assets.ts
@@ -723,6 +723,42 @@ describe('Assets Class', () => {
     });
   });
 
+  describe('method: getTickerRegistrationConfig', () => {
+    it('should return the chain-wide ticker registration rules', async () => {
+      const maxTickerLength = new BigNumber(12);
+      const registrationLength = new BigNumber(60 * 24 * 60 * 60 * 1000);
+
+      dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+        returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+          maxTickerLength: dsMockUtils.createMockU8(maxTickerLength),
+          registrationLength: dsMockUtils.createMockOption(
+            dsMockUtils.createMockU64(registrationLength)
+          ),
+        }),
+      });
+
+      const result = await assets.getTickerRegistrationConfig();
+
+      expect(result).toEqual({
+        maxTickerLength,
+        registrationLength,
+      });
+    });
+
+    it('should return a null registration length if tickers never expire', async () => {
+      dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+        returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+          maxTickerLength: dsMockUtils.createMockU8(new BigNumber(12)),
+          registrationLength: dsMockUtils.createMockOption(),
+        }),
+      });
+
+      const result = await assets.getTickerRegistrationConfig();
+
+      expect(result.registrationLength).toBeNull();
+    });
+  });
+
   describe('method: transferFunds', () => {
     it('should prepare the procedure and return the resulting transaction', async () => {
       const args = {

--- a/src/api/entities/Asset/Base/BaseAsset.ts
+++ b/src/api/entities/Asset/Base/BaseAsset.ts
@@ -54,6 +54,7 @@ import {
   bigNumberToU32,
   boolToBoolean,
   bytesToString,
+  fundingRoundToAssetFundingRound,
   identitiesSetToIdentities,
   identityIdToString,
   tickerToString,
@@ -535,6 +536,29 @@ export class BaseAsset extends Entity<UniqueIdentifiers, string> {
 
     const fundingRound = await asset.fundingRound(rawAssetId);
     return assembleResult(fundingRound);
+  }
+
+  /**
+   * Retrieve the total amount of the Asset issued in the given funding round
+   *
+   * @param fundingRound - name of the funding round to query
+   */
+  public async getIssuedInFundingRound(fundingRound: string): Promise<BigNumber> {
+    const {
+      context,
+      context: {
+        polymeshApi: {
+          query: { asset },
+        },
+      },
+    } = this;
+
+    const rawAssetId = assetToMeshAssetId(this, context);
+    const rawFundingRound = fundingRoundToAssetFundingRound(fundingRound, context);
+
+    const issued = await asset.issuedInFundingRound([rawAssetId, rawFundingRound]);
+
+    return balanceToBigNumber(issued);
   }
 
   /**

--- a/src/api/entities/Asset/__tests__/Fungible/index.ts
+++ b/src/api/entities/Asset/__tests__/Fungible/index.ts
@@ -398,6 +398,30 @@ describe('Fungible class', () => {
     });
   });
 
+  describe('method: getIssuedInFundingRound', () => {
+    it('should return the amount of the Asset issued in the given funding round', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const fundingRound = 'Series A';
+      const issuedAmount = new BigNumber(1000);
+
+      const context = dsMockUtils.getContextInstance();
+      const asset = new FungibleAsset({ assetId }, context);
+
+      const rawFundingRound = dsMockUtils.createMockBytes(fundingRound);
+      when(jest.spyOn(utilsConversionModule, 'fundingRoundToAssetFundingRound'))
+        .calledWith(fundingRound, context)
+        .mockReturnValue(rawFundingRound);
+
+      dsMockUtils.createQueryMock('asset', 'issuedInFundingRound', {
+        returnValue: dsMockUtils.createMockBalance(issuedAmount.shiftedBy(6)),
+      });
+
+      const result = await asset.getIssuedInFundingRound(fundingRound);
+
+      expect(result).toEqual(issuedAmount);
+    });
+  });
+
   describe('method: getIdentifiers', () => {
     let assetId: string;
     let isinValue: string;

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -262,6 +262,17 @@ export interface VenueFilteringDetails {
   allowedVenues: Venue[];
 }
 
+export interface TickerRegistrationConfig {
+  /**
+   * maximum allowed length for a ticker
+   */
+  maxTickerLength: BigNumber;
+  /**
+   * amount of time (in milliseconds) a ticker reservation is valid for before it expires, starting from the moment it is reserved. A null value means ticker reservations never expire
+   */
+  registrationLength: BigNumber | null;
+}
+
 /**
  * A metadata entry for which each NFT in the collection must have an entry for
  *

--- a/src/api/procedures/createAsset.ts
+++ b/src/api/procedures/createAsset.ts
@@ -42,6 +42,7 @@ import {
   stringToTicker,
 } from '~/utils/conversion';
 import {
+  assertTickerLengthValid,
   checkTxType,
   isAllowedCharacters,
   optionize,
@@ -272,6 +273,7 @@ export async function prepareCreateAsset(
   let rawTicker: PolymeshPrimitivesTicker | undefined;
 
   if (ticker) {
+    await assertTickerLengthValid(ticker, context);
     rawTicker = stringToTicker(ticker, context);
   }
 

--- a/src/api/procedures/createNftCollection.ts
+++ b/src/api/procedures/createNftCollection.ts
@@ -45,6 +45,7 @@ import {
   stringToTicker,
 } from '~/utils/conversion';
 import {
+  assertTickerLengthValid,
   checkTxType,
   isAllowedCharacters,
   optionize,
@@ -190,6 +191,7 @@ export async function prepareCreateNftCollection(
 
   if (ticker) {
     assertTickerOk(ticker);
+    await assertTickerLengthValid(ticker, context);
   }
 
   const internalNftType = getInternalNftType(customTypeData, nftType);

--- a/src/api/procedures/reserveTicker.ts
+++ b/src/api/procedures/reserveTicker.ts
@@ -4,7 +4,7 @@ import { Context, PolymeshError, Procedure, TickerReservation } from '~/internal
 import { ErrorCode, ReserveTickerParams, RoleType, TickerReservationStatus, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import { stringToTicker, tickerToString } from '~/utils/conversion';
-import { filterEventRecords, isAllowedCharacters } from '~/utils/internal';
+import { assertTickerLengthValid, filterEventRecords, isAllowedCharacters } from '~/utils/internal';
 
 /**
  * @hidden
@@ -42,6 +42,8 @@ export async function prepareReserveTicker(
       message: 'New Tickers can only contain alphanumeric values "_", "-", ".", and "/"',
     });
   }
+
+  await assertTickerLengthValid(ticker, context);
 
   const rawTicker = stringToTicker(ticker, context);
 

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -98,6 +98,7 @@ import {
   assertMetaLength,
   assertNoPendingAuthorizationExists,
   assertStatIsSet,
+  assertTickerLengthValid,
   assertTickerValid,
   calculateNextKey,
   calculateRawStakingPayee,
@@ -1789,6 +1790,52 @@ describe('assertTickerValid', () => {
     const ticker = 'FAKE_TICKER';
 
     expect(() => assertTickerValid(ticker)).not.toThrow();
+  });
+});
+
+describe('assertTickerLengthValid', () => {
+  it('should throw an error if the ticker length exceeds the chain configured max ticker length', async () => {
+    const context = dsMockUtils.getContextInstance();
+    const maxTickerLength = new BigNumber(6);
+
+    dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+      returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+        maxTickerLength: dsMockUtils.createMockU8(maxTickerLength),
+        registrationLength: dsMockUtils.createMockOption(),
+      }),
+    });
+
+    await expect(assertTickerLengthValid('TOO_LONG', context)).rejects.toThrow(
+      `Ticker length must be between 1 and ${maxTickerLength.toString()} characters`
+    );
+  });
+
+  it('should throw an error if the ticker is empty', async () => {
+    const context = dsMockUtils.getContextInstance();
+
+    dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+      returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+        maxTickerLength: dsMockUtils.createMockU8(new BigNumber(12)),
+        registrationLength: dsMockUtils.createMockOption(),
+      }),
+    });
+
+    await expect(assertTickerLengthValid('', context)).rejects.toThrow(
+      'Ticker length must be between 1 and 12 characters'
+    );
+  });
+
+  it('should not throw an error if the ticker length is within the chain configured max ticker length', async () => {
+    const context = dsMockUtils.getContextInstance();
+
+    dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+      returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+        maxTickerLength: dsMockUtils.createMockU8(new BigNumber(12)),
+        registrationLength: dsMockUtils.createMockOption(),
+      }),
+    });
+
+    await expect(assertTickerLengthValid('FAKE_TICKER', context)).resolves.not.toThrow();
   });
 });
 

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -134,6 +134,7 @@ import {
   stringToTicker,
   tickerToString,
   transferRestrictionTypeToStatOpType,
+  u8ToBigNumber,
   u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -997,6 +998,36 @@ export function assertTickerValid(ticker: string): void {
     throw new PolymeshError({
       code: ErrorCode.ValidationError,
       message: 'Ticker cannot contain lower case letters',
+    });
+  }
+}
+
+/**
+ * @hidden
+ *
+ * Validates a ticker's length against the chain's current ticker registration rules.
+ *
+ * @note this is distinct from {@link assertTickerValid}, which enforces the fixed 12 byte
+ *   width of the on chain `Ticker` type. `maxTickerLength` is a separate, governance
+ *   configurable ceiling (never greater than 12) used to validate new ticker registrations
+ */
+export async function assertTickerLengthValid(ticker: string, context: Context): Promise<void> {
+  const {
+    polymeshApi: {
+      query: {
+        asset: { tickerConfig },
+      },
+    },
+  } = context;
+
+  const { maxTickerLength: rawMaxTickerLength } = await tickerConfig();
+  const maxTickerLength = u8ToBigNumber(rawMaxTickerLength);
+
+  if (!ticker.length || maxTickerLength.lt(ticker.length)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: `Ticker length must be between 1 and ${maxTickerLength.toString()} characters`,
+      data: { maxTickerLength },
     });
   }
 }


### PR DESCRIPTION
### Description

Exposes two previously-missing read-only `Asset` pallet storage items and uses one of them to replace a hardcoded client-side constant with a live chain query:

- **`Assets.getTickerRegistrationConfig()`** — reads `Asset.TickerConfig`, the chain-wide ticker registration rules (`maxTickerLength`, `registrationLength`).
- **`BaseAsset.getIssuedInFundingRound(fundingRound)`** — reads `Asset.IssuedInFundingRound`, the cumulative amount of an Asset issued in a given funding round.
- **Dynamic ticker length validation** — `reserveTicker`, `createAsset`, and `createNftCollection` now validate a new ticker's length against the live `TickerConfig.maxTickerLength` (via `assertTickerLengthValid`) instead of the hardcoded `MAX_TICKER_LENGTH` constant, so SDK-side validation fails fast in line with whatever the chain is actually configured to accept.

Note: `MAX_TICKER_LENGTH` is still used as-is for padding tickers to the fixed 12-byte `PolymeshPrimitivesTicker` on-chain encoding (`stringToTicker`) — that's an immutable wire-format constant, not the governance-configurable business rule, so it was intentionally left untouched.

### Breaking Changes

None. Both new methods are additive. The ticker length validation error is thrown in the same cases as before (a too-long or empty ticker), just sourced from the live chain config instead of a local constant.

### JIRA Link

<!-- Insert JIRA issue here -->

### Checklist

- [ ] Updated the Readme.md (if required) ?