### PR TITLE
feat: 🎸 add portfolio-level asset pre-approval and getters

### DIFF
--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -26,13 +26,21 @@ import {
   SettlementDirectionEnum,
 } from '~/types';
 import { tuple } from '~/types/utils';
-import { hexToUuid } from '~/utils';
+import { hexToUuid, uuidToHex } from '~/utils';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as utilsInternalModule from '~/utils/internal';
 
 jest.mock(
   '~/api/entities/Identity',
   require('~/testUtils/mocks/entities').mockIdentityModule('~/api/entities/Identity')
+);
+jest.mock(
+  '~/api/entities/Asset/Fungible',
+  require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+jest.mock(
+  '~/api/entities/Asset/NonFungible',
+  require('~/testUtils/mocks/entities').mockNftCollectionModule('~/api/entities/Asset/NonFungible')
 );
 jest.mock(
   '~/api/entities/NumberedPortfolio',
@@ -579,6 +587,45 @@ describe('Portfolio class', () => {
       const result = await portfolio.isAssetPreApproved(assetId);
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe('method: preApprovedAssets', () => {
+    let did: string;
+    let id: BigNumber;
+
+    beforeAll(() => {
+      did = 'someDid';
+      id = new BigNumber(1);
+      jest.spyOn(utilsConversionModule, 'portfolioIdToMeshPortfolioId').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return the list of pre-approved assets for the portfolio', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const rawAssetId = dsMockUtils.createMockAssetId(uuidToHex(assetId));
+      const rawPortfolioId = dsMockUtils.createMockPortfolioId({
+        did: dsMockUtils.createMockIdentityId(did),
+        kind: dsMockUtils.createMockPortfolioKind({
+          User: dsMockUtils.createMockU64(id),
+        }),
+      });
+
+      dsMockUtils.createQueryMock('portfolio', 'preApprovedPortfolios', {
+        entries: [tuple([rawPortfolioId, rawAssetId], dsMockUtils.createMockBool(true))],
+      });
+
+      const portfolio = new NonAbstract({ did, id }, context);
+
+      const result = await portfolio.preApprovedAssets();
+
+      expect(result).toEqual({
+        data: [expect.objectContaining({ id: assetId })],
+        next: null,
+      });
     });
   });
 

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -545,6 +545,43 @@ describe('Portfolio class', () => {
     });
   });
 
+  describe('method: isAssetPreApproved', () => {
+    let did: string;
+    let id: BigNumber;
+
+    beforeAll(() => {
+      did = 'someDid';
+      id = new BigNumber(1);
+      jest.spyOn(utilsConversionModule, 'portfolioIdToMeshPortfolioId').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return whether the asset is pre-approved or not', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const asset = entityMockUtils.getBaseAssetInstance({ assetId });
+      const rawAssetId = dsMockUtils.createMockAssetId(assetId);
+
+      jest.spyOn(utilsInternalModule, 'asBaseAsset').mockResolvedValue(asset);
+      const assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
+      when(assetToMeshAssetIdSpy)
+        .calledWith(expect.objectContaining({ id: assetId }), context)
+        .mockReturnValue(rawAssetId);
+
+      dsMockUtils
+        .createQueryMock('portfolio', 'preApprovedPortfolios')
+        .mockResolvedValue(dsMockUtils.createMockBool(true));
+
+      const portfolio = new NonAbstract({ did, id }, context);
+
+      const result = await portfolio.isAssetPreApproved(assetId);
+
+      expect(result).toBe(true);
+    });
+  });
+
   describe('method: moveFunds', () => {
     it('should prepare the procedure and return the resulting transaction', async () => {
       const args: MoveFundsParams = {
@@ -574,6 +611,46 @@ describe('Portfolio class', () => {
         .mockResolvedValue(expectedTransaction);
 
       const tx = await portfolio.quitCustody();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: preApproveAsset', () => {
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const portfolio = new NonAbstract({ did: 'someDid', id: new BigNumber(0) }, context);
+      const asset = entityMockUtils.getBaseAssetInstance({ assetId: 'SOME_ASSET' });
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          { args: { asset, portfolio, preApprove: true }, transformer: undefined },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await portfolio.preApproveAsset({ asset });
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: removeAssetPreApproval', () => {
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const portfolio = new NonAbstract({ did: 'someDid', id: new BigNumber(0) }, context);
+      const asset = entityMockUtils.getBaseAssetInstance({ assetId: 'SOME_ASSET' });
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          { args: { asset, portfolio, preApprove: false }, transformer: undefined },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await portfolio.removeAssetPreApproval({ asset });
 
       expect(tx).toBe(expectedTransaction);
     });

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -12,6 +12,7 @@ import {
   PortfolioCollection,
 } from '~/api/entities/Portfolio/types';
 import {
+  BaseAsset,
   Context,
   Entity,
   FungibleAsset,
@@ -21,6 +22,7 @@ import {
   NftCollection,
   PolymeshError,
   quitCustody,
+  togglePortfolioPreApproval,
 } from '~/internal';
 import { portfolioMovementsQuery } from '~/middleware/queries/portfolios';
 import { settlementsQuery } from '~/middleware/queries/settlements';
@@ -29,7 +31,9 @@ import { ErrorCode, MoveFundsParams, NoArgsProcedureMethod, ProcedureMethod } fr
 import { Ensured } from '~/types/utils';
 import {
   assetIdToString,
+  assetToMeshAssetId,
   balanceToBigNumber,
+  boolToBoolean,
   identityIdToString,
   portfolioIdToMeshPortfolioId,
   toHistoricalSettlements,
@@ -37,6 +41,7 @@ import {
 } from '~/utils/conversion';
 import {
   asAssetId,
+  asBaseAsset,
   asFungibleAsset,
   createProcedureMethod,
   getAssetIdForMiddleware,
@@ -99,6 +104,24 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
       { getProcedureAndArgs: () => [quitCustody, { portfolio: this }], voidArgs: true },
       context
     );
+    this.preApproveAsset = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [
+          togglePortfolioPreApproval,
+          { ...args, portfolio: this, preApprove: true },
+        ],
+      },
+      context
+    );
+    this.removeAssetPreApproval = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [
+          togglePortfolioPreApproval,
+          { ...args, portfolio: this, preApprove: false },
+        ],
+      },
+      context
+    );
   }
 
   /**
@@ -128,6 +151,31 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
     ]);
 
     return portfolioCustodian.isEqual(targetIdentity);
+  }
+
+  /**
+   * Returns whether or not this Portfolio has pre-approved a particular asset
+   */
+  public async isAssetPreApproved(asset: BaseAsset | string): Promise<boolean> {
+    const {
+      owner: { did },
+      _id: id,
+      context,
+      context: {
+        polymeshApi: {
+          query: { portfolio },
+        },
+      },
+    } = this;
+
+    const baseAsset = await asBaseAsset(asset, context);
+    const rawAssetId = assetToMeshAssetId(baseAsset, context);
+
+    const rawPortfolioId = portfolioIdToMeshPortfolioId({ did, number: id }, context);
+
+    const rawIsApproved = await portfolio.preApprovedPortfolios(rawPortfolioId, rawAssetId);
+
+    return boolToBoolean(rawIsApproved);
   }
 
   /**
@@ -319,6 +367,16 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
    *   - Portfolio Custodian
    */
   public quitCustody: NoArgsProcedureMethod<void>;
+
+  /**
+   * Pre-approves receiving an asset for this Portfolio. Receiving this asset in a settlement will not require manual affirmation
+   */
+  public preApproveAsset: ProcedureMethod<{ asset: BaseAsset | string }, void>;
+
+  /**
+   * Removes pre-approval of an asset for this Portfolio
+   */
+  public removeAssetPreApproval: ProcedureMethod<{ asset: BaseAsset | string }, void>;
 
   /**
    * Retrieve the custodian Identity of this Portfolio

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -27,7 +27,15 @@ import {
 import { portfolioMovementsQuery } from '~/middleware/queries/portfolios';
 import { settlementsQuery } from '~/middleware/queries/settlements';
 import { Query } from '~/middleware/types';
-import { ErrorCode, MoveFundsParams, NoArgsProcedureMethod, ProcedureMethod } from '~/types';
+import {
+  Asset,
+  ErrorCode,
+  MoveFundsParams,
+  NoArgsProcedureMethod,
+  PaginationOptions,
+  ProcedureMethod,
+  ResultSet,
+} from '~/types';
 import { Ensured } from '~/types/utils';
 import {
   assetIdToString,
@@ -40,12 +48,14 @@ import {
   u64ToBigNumber,
 } from '~/utils/conversion';
 import {
+  asAsset,
   asAssetId,
   asBaseAsset,
   asFungibleAsset,
   createProcedureMethod,
   getAssetIdForMiddleware,
   getIdentity,
+  requestPaginated,
   toHumanReadable,
 } from '~/utils/internal';
 
@@ -176,6 +186,42 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
     const rawIsApproved = await portfolio.preApprovedPortfolios(rawPortfolioId, rawAssetId);
 
     return boolToBoolean(rawIsApproved);
+  }
+
+  /**
+   * Returns a list of all assets this Portfolio has pre-approved. These assets will not require affirmation when being received in settlements
+   */
+  public async preApprovedAssets(paginationOpts?: PaginationOptions): Promise<ResultSet<Asset>> {
+    const {
+      owner: { did },
+      _id: id,
+      context,
+      context: {
+        polymeshApi: {
+          query: { portfolio },
+        },
+      },
+    } = this;
+
+    const rawPortfolioId = portfolioIdToMeshPortfolioId({ did, number: id }, context);
+
+    const { entries, lastKey: next } = await requestPaginated(portfolio.preApprovedPortfolios, {
+      arg: rawPortfolioId,
+      paginationOpts,
+    });
+
+    const data = await Promise.all(
+      entries.map(([storageKey]) => {
+        const {
+          args: [, rawAssetId],
+        } = storageKey;
+        const assetId = assetIdToString(rawAssetId);
+
+        return asAsset(assetId, context);
+      })
+    );
+
+    return { data, next };
   }
 
   /**

--- a/src/api/procedures/__tests__/togglePortfolioPreApproval.ts
+++ b/src/api/procedures/__tests__/togglePortfolioPreApproval.ts
@@ -1,0 +1,214 @@
+import {
+  PolymeshPrimitivesAssetAssetId,
+  PolymeshPrimitivesIdentityIdPortfolioId,
+} from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareStorage,
+  prepareTogglePortfolioPreApproval,
+  Storage,
+} from '~/api/procedures/togglePortfolioPreApproval';
+import { BaseAsset, Context, NumberedPortfolio } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { PortfolioId, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+import * as utilsInternalModule from '~/utils/internal';
+
+jest.mock(
+  '~/api/entities/Asset/Fungible',
+  require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+jest.mock(
+  '~/api/entities/NumberedPortfolio',
+  require('~/testUtils/mocks/entities').mockNumberedPortfolioModule(
+    '~/api/entities/NumberedPortfolio'
+  )
+);
+
+describe('togglePortfolioPreApproval procedure', () => {
+  const did = 'someDid';
+  const id = new BigNumber(1);
+  const portfolioId: PortfolioId = { did, number: id };
+
+  let mockContext: Mocked<Context>;
+  let assetToMeshAssetIdSpy: jest.SpyInstance;
+  let portfolioIdToMeshPortfolioIdSpy: jest.SpyInstance;
+  let portfolioLikeToPortfolioIdSpy: jest.SpyInstance;
+  let asBaseAssetSpy: jest.SpyInstance;
+  let assetId: string;
+  let asset: BaseAsset;
+  let rawAssetId: PolymeshPrimitivesAssetAssetId;
+  let rawPortfolioId: PolymeshPrimitivesIdentityIdPortfolioId;
+  let portfolio: Mocked<NumberedPortfolio>;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
+    portfolioIdToMeshPortfolioIdSpy = jest.spyOn(
+      utilsConversionModule,
+      'portfolioIdToMeshPortfolioId'
+    );
+    portfolioLikeToPortfolioIdSpy = jest.spyOn(utilsConversionModule, 'portfolioLikeToPortfolioId');
+    asBaseAssetSpy = jest.spyOn(utilsInternalModule, 'asBaseAsset');
+    assetId = 'TEST';
+    asset = entityMockUtils.getBaseAssetInstance({ assetId });
+    rawAssetId = dsMockUtils.createMockTicker(assetId);
+    rawPortfolioId = dsMockUtils.createMockPortfolioId({
+      did: dsMockUtils.createMockIdentityId(did),
+      kind: dsMockUtils.createMockPortfolioKind({
+        User: dsMockUtils.createMockU64(id),
+      }),
+    });
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance();
+    portfolio = entityMockUtils.getNumberedPortfolioInstance({
+      did,
+      id,
+      isAssetPreApproved: false,
+    });
+    asBaseAssetSpy.mockResolvedValue(asset);
+    when(assetToMeshAssetIdSpy)
+      .calledWith(expect.objectContaining({ id: assetId }), mockContext)
+      .mockReturnValue(rawAssetId);
+    when(portfolioIdToMeshPortfolioIdSpy)
+      .calledWith(portfolioId, mockContext)
+      .mockReturnValue(rawPortfolioId);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if pre approving an asset that is already pre-approved', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      portfolioId,
+    });
+    portfolio.isAssetPreApproved.mockResolvedValue(true);
+
+    return expect(
+      prepareTogglePortfolioPreApproval.call(proc, {
+        portfolio,
+        asset,
+        preApprove: true,
+      })
+    ).rejects.toThrow('The Portfolio has already pre-approved the asset');
+  });
+
+  it('should throw an error if removing pre approval for an asset that is not pre-approved', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      portfolioId,
+    });
+
+    return expect(
+      prepareTogglePortfolioPreApproval.call(proc, {
+        portfolio,
+        asset,
+        preApprove: false,
+      })
+    ).rejects.toThrow('The Portfolio has not pre-approved the asset');
+  });
+
+  it('should return a pre approve portfolio transaction spec', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      portfolioId,
+    });
+
+    const transaction = dsMockUtils.createTxMock('portfolio', 'preApprovePortfolio');
+
+    const result = await prepareTogglePortfolioPreApproval.call(proc, {
+      portfolio,
+      asset,
+      preApprove: true,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawAssetId, rawPortfolioId],
+      resolver: undefined,
+    });
+  });
+
+  it('should return a remove portfolio pre approval transaction spec', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      portfolioId,
+    });
+    portfolio.isAssetPreApproved.mockResolvedValue(true);
+
+    const transaction = dsMockUtils.createTxMock('portfolio', 'removePortfolioPreApproval');
+
+    const result = await prepareTogglePortfolioPreApproval.call(proc, {
+      portfolio,
+      asset,
+      preApprove: false,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawAssetId, rawPortfolioId],
+      resolver: undefined,
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        portfolioId,
+      });
+      const boundFunc = getAuthorization.bind(proc);
+      const args: Params = {
+        portfolio,
+        asset,
+        preApprove: true,
+      };
+
+      expect(boundFunc(args)).toEqual({
+        permissions: {
+          transactions: [TxTags.portfolio.PreApprovePortfolio],
+          assets: [],
+          portfolios: [portfolio],
+        },
+      });
+
+      args.preApprove = false;
+
+      expect(boundFunc(args)).toEqual({
+        permissions: {
+          transactions: [TxTags.portfolio.RemovePortfolioPreApproval],
+          assets: [],
+          portfolios: [portfolio],
+        },
+      });
+    });
+  });
+
+  describe('prepareStorage', () => {
+    it('should return the portfolio id', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext);
+      const boundFunc = prepareStorage.bind(proc);
+
+      when(portfolioLikeToPortfolioIdSpy).calledWith(portfolio).mockReturnValue(portfolioId);
+
+      const result = boundFunc({ portfolio, asset, preApprove: true });
+
+      expect(result).toEqual({
+        portfolioId,
+      });
+    });
+  });
+});

--- a/src/api/procedures/togglePortfolioPreApproval.ts
+++ b/src/api/procedures/togglePortfolioPreApproval.ts
@@ -1,0 +1,110 @@
+import {
+  BaseAsset,
+  DefaultPortfolio,
+  NumberedPortfolio,
+  PolymeshError,
+  Procedure,
+} from '~/internal';
+import { ErrorCode, PortfolioId, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import {
+  assetToMeshAssetId,
+  portfolioIdToMeshPortfolioId,
+  portfolioLikeToPortfolioId,
+} from '~/utils/conversion';
+import { asBaseAsset } from '~/utils/internal';
+
+/**
+ * @hidden
+ */
+export interface Params {
+  portfolio: DefaultPortfolio | NumberedPortfolio;
+  asset: BaseAsset | string;
+  preApprove: boolean;
+}
+
+export interface Storage {
+  portfolioId: PortfolioId;
+}
+
+/**
+ * @hidden
+ */
+export async function prepareTogglePortfolioPreApproval(
+  this: Procedure<Params, void, Storage>,
+  args: Params
+): Promise<TransactionSpec<void, ExtrinsicParams<'portfolio', 'preApprovePortfolio'>>> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    storage: { portfolioId },
+    context,
+  } = this;
+  const { portfolio, asset, preApprove } = args;
+
+  const baseAsset = await asBaseAsset(asset, context);
+  const isPreApproved = await portfolio.isAssetPreApproved(baseAsset);
+
+  if (isPreApproved === preApprove) {
+    const message = isPreApproved
+      ? 'The Portfolio has already pre-approved the asset'
+      : 'The Portfolio has not pre-approved the asset';
+    throw new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message,
+      data: { portfolioId, assetId: baseAsset.id },
+    });
+  }
+
+  const rawAssetId = assetToMeshAssetId(baseAsset, context);
+  const rawPortfolioId = portfolioIdToMeshPortfolioId(portfolioId, context);
+
+  const transaction = preApprove
+    ? tx.portfolio.preApprovePortfolio
+    : tx.portfolio.removePortfolioPreApproval;
+
+  return {
+    transaction,
+    args: [rawAssetId, rawPortfolioId],
+    resolver: undefined,
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void, Storage>,
+  { preApprove, portfolio }: Params
+): ProcedureAuthorization {
+  return {
+    permissions: {
+      transactions: [
+        preApprove
+          ? TxTags.portfolio.PreApprovePortfolio
+          : TxTags.portfolio.RemovePortfolioPreApproval,
+      ],
+      assets: [],
+      portfolios: [portfolio],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export function prepareStorage(
+  this: Procedure<Params, void, Storage>,
+  { portfolio }: Params
+): Storage {
+  return {
+    portfolioId: portfolioLikeToPortfolioId(portfolio),
+  };
+}
+
+/**
+ * @hidden
+ */
+export const togglePortfolioPreApproval = (): Procedure<Params, void, Storage> =>
+  new Procedure(prepareTogglePortfolioPreApproval, getAuthorization, prepareStorage);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -181,6 +181,7 @@ export { setMultiSigAdmin } from '~/api/procedures/setMultiSigAdmin';
 export { setVenueFiltering } from '~/api/procedures/setVenueFiltering';
 export { registerCustomClaimType } from '~/api/procedures/registerCustomClaimType';
 export { toggleAssetPreApproval } from '~/api/procedures/toggleAssetPreApproval';
+export { togglePortfolioPreApproval } from '~/api/procedures/togglePortfolioPreApproval';
 export { setMandatoryReceiverAffirmation } from '~/api/procedures/setMandatoryReceiverAffirmation';
 export { allowIdentityToCreatePortfolios } from '~/api/procedures/allowIdentityToCreatePortfolios';
 export { revokeIdentityToCreatePortfolios } from '~/api/procedures/revokeIdentityToCreatePortfolios';

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -279,6 +279,7 @@ interface NumberedPortfolioOptions extends EntityOptions {
   getCollections?: EntityGetter<PortfolioCollection[]>;
   getCustodian?: EntityGetter<Identity>;
   isCustodiedBy?: EntityGetter<boolean>;
+  isAssetPreApproved?: EntityGetter<boolean>;
 }
 
 interface DefaultPortfolioOptions extends EntityOptions {
@@ -288,6 +289,7 @@ interface DefaultPortfolioOptions extends EntityOptions {
   getCollections?: EntityGetter<PortfolioCollection[]>;
   getCustodian?: EntityGetter<Identity>;
   isCustodiedBy?: EntityGetter<boolean>;
+  isAssetPreApproved?: EntityGetter<boolean>;
 }
 
 interface CustomPermissionGroupOptions extends EntityOptions {
@@ -1649,6 +1651,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
     getCollections!: jest.Mock;
     getCustodian!: jest.Mock;
     isCustodiedBy!: jest.Mock;
+    isAssetPreApproved!: jest.Mock;
 
     /**
      * @hidden
@@ -1669,6 +1672,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
       this.getCollections = createEntityGetterMock(opts.getCollections);
       this.getCustodian = createEntityGetterMock(opts.getCustodian);
       this.isCustodiedBy = createEntityGetterMock(opts.isCustodiedBy);
+      this.isAssetPreApproved = createEntityGetterMock(opts.isAssetPreApproved);
     }
   },
   () => ({
@@ -1686,6 +1690,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
     did: 'someDid',
     getCustodian: getIdentityInstance(),
     isCustodiedBy: true,
+    isAssetPreApproved: false,
     toHuman: {
       did: 'someDid',
       id: '1',
@@ -1703,6 +1708,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
     getCollections!: jest.Mock;
     getCustodian!: jest.Mock;
     isCustodiedBy!: jest.Mock;
+    isAssetPreApproved!: jest.Mock;
 
     /**
      * @hidden
@@ -1722,6 +1728,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
       this.getCollections = createEntityGetterMock(opts.getCollections);
       this.getCustodian = createEntityGetterMock(opts.getCustodian);
       this.isCustodiedBy = createEntityGetterMock(opts.isCustodiedBy);
+      this.isAssetPreApproved = createEntityGetterMock(opts.isAssetPreApproved);
     }
   },
   () => ({
@@ -1738,6 +1745,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
     did: 'someDid',
     getCustodian: getIdentityInstance(),
     isCustodiedBy: true,
+    isAssetPreApproved: false,
     toHuman: {
       did: 'someDid',
     },


### PR DESCRIPTION
### Description

Adds portfolio-level asset pre-approval, the counterpart to the existing asset-level pre-approval (`BaseAsset.Settlements.preApprove`/`removePreApproval`). A specific `Portfolio` (rather than "any portfolio of this identity") can now pre-approve receiving a given asset, so incoming transfers of it auto-affirm without a manual affirm step — mirroring the chain's `portfolio.preApprovePortfolio` / `portfolio.removePortfolioPreApproval` extrinsics.

New public API on `Portfolio` (works for both `DefaultPortfolio` and `NumberedPortfolio`):
- `portfolio.preApproveAsset({ asset })` — pre-approves receiving `asset` into this portfolio
- `portfolio.removeAssetPreApproval({ asset })` — removes that pre-approval
- `portfolio.isAssetPreApproved(asset)` — reads current pre-approval status from `portfolio.preApprovedPortfolios` storage
- `portfolio.preApprovedAssets(paginationOpts?)` — lists all assets this portfolio has pre-approved, paginated over the same storage's `entries()`, mirroring `Identity.preApprovedAssets`

Implementation:
- New `togglePortfolioPreApproval` procedure (`src/api/procedures/togglePortfolioPreApproval.ts`), dispatching `tx.portfolio.preApprovePortfolio` / `removePortfolioPreApproval` with `args: [rawAssetId, rawPortfolioId]` (asset first, matching the chain call's argument order — note this is the reverse of the `(PortfolioId, AssetId)` storage key order). Includes a `NoDataChange` no-op guard backed by `isAssetPreApproved`.
- All four methods wired onto `Portfolio` directly (via `createProcedureMethod` for the two procedure calls, following the existing `moveFunds`/`quitCustody` pattern).

Verified against a live local v8 dev chain in addition to unit tests: asset creation → pre-approve → query → remove → query, no-op guard checks, and `preApprovedAssets` listing/pagination — for both `DefaultPortfolio` and `NumberedPortfolio`.

### Breaking Changes

None — purely additive.

### JIRA Link



### Checklist

- [ ] Updated the Readme.md (if required)?