### PR TITLE
feat: 🎸 add registerDid procedure for registrar-gated DID registration

### DIFF
--- a/src/api/client/Identities.ts
+++ b/src/api/client/Identities.ts
@@ -10,6 +10,7 @@ import {
   createPortfolios,
   Identity,
   NumberedPortfolio,
+  registerDid,
   registerIdentity,
   revokeIdentityToCreatePortfolios,
   rotatePrimaryKey,
@@ -23,6 +24,7 @@ import {
   CreateChildIdentityParams,
   NoArgsProcedureMethod,
   ProcedureMethod,
+  RegisterDidParams,
   RegisterIdentityParams,
   RevokeIdentityToCreatePortfoliosParams,
   RotatePrimaryKeyParams,
@@ -50,6 +52,11 @@ export class Identities {
 
     this.selfRegisterDid = createProcedureMethod(
       { getProcedureAndArgs: () => [selfRegisterDid, undefined], voidArgs: true },
+      context
+    );
+
+    this.registerDid = createProcedureMethod(
+      { getProcedureAndArgs: args => [registerDid, args] },
       context
     );
 
@@ -140,6 +147,16 @@ export class Identities {
    * @throws if the signing Account is already linked to an Identity
    */
   public selfRegisterDid: NoArgsProcedureMethod<Identity>;
+
+  /**
+   * Register a new DID for the `targetAccount`
+   *
+   * @note the transaction signer must be an active DID Registrar
+   * @note unlike {@link registerIdentity}, this does not support secondary keys or CDD claims
+   *
+   * @throws if the `targetAccount` is already linked to an Identity
+   */
+  public registerDid: ProcedureMethod<RegisterDidParams, Identity>;
 
   /**
    * Get CDD Provider's attestation to change primary key

--- a/src/api/client/__tests__/Identities.ts
+++ b/src/api/client/__tests__/Identities.ts
@@ -139,6 +139,24 @@ describe('Identities Class', () => {
     });
   });
 
+  describe('method: registerDid', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const args = {
+        targetAccount: 'someTarget',
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Identity>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, context, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await identities.registerDid(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
   describe('method: selfRegisterDid', () => {
     it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
       const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Identity>;

--- a/src/api/procedures/__tests__/registerDid.ts
+++ b/src/api/procedures/__tests__/registerDid.ts
@@ -1,0 +1,166 @@
+import { AccountId } from '@polkadot/types/interfaces';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { when } from 'jest-when';
+
+import {
+  createRegisterDidResolver,
+  prepareRegisterDid,
+  registerDid,
+} from '~/api/procedures/registerDid';
+import { Context, Identity, PolymeshError, Procedure } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { ErrorCode, RegisterDidParams, RoleType, TxTags } from '~/types';
+import { PolymeshTx } from '~/types/internal';
+import * as utilsConversionModule from '~/utils/conversion';
+import * as utilsInternalModule from '~/utils/internal';
+
+jest.mock(
+  '~/api/entities/Account',
+  require('~/testUtils/mocks/entities').mockAccountModule('~/api/entities/Account')
+);
+
+describe('registerDid procedure', () => {
+  const targetAccount = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+  const rawAccountId = dsMockUtils.createMockAccountId(targetAccount);
+
+  let mockContext: Mocked<Context>;
+  let stringToAccountIdSpy: jest.SpyInstance<AccountId, [string, Context]>;
+  let registerDidTransaction: PolymeshTx<unknown[]>;
+  let proc: Procedure<RegisterDidParams, Identity, Record<string, unknown>>;
+
+  beforeAll(() => {
+    entityMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    dsMockUtils.initMocks();
+    stringToAccountIdSpy = jest.spyOn(utilsConversionModule, 'stringToAccountId');
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance({ isV7: false });
+    registerDidTransaction = dsMockUtils.createTxMock('identity', 'registerDid');
+    proc = procedureMockUtils.getInstance<RegisterDidParams, Identity>(mockContext);
+    jest.spyOn(utilsInternalModule, 'assertAddressValid').mockImplementation();
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should return a registerDid transaction spec', async () => {
+    entityMockUtils.configureMocks({
+      accountOptions: {
+        getIdentity: null,
+      },
+    });
+
+    const args = {
+      targetAccount,
+    };
+
+    when(stringToAccountIdSpy).calledWith(targetAccount, mockContext).mockReturnValue(rawAccountId);
+
+    const result = await prepareRegisterDid.call(proc, args);
+
+    expect(result).toEqual({
+      transaction: registerDidTransaction,
+      args: [rawAccountId],
+      resolver: expect.any(Function),
+    });
+  });
+
+  it('should throw if called for chain v7', () => {
+    mockContext = dsMockUtils.getContextInstance({ isV7: true });
+    proc = procedureMockUtils.getInstance<RegisterDidParams, Identity>(mockContext);
+
+    const args = {
+      targetAccount,
+    };
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.NotSupported,
+      message: 'registerDid is only supported in chain v8',
+    });
+
+    return expect(prepareRegisterDid.call(proc, args)).rejects.toThrow(expectedError);
+  });
+
+  it('should throw if the target Account already has an Identity', () => {
+    const identity = entityMockUtils.getIdentityInstance({
+      getPrimaryAccount: {
+        account: entityMockUtils.getAccountInstance({ address: targetAccount }),
+      },
+    });
+
+    entityMockUtils.getAccountInstance({ address: targetAccount, getIdentity: identity });
+
+    const args = {
+      targetAccount,
+    };
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message: 'The target account already has an identity',
+    });
+
+    return expect(prepareRegisterDid.call(proc, args)).rejects.toThrow(expectedError);
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', async () => {
+      const args = {
+        targetAccount,
+      };
+
+      const result = await registerDid().requiredAuthorizations(args);
+
+      expect(result).toEqual({
+        roles: [{ type: RoleType.DidRegistrar }],
+        permissions: {
+          assets: [],
+          portfolios: [],
+          transactions: [TxTags.identity.RegisterDid],
+        },
+      });
+    });
+  });
+});
+
+describe('createRegisterDidResolver', () => {
+  const filterEventRecordsSpy = jest.spyOn(utilsInternalModule, 'filterEventRecords');
+  const did = 'someDid';
+  const rawDid = dsMockUtils.createMockIdentityId(did);
+
+  beforeAll(() => {
+    entityMockUtils.initMocks({
+      identityOptions: {
+        did,
+      },
+    });
+  });
+
+  beforeEach(() => {
+    filterEventRecordsSpy.mockReturnValue([
+      dsMockUtils.createMockIEvent([rawDid, 'accountId', 'signingItem']),
+    ]);
+  });
+
+  afterEach(() => {
+    filterEventRecordsSpy.mockReset();
+  });
+
+  it('should return the new Identity', () => {
+    const fakeContext = {} as Context;
+
+    const result = createRegisterDidResolver(fakeContext)({} as ISubmittableResult);
+
+    expect(result.did).toEqual(did);
+  });
+});

--- a/src/api/procedures/registerDid.ts
+++ b/src/api/procedures/registerDid.ts
@@ -1,0 +1,77 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+
+import { Context, Identity, PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, RegisterDidParams, RoleType, TxTags } from '~/types';
+import { ExtrinsicParams, TransactionSpec } from '~/types/internal';
+import { identityIdToString, stringToAccountId } from '~/utils/conversion';
+import { asAccount, filterEventRecords } from '~/utils/internal';
+
+/**
+ * @hidden
+ */
+export const createRegisterDidResolver =
+  (context: Context) =>
+  (receipt: ISubmittableResult): Identity => {
+    const [record] = filterEventRecords(receipt, 'identity', 'DidCreated');
+
+    const { data } = record!;
+
+    const did = identityIdToString(data[0]);
+
+    return new Identity({ did }, context);
+  };
+
+/**
+ * @hidden
+ */
+export async function prepareRegisterDid(
+  this: Procedure<RegisterDidParams, Identity>,
+  args: RegisterDidParams
+): Promise<TransactionSpec<Identity, ExtrinsicParams<'identity', 'registerDid'>>> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    context,
+  } = this;
+  const { targetAccount } = args;
+
+  if (context.isV7) {
+    throw new PolymeshError({
+      code: ErrorCode.NotSupported,
+      message: 'registerDid is only supported in chain v8',
+    });
+  }
+
+  const account = asAccount(targetAccount, context);
+
+  const identityExists = await account.getIdentity();
+
+  if (identityExists) {
+    throw new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message: 'The target account already has an identity',
+    });
+  }
+
+  const rawTargetAccount = stringToAccountId(account.address, context);
+
+  return {
+    transaction: tx.identity.registerDid,
+    args: [rawTargetAccount],
+    resolver: createRegisterDidResolver(context),
+  };
+}
+
+/**
+ * @hidden
+ */
+export const registerDid = (): Procedure<RegisterDidParams, Identity> =>
+  new Procedure(prepareRegisterDid, {
+    roles: [{ type: RoleType.DidRegistrar }],
+    permissions: {
+      assets: [],
+      portfolios: [],
+      transactions: [TxTags.identity.RegisterDid],
+    },
+  });

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1002,6 +1002,13 @@ export interface RegisterIdentityParams {
   expiry?: Date;
 }
 
