### PR TITLE
feat: 🎸 add `unlockInstruction` to complete the lock/relock cycle

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -303,6 +303,73 @@ describe('Instruction class', () => {
     });
   });
 
+  describe('method: getRelockStatus', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    let bigNumberToU64Spy: jest.SpyInstance;
+    const unlockedTime = new Date('2025-07-01');
+    const relockCooldown = new BigNumber(86400000);
+    const maxRelockCount = new BigNumber(3);
+    const relockCount = new BigNumber(1);
+
+    beforeAll(() => {
+      bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+      dsMockUtils.createQueryMock('settlement', 'unlockedTimestamp');
+      dsMockUtils.createQueryMock('settlement', 'instructionRelockCount');
+    });
+
+    beforeEach(() => {
+      when(bigNumberToU64Spy).calledWith(id, context).mockReturnValue(rawId);
+
+      dsMockUtils.setConstMock('settlement', 'relockCooldown', {
+        returnValue: dsMockUtils.createMockU64(relockCooldown),
+      });
+      dsMockUtils.setConstMock('settlement', 'maxRelockCount', {
+        returnValue: dsMockUtils.createMockU32(maxRelockCount),
+      });
+    });
+
+    it('should return all the details for an instruction that has been unlocked', async () => {
+      dsMockUtils
+        .getQueryMultiMock()
+        .mockResolvedValue([
+          dsMockUtils.createMockOption(
+            dsMockUtils.createMockU64(new BigNumber(unlockedTime.getTime()))
+          ),
+          dsMockUtils.createMockU32(relockCount),
+        ]);
+
+      const result = await instruction.getRelockStatus();
+
+      expect(result).toEqual({
+        unlockedAt: unlockedTime,
+        relockCount,
+        maxRelockCount,
+        cooldownEndsAt: new Date(unlockedTime.getTime() + relockCooldown.toNumber()),
+      });
+    });
+
+    it('should return all the details for an instruction that has never been unlocked', async () => {
+      dsMockUtils
+        .getQueryMultiMock()
+        .mockResolvedValue([
+          dsMockUtils.createMockOption(),
+          dsMockUtils.createMockU32(new BigNumber(0)),
+        ]);
+
+      const result = await instruction.getRelockStatus();
+
+      expect(result).toEqual({
+        unlockedAt: null,
+        relockCount: new BigNumber(0),
+        maxRelockCount,
+        cooldownEndsAt: null,
+      });
+    });
+  });
+
   describe('method: onStatusChange', () => {
     let bigNumberToU64Spy: jest.SpyInstance;
     let instructionStatusesMock: jest.Mock;
@@ -1535,6 +1602,31 @@ describe('Instruction class', () => {
         .mockResolvedValue(expectedTransaction);
 
       const tx = await instruction.lockForExecution();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: unlockForExecution', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Instruction>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          {
+            args: { id },
+            transformer: undefined,
+          },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await instruction.unlockForExecution();
 
       expect(tx).toBe(expectedTransaction);
     });

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -9,6 +9,7 @@ import {
   AffirmationStatus,
   InstructionAffirmation,
   InstructionDetails,
+  InstructionRelockStatus,
   InstructionStatus,
   InstructionStatusResult,
   Leg,
@@ -17,6 +18,7 @@ import {
 } from '~/api/entities/Instruction/types';
 import { executeManualInstruction } from '~/api/procedures/executeManualInstruction';
 import { lockInstructionForExecution } from '~/api/procedures/lockInstructionForExecution';
+import { unlockInstructionForExecution } from '~/api/procedures/unlockInstructionForExecution';
 import {
   Account,
   Context,
@@ -90,6 +92,7 @@ import {
   momentToDate,
   stringToBytes,
   tickerToString,
+  u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
 import {
@@ -221,6 +224,14 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       },
       context
     );
+
+    this.unlockForExecution = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [unlockInstructionForExecution, { id }],
+        voidArgs: true,
+      },
+      context
+    );
   }
 
   /**
@@ -344,6 +355,59 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       lockedAt: null,
       expiry: null,
       unlocksAt: null,
+    };
+  }
+
+  /**
+   * Retrieve the relock cooldown status of the Instruction
+   *
+   * @note After a mediator unlocks an Instruction, they must wait for the relock cooldown period to
+   *   end before locking it again. `maxRelockCount` limits the total number of times an Instruction can be relocked.
+   */
+  public async getRelockStatus(): Promise<InstructionRelockStatus> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { settlement },
+          consts: {
+            settlement: { relockCooldown, maxRelockCount },
+          },
+        },
+      },
+      id,
+      context,
+    } = this;
+
+    const rawId = bigNumberToU64(id, context);
+
+    const [rawUnlockedTimestamp, rawRelockCount] = await requestMulti<
+      [typeof settlement.unlockedTimestamp, typeof settlement.instructionRelockCount]
+    >(context, [
+      [settlement.unlockedTimestamp, rawId],
+      [settlement.instructionRelockCount, rawId],
+    ]);
+
+    const relockCount = u32ToBigNumber(rawRelockCount);
+    const maxRelockCountValue = u32ToBigNumber(maxRelockCount);
+
+    if (rawUnlockedTimestamp.isSome) {
+      const unlockedAt = momentToDate(rawUnlockedTimestamp.unwrap());
+      const cooldown = u64ToBigNumber(relockCooldown);
+      const cooldownEndsAt = new Date(unlockedAt.getTime() + cooldown.toNumber());
+
+      return {
+        unlockedAt,
+        relockCount,
+        maxRelockCount: maxRelockCountValue,
+        cooldownEndsAt,
+      };
+    }
+
+    return {
+      unlockedAt: null,
+      relockCount,
+      maxRelockCount: maxRelockCountValue,
+      cooldownEndsAt: null,
     };
   }
 
@@ -959,6 +1023,13 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
    * @throws if any of the above conditions are not met
    */
   public lockForExecution: NoArgsProcedureMethod<Instruction>;
+
+  /**
+   * Unlocks an Instruction that is currently `LockedForExecution`, moving it back to `Pending`. Only a mediator of the instruction can unlock it.
+   *
+   * @note After unlocking, the mediator must wait for the relock cooldown period (see {@link getRelockStatus}) before locking the instruction again. This gives other parties time to reject the instruction if they wish to back out.
+   */
+  public unlockForExecution: NoArgsProcedureMethod<Instruction>;
 
   /**
    * @hidden

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -168,6 +168,25 @@ export interface GroupedInvolvedInstructions {
   owned: Omit<GroupedInstructions, 'affirmed'>;
 }
 
+export interface InstructionRelockStatus {
+  /**
+   * The date and time when the instruction was last unlocked by a mediator, `null` if it has never been unlocked
+   */
+  unlockedAt: Date | null;
+  /**
+   * The number of times the instruction has been relocked
+   */
+  relockCount: BigNumber;
+  /**
+   * The maximum number of times the instruction can be relocked
+   */
+  maxRelockCount: BigNumber;
+  /**
+   * The date and time after which the instruction can be locked again, `null` if it has never been unlocked
+   */
+  cooldownEndsAt: Date | null;
+}
+
 export interface InstructionLockedInfo {
   /**
    * Whether the instruction is locked for execution

--- a/src/api/procedures/__tests__/unlockInstructionForExecution.ts
+++ b/src/api/procedures/__tests__/unlockInstructionForExecution.ts
@@ -1,0 +1,140 @@
+import { u64 } from '@polkadot/types';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareUnlockInstructionForExecution,
+} from '~/api/procedures/unlockInstructionForExecution';
+import * as procedureUtilsModule from '~/api/procedures/utils';
+import { Context, Instruction } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { AffirmationStatus, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Instruction',
+  require('~/testUtils/mocks/entities').mockInstructionModule('~/api/entities/Instruction')
+);
+
+describe('unlockInstructionForExecution procedure', () => {
+  const id = new BigNumber(1);
+  const rawInstructionId = dsMockUtils.createMockU64(id);
+
+  let mockContext: Mocked<Context>;
+  let bigNumberToU64Spy: jest.SpyInstance<u64, [BigNumber, Context]>;
+
+  let unlockInstructionTxMock: jest.Mock;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+
+    bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+
+    jest.spyOn(procedureUtilsModule, 'assertInstructionValidForUnlocking').mockImplementation();
+  });
+
+  beforeEach(() => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          { identity: entityMockUtils.getIdentityInstance(), status: AffirmationStatus.Affirmed },
+        ],
+      },
+    });
+
+    unlockInstructionTxMock = dsMockUtils.createTxMock('settlement', 'unlockInstruction');
+
+    mockContext = dsMockUtils.getContextInstance();
+    when(bigNumberToU64Spy).calledWith(id, mockContext).mockReturnValue(rawInstructionId);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if signer is not a mediator', () => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          {
+            identity: entityMockUtils.getIdentityInstance({ did: 'randomDid' }),
+            status: AffirmationStatus.Affirmed,
+          },
+        ],
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    return expect(
+      prepareUnlockInstructionForExecution.call(proc, {
+        id,
+      })
+    ).rejects.toThrow('Only mediators can unlock instructions for execution');
+  });
+
+  it('should throw an error if mediator affirmation has expired', () => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          {
+            identity: entityMockUtils.getIdentityInstance(),
+            status: AffirmationStatus.Affirmed,
+            expiry: new Date('2022/01/01'),
+          },
+        ],
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    return expect(
+      prepareUnlockInstructionForExecution.call(proc, {
+        id,
+      })
+    ).rejects.toThrow('Mediator affirmation has expired');
+  });
+
+  it('should return a transaction spec on successful unlocking', async () => {
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    const result = await prepareUnlockInstructionForExecution.call(proc, {
+      id,
+    });
+
+    expect(result).toEqual({
+      transaction: unlockInstructionTxMock,
+      args: [rawInstructionId],
+      resolver: expect.objectContaining({ id }),
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext, { id });
+      const boundFunc = getAuthorization.bind(proc);
+
+      const result = boundFunc();
+
+      expect(result).toEqual({
+        permissions: {
+          assets: [],
+          portfolios: [],
+          transactions: [TxTags.settlement.UnlockInstruction],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/__tests__/utils.ts
+++ b/src/api/procedures/__tests__/utils.ts
@@ -12,6 +12,7 @@ import {
   assertInstructionValid,
   assertInstructionValidForLocking,
   assertInstructionValidForManualExecution,
+  assertInstructionValidForUnlocking,
   assertPortfolioExists,
   assertRequirementsNotTooComplex,
   assertSecondaryAccounts,
@@ -258,6 +259,38 @@ describe('assertInstructionValidForLocking', () => {
       assertInstructionValidForLocking({
         status: InstructionStatus.Pending,
         type: InstructionType.SettleAfterLock,
+      } as InstructionDetails)
+    ).not.toThrow();
+  });
+});
+
+describe('assertInstructionValidForUnlocking', () => {
+  it('should throw an error if instruction is not in pending or failed state', () => {
+    expect(() =>
+      assertInstructionValidForUnlocking({
+        status: InstructionStatus.Success,
+      } as InstructionDetails)
+    ).toThrow('The Instruction has already been executed');
+
+    expect(() =>
+      assertInstructionValidForUnlocking({
+        status: InstructionStatus.Rejected,
+      } as InstructionDetails)
+    ).toThrow('The Instruction has already been executed');
+  });
+
+  it('should throw an error if the instruction is not locked for execution', () => {
+    expect(() =>
+      assertInstructionValidForUnlocking({
+        status: InstructionStatus.Pending,
+      } as InstructionDetails)
+    ).toThrow('The Instruction is not locked for execution');
+  });
+
+  it('should not throw an error for valid instruction', () => {
+    expect(() =>
+      assertInstructionValidForUnlocking({
+        status: InstructionStatus.LockedForExecution,
       } as InstructionDetails)
     ).not.toThrow();
   });

--- a/src/api/procedures/unlockInstructionForExecution.ts
+++ b/src/api/procedures/unlockInstructionForExecution.ts
@@ -1,0 +1,89 @@
+import BigNumber from 'bignumber.js';
+
+import { assertInstructionValidForUnlocking } from '~/api/procedures/utils';
+import { Instruction, PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { bigNumberToU64 } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export type Params = {
+  id: BigNumber;
+};
+
+/**
+ * @hidden
+ */
+export async function prepareUnlockInstructionForExecution(
+  this: Procedure<Params, Instruction>,
+  args: Params
+): Promise<TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'unlockInstruction'>>> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: { settlement: settlementTx },
+      },
+    },
+    context,
+  } = this;
+
+  const { id } = args;
+
+  const instruction = new Instruction({ id }, context);
+
+  const [{ did: signerDid }, instructionDetails, mediatorAffirmations] = await Promise.all([
+    context.getSigningIdentity(),
+    instruction.detailsFromChain(),
+    instruction.getMediators(),
+  ]);
+
+  assertInstructionValidForUnlocking(instructionDetails);
+
+  const mediatorWithAffirmation = mediatorAffirmations.find(
+    ({ identity: { did } }) => did === signerDid
+  );
+
+  if (!mediatorWithAffirmation) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Only mediators can unlock instructions for execution',
+      data: { signer: signerDid, instructionId: id.toString() },
+    });
+  }
+
+  if (mediatorWithAffirmation.expiry && mediatorWithAffirmation.expiry < new Date()) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Mediator affirmation has expired',
+    });
+  }
+
+  const rawInstructionId = bigNumberToU64(id, context);
+
+  return {
+    transaction: settlementTx.unlockInstruction,
+    resolver: instruction,
+    args: [rawInstructionId],
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(this: Procedure<Params, Instruction>): ProcedureAuthorization {
+  return {
+    permissions: {
+      transactions: [TxTags.settlement.UnlockInstruction],
+      assets: [],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const unlockInstructionForExecution = (): Procedure<Params, Instruction> =>
+  new Procedure(prepareUnlockInstructionForExecution, getAuthorization);

--- a/src/api/procedures/utils.ts
+++ b/src/api/procedures/utils.ts
@@ -152,6 +152,25 @@ export function assertInstructionValidForLocking(details: InstructionDetails): v
 /**
  * @hidden
  */
+export function assertInstructionValidForUnlocking(details: InstructionDetails): void {
+  const { status } = details;
+
+  assertInstructionIsNotPruned(status);
+
+  if (status !== InstructionStatus.LockedForExecution) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The Instruction is not locked for execution',
+      data: {
+        currentStatus: status,
+      },
+    });
+  }
+}
+
+/**
+ * @hidden
+ */
 export async function assertPortfolioExists(
   portfolioId: PortfolioId,
   context: Context


### PR DESCRIPTION
### Description

- Add `Instruction.unlockForExecution` — a mediator-only procedure that moves an instruction from `LockedForExecution` back to `Pending` (mirrors the existing `lockForExecution`, dispatching `settlement.unlockInstruction` on-chain).
- Add `Instruction.getRelockStatus()` — reads `unlockedTimestamp` / `instructionRelockCount` storage plus the `relockCooldown` / `maxRelockCount` chain consts, returning `{ unlockedAt, relockCount, maxRelockCount, cooldownEndsAt }` so callers can show/enforce the cooldown before relocking.
- Adds `assertInstructionValidForUnlocking` guard (mirrors `assertInstructionValidForLocking`, validating `LockedForExecution` status).

This completes the lock/relock cycle — `lockForExecution` existed already, but there was no way to unlock a locked instruction back to `Pending`.

### Breaking Changes

NA

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [x] Unit tests for the new procedure (`unlockInstructionForExecution.ts`), the new guard (`utils.ts`), and the new entity methods (`Instruction/__tests__/index.ts`)
- [x] `yarn test`, `tsc --noEmit`, and `eslint` all pass
- [x] Verified live end-to-end against a real v8 chain (`polymesh:8.0.2-testnet-debian` via `polymesh-dev-env` docker compose): created a `SettleAfterLock` instruction with a mediator, locked it, confirmed `getRelockStatus()` before/after unlock, unlocked it back to `Pending`, and confirmed the chain rejects an immediate relock during the cooldown window
