### PR TITLE
feat: 🎸 add getters for fetching legs status and signer count

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -45,6 +45,7 @@ import {
   InstructionAffirmationOperation,
   InstructionStatus,
   InstructionType,
+  LegStatusType,
   NftLeg,
   OffChainLeg,
   SignerKeyRingType,
@@ -53,6 +54,7 @@ import {
 import { InstructionStatus as InternalInstructionStatus } from '~/types/internal';
 import { tuple } from '~/types/utils';
 import { hexToUuid } from '~/utils';
+import { DUMMY_ACCOUNT_ID } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as utilsInternalModule from '~/utils/internal';
 
@@ -2750,6 +2752,40 @@ describe('Instruction class', () => {
 
         expect(result).toEqual(AffirmationStatus.Pending);
       });
+    });
+  });
+
+  describe('method: getLegStatus', () => {
+    const legId = new BigNumber(2);
+
+    it('should return the execution status for a specific leg', async () => {
+      dsMockUtils.createQueryMock('settlement', 'instructionLegStatus', {
+        returnValue: dsMockUtils.createMockLegStatus('ExecutionPending'),
+      });
+
+      const result = await instruction.getLegStatus({ legId });
+
+      expect(result).toEqual({ type: LegStatusType.ExecutionPending });
+    });
+
+    it('should return the receipt details when the leg execution is to be skipped', async () => {
+      const address = DUMMY_ACCOUNT_ID;
+      const uid = new BigNumber(10);
+
+      dsMockUtils.createQueryMock('settlement', 'instructionLegStatus', {
+        returnValue: dsMockUtils.createMockLegStatus({
+          ExecutionToBeSkipped: [
+            dsMockUtils.createMockAccountId(address),
+            dsMockUtils.createMockU64(uid),
+          ],
+        }),
+      });
+
+      const result = await instruction.getLegStatus({ legId });
+
+      expect(result).toEqual(
+        expect.objectContaining({ type: LegStatusType.ExecutionToBeSkipped, uid })
+      );
     });
   });
 

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -13,6 +13,7 @@ import {
   InstructionStatus,
   InstructionStatusResult,
   Leg,
+  LegStatus,
   MediatorAffirmation,
   OffChainAffirmation,
 } from '~/api/entities/Instruction/types';