+export interface RegisterDidParams {
+  /**
+   * The Account that should function as the primary key of the newly created Identity. Can be ss58 encoded address or an instance of Account
+   */
+  targetAccount: string | Account;
+}
+
 export interface AttestPrimaryKeyRotationParams {
   /**
    * The Account that will be attested to become the primary key of the `identity`. Can be ss58 encoded address or an instance of Account

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -47,6 +47,7 @@ export {
   Params as ModifyAssetTrustedClaimIssuersParams,
 } from '~/api/procedures/modifyAssetTrustedClaimIssuers';
 export { registerIdentity } from '~/api/procedures/registerIdentity';
+export { registerDid } from '~/api/procedures/registerDid';
 export { selfRegisterDid } from '~/api/procedures/selfRegisterDid';
 export { createChildIdentity } from '~/api/procedures/createChildIdentity';
 export { createChildIdentities } from '~/api/procedures/createChildIdentities';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5840,30 +5840,30 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -8270,9 +8270,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.3
-  resolution: "fast-uri@npm:3.1.3"
-  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
   languageName: node
   linkType: hard
 
@@ -9599,9 +9599,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 
@@ -11043,7 +11043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"launch-editor@npm:^2.6.1":
+"launch-editor@npm:^2.14.1":
   version: 2.14.1
   resolution: "launch-editor@npm:2.14.1"
   dependencies:
@@ -11210,11 +11210,11 @@ __metadata:
   linkType: hard
 
 "linkify-it@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "linkify-it@npm:5.0.1"
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: "npm:^2.0.0"
-  checksum: 10c0/d06d04f1ed03be131740fc900a5e74ea1f49886b052213599e306d469d5ffe2303db76dd8f771de9f28e2b0b38852de22ec46ae597d245f8b66439b0ceb19b10
+  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
   languageName: node
   linkType: hard
 
@@ -16113,16 +16113,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.23.0, undici@npm:^6.25.0":
-  version: 6.27.0
-  resolution: "undici@npm:6.27.0"
-  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10c0/3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
   languageName: node
   linkType: hard
 
 "undici@npm:^7.0.0":
-  version: 7.28.0
-  resolution: "undici@npm:7.28.0"
-  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
   languageName: node
   linkType: hard
 
@@ -16457,8 +16457,8 @@ __metadata:
   linkType: hard
 
 "webpack-dev-server@npm:^5.2.1":
-  version: 5.2.5
-  resolution: "webpack-dev-server@npm:5.2.5"
+  version: 5.2.6
+  resolution: "webpack-dev-server@npm:5.2.6"
   dependencies:
     "@types/bonjour": "npm:^3.5.13"
     "@types/connect-history-api-fallback": "npm:^1.5.4"
@@ -16478,7 +16478,7 @@ __metadata:
     graceful-fs: "npm:^4.2.6"
     http-proxy-middleware: "npm:^2.0.9"
     ipaddr.js: "npm:^2.1.0"
-    launch-editor: "npm:^2.6.1"
+    launch-editor: "npm:^2.14.1"
     open: "npm:^10.0.3"
     p-retry: "npm:^6.2.0"
     schema-utils: "npm:^4.2.0"
@@ -16497,7 +16497,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 10c0/8963b3533197ebd820456f3cb14d9234ba4dff10412eb11200b8099c501559abf7a700e9a5d4136f17929374b61c1af5c6ef597471ea45b97ba6ca69a12e5ca8
+  checksum: 10c0/8240a52d7eee2ca156a708f1533236e24dae9ebd0794fb17c98cfd77804e2384d9b402e8778d6453e53542a8e99647335f0002e319ac6b9d13aa6ff1b4f4bf5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Adds `Identities.registerDid({ targetAccount })`, wrapping the v8-only `identity.registerDid` extrinsic, which lets an active **DID Registrar** register a DID for *someone else's* account.
- This is the registrar-gated sibling of the already-implemented `selfRegisterDid` (permissionless self-onboarding). The only prior way to register an identity on someone else's behalf was the deprecated `cddRegisterDid`/`cddRegisterDidWithCdd` pair (`registerIdentity`), which as of v8 no longer attaches a CDD claim and is retained only for its secondary-key support.
- `registerDid` takes a single argument (`targetAccount`) — no secondary keys, no expiry, no CDD claim — matching the simpler chain-side `register_did` extrinsic (`Self::base_register_did(origin, target_account, vec![])`).
- Uses `RoleType.DidRegistrar` for authorization (checked against `didRegistrars.activeMembers` on v8), rather than the legacy `RoleType.CddProvider` used by `registerIdentity` — this is its first real consumer in the SDK.

## Changes

- `src/api/procedures/registerDid.ts` (new): the procedure — guards against chain v7 (`registerDid` doesn't exist pre-v8), checks the target account doesn't already have an identity (`ErrorCode.NoDataChange` otherwise), dispatches `tx.identity.registerDid`, and resolves to the new `Identity` via the `identity.DidCreated` event.
- `src/api/procedures/__tests__/registerDid.ts` (new): unit tests for v7 rejection, target-already-registered rejection, successful transaction spec, the `DidCreated` resolver, and the `RoleType.DidRegistrar` authorization.
- `src/api/procedures/types.ts`: adds `RegisterDidParams { targetAccount: string | Account }`.
- `src/internal.ts`: exports the new procedure.
- `src/api/client/Identities.ts` / `__tests__/Identities.ts`: exposes `Identities.registerDid` as a `ProcedureMethod<RegisterDidParams, Identity>`, wired the same way as `registerIdentity`.

## Test plan

- [x] `yarn test` — full suite passes (208 suites / 2497 tests), including new `registerDid` procedure and `Identities` client tests
- [x] `yarn lint` — clean
- [x] `tsc -b tsconfig.lib.json` — clean
- [x] Verified end-to-end against a live local v8 dev chain (`polymeshassociation/polymesh:8.0.2-testnet-debian`):
  - Alice (genesis DID Registrar) successfully registers a DID for a fresh, unregistered account
  - The new identity resolves correctly and is linked on-chain
  - No CDD claim is attached (`hasValidCdd()` reduces to identity existence in v8, matching the chain's "DID existence is sufficient for onboarding" semantics)
  - Re-registering the same target account throws `NoDataChange`, as expected
  - A non-registrar identity (self-registered via `selfRegisterDid`) attempting to call `registerDid` is correctly rejected with a role-authorization error, confirming the `RoleType.DidRegistrar` gate is enforced on-chain, not just in the SDK's local checks