@@ -82,6 +83,7 @@ import {
   meshAffirmationStatusToAffirmationStatus,
   meshAssetHolderToAssetHolder,
   meshInstructionStatusToInstructionStatus,
+  meshLegStatusToLegStatus,
   meshNftToNftId,
   meshSettlementTypeToEndCondition,
   middlewareAffirmStatusToAffirmationStatus,
@@ -1327,6 +1329,33 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
     const rawAffirmStatus = await settlement.offChainAffirmations(rawId, rawLegId);
 
     return meshAffirmationStatusToAffirmationStatus(rawAffirmStatus);
+  }
+
+  /**
+   * Returns the execution status of a specific leg in this Instruction
+   *
+   * @param args.legId index of the leg whose status is to be fetched
+   */
+  public async getLegStatus(args: { legId: BigNumber }): Promise<LegStatus> {
+    const {
+      id,
+      context,
+      context: {
+        polymeshApi: {
+          query: { settlement },
+        },
+      },
+    } = this;
+
+    const { legId } = args;
+
+    const rawId = bigNumberToU64(id, context);
+
+    const rawLegId = bigNumberToU64(legId, context);
+
+    const rawLegStatus = await settlement.instructionLegStatus(rawId, rawLegId);
+
+    return meshLegStatusToLegStatus(rawLegStatus, context);
   }
 
   /**

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -105,6 +105,25 @@ export enum ReceiverAffirmationRequirement {
   Required = 'Required',
 }
 
+export enum LegStatusType {
+  PendingTokenLock = 'PendingTokenLock',
+  ExecutionPending = 'ExecutionPending',
+  ExecutionToBeSkipped = 'ExecutionToBeSkipped',
+}
+
+export type LegStatus =
+  | {
+      type: LegStatusType.PendingTokenLock;
+    }
+  | {
+      type: LegStatusType.ExecutionPending;
+    }
+  | {
+      type: LegStatusType.ExecutionToBeSkipped;
+      signer: Account;
+      uid: BigNumber;
+    };
+
 export interface InstructionAffirmation {
   party: Identity | Account;
   status: AffirmationStatus;

--- a/src/api/entities/Venue/__tests__/index.ts
+++ b/src/api/entities/Venue/__tests__/index.ts
@@ -409,6 +409,20 @@ describe('Venue class', () => {
     });
   });
 
+  describe('method: getSignerCount', () => {
+    it('should return the number of signers allowed by the Venue', async () => {
+      const count = new BigNumber(3);
+
+      dsMockUtils.createQueryMock('settlement', 'numberOfVenueSigners', {
+        returnValue: dsMockUtils.createMockU32(count),
+      });
+
+      const result = await venue.getSignerCount();
+
+      expect(result).toEqual(count);
+    });
+  });
+
   describe('method: addSigners', () => {
     afterAll(() => {
       jest.restoreAllMocks();

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -34,6 +34,7 @@ import {
   identityIdToString,
   meshVenueTypeToVenueType,
   middlewareInstructionToHistoricInstruction,
+  u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
 import { calculateNextKey, createProcedureMethod } from '~/utils/internal';
@@ -315,6 +316,25 @@ export class Venue extends Entity<UniqueIdentifiers, string> {
         },
       ]) => new Account({ address: accountIdToString(rawAccountId) }, context)
     );
+  }
+
+  /**
+   * Get the number of signers allowed by this Venue
+   */
+  public async getSignerCount(): Promise<BigNumber> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { settlement },
+        },
+      },
+      id,
+      context,
+    } = this;
+
+    const rawCount = await settlement.numberOfVenueSigners(bigNumberToU64(id, context));
+
+    return u32ToBigNumber(rawCount);
   }
 
   /**

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -136,6 +136,7 @@ import {
   PolymeshPrimitivesSettlementInstruction,
   PolymeshPrimitivesSettlementInstructionStatus,
   PolymeshPrimitivesSettlementLeg,
+  PolymeshPrimitivesSettlementLegStatus,
   PolymeshPrimitivesSettlementMediatorAffirmationStatus,
   PolymeshPrimitivesSettlementSettlementType,
   PolymeshPrimitivesSettlementVenueType,
@@ -3490,6 +3491,16 @@ export const createMockAffirmationStatus = (
   authorizationStatus?: 'Unknown' | 'Pending' | 'Affirmed'
 ): MockCodec<PolymeshPrimitivesSettlementAffirmationStatus> => {
   return createMockEnum<PolymeshPrimitivesSettlementAffirmationStatus>(authorizationStatus);
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
+export const createMockLegStatus = (
+  legStatus?: 'PendingTokenLock' | 'ExecutionPending' | { ExecutionToBeSkipped: [AccountId, u64] }
+): MockCodec<PolymeshPrimitivesSettlementLegStatus> => {
+  return createMockEnum<PolymeshPrimitivesSettlementLegStatus>(legStatus);
 };
 
 /**

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -162,6 +162,7 @@ import {
   KnownAssetType,
   KnownNftType,
   Leg,
+  LegStatusType,
   MetadataLockStatus,
   MetadataType,
   ModuleName,
@@ -318,6 +319,7 @@ import {
   meshCorporateBallotMetaToCorporateBallotMeta,
   meshCorporateBallotMotionToCorporateBallotMotion,
   meshInstructionStatusToInstructionStatus,
+  meshLegStatusToLegStatus,
   meshMetadataKeyToMetadataKey,
   meshMetadataSpecToMetadataSpec,
   meshMetadataValueToMetadataValue,
@@ -7232,6 +7234,54 @@ describe('meshAffirmationStatusToAffirmationStatus', () => {
 
     result = meshAffirmationStatusToAffirmationStatus(authorizationStatus);
     expect(result).toEqual(fakeResult);
+  });
+});
+
+describe('meshLegStatusToLegStatus', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should convert a polkadot LegStatus object to a LegStatus', () => {
+    const context = dsMockUtils.getContextInstance();
+
+    let legStatus = dsMockUtils.createMockLegStatus('PendingTokenLock');
+
+    let result = meshLegStatusToLegStatus(legStatus, context);
+    expect(result).toEqual({ type: LegStatusType.PendingTokenLock });
+
+    legStatus = dsMockUtils.createMockLegStatus('ExecutionPending');
+
+    result = meshLegStatusToLegStatus(legStatus, context);
+    expect(result).toEqual({ type: LegStatusType.ExecutionPending });
+
+    const address = DUMMY_ACCOUNT_ID;
+    const uid = new BigNumber(10);
+
+    legStatus = dsMockUtils.createMockLegStatus({
+      ExecutionToBeSkipped: [
+        dsMockUtils.createMockAccountId(address),
+        dsMockUtils.createMockU64(uid),
+      ],
+    });
+
+    result = meshLegStatusToLegStatus(legStatus, context);
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: LegStatusType.ExecutionToBeSkipped,
+        uid,
+      })
+    );
+    expect((result as { signer: Account }).signer).toBeInstanceOf(Account);
+    expect((result as { signer: Account }).signer.address).toBe(address);
   });
 });
 

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -78,6 +78,7 @@ import {
   PolymeshPrimitivesSettlementAssetCount,
   PolymeshPrimitivesSettlementInstructionStatus,
   PolymeshPrimitivesSettlementLeg,
+  PolymeshPrimitivesSettlementLegStatus,
   PolymeshPrimitivesSettlementMediatorAffirmationStatus,
   PolymeshPrimitivesSettlementReceiptDetails,
   PolymeshPrimitivesSettlementReceiptMetadata,
@@ -252,6 +253,8 @@ import {
   KnownAssetType,
   KnownNftType,
   Leg,
+  LegStatus,
+  LegStatusType,
   MediatorAffirmation,
   MetadataKeyId,
   MetadataLockStatus,
@@ -3410,6 +3413,30 @@ export function meshAffirmationStatusToAffirmationStatus(
   }
 
   return AffirmationStatus.Affirmed;
+}
+
+/**
+ * @hidden
+ */
+export function meshLegStatusToLegStatus(
+  status: PolymeshPrimitivesSettlementLegStatus,
+  context: Context
+): LegStatus {
+  if (status.isPendingTokenLock) {
+    return { type: LegStatusType.PendingTokenLock };
+  }
+
+  if (status.isExecutionPending) {
+    return { type: LegStatusType.ExecutionPending };
+  }
+
+  const [rawSigner, rawUid] = status.asExecutionToBeSkipped;
+
+  return {
+    type: LegStatusType.ExecutionToBeSkipped,
+    signer: new Account({ address: accountIdToString(rawSigner) }, context),
+    uid: u64ToBigNumber(rawUid),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds two independent read-only getters for Settlement-pallet storage items that previously had no SDK coverage:

- **`Instruction.getLegStatus({ legId })`** — reads `settlement.instructionLegStatus`, returning the per-leg execution status (`PendingTokenLock` / `ExecutionPending` / `ExecutionToBeSkipped`), distinct from the existing affirmation-status getters. Useful for settlement-monitoring UIs that need to know which specific legs of a multi-leg instruction have settled vs. failed.
- **`Venue.getSignerCount()`** — reads `settlement.numberOfVenueSigners`, returning a `BigNumber` count of a Venue's allowed signers, cheaper than calling `getAllowedSigners()` just to count the list.

Both are plain chain reads with no middleware/subquery equivalent (`LegStatus` is inherently transient on-chain state), so neither method branches on middleware availability.

## Changes

- `src/utils/conversion.ts` — new `meshLegStatusToLegStatus` conversion function, mirroring `meshAffirmationStatusToAffirmationStatus`, handling the data-carrying `ExecutionToBeSkipped(AccountId, u64)` variant.
- `src/api/entities/Instruction/types.ts` — new `LegStatus` type (`LegStatusType` enum + discriminated union), re-exported from `~/types` via the existing `Instruction/types` re-export chain (same path as `AffirmationStatus`).
- `src/api/entities/Instruction/index.ts` — new `getLegStatus({ legId })` method.
- `src/api/entities/Venue/index.ts` — new `getSignerCount()` method.
- `src/testUtils/mocks/dataSources.ts` — new `createMockLegStatus` test helper.
- Unit tests for the conversion function (all 3 chain variants) and both new entity methods.

No changes to existing affirmation-status logic, no new extrinsics.

## Test plan

- [x] `meshLegStatusToLegStatus` unit tests cover all 3 chain enum variants, including the data-carrying `ExecutionToBeSkipped`
- [x] `Instruction.getLegStatus` unit tests (pending-execution and execution-to-be-skipped cases)
- [x] `Venue.getSignerCount` unit test
- [x] Full suite passes: 207 suites / 2495 tests, no regressions
- [x] Lint and `tsc -b` typecheck clean
- [x] Verified against a live local v8 dev chain (`polymesh-dev-env`):
  - `Venue.getSignerCount()` correctly tracked 0 → 1 → 0 across `addSigners`/`removeSigners`
  - `Instruction.getLegStatus()` correctly read `ExecutionPending` for a real two-identity (Alice/Bob) instruction leg