### PR TITLE
docs: add v30.1.0-v30.2.0 changelog

### DIFF
--- a/changelogs/v30.1.0-next.md
+++ b/changelogs/v30.1.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v30.1.0 to next release
-description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes Ledger signing support fixes and corrected POLYX balance calculations for chain v8.
+description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes registrar-gated DID registration, portfolio-level asset pre-approval, new settlement/asset getters, Ledger signing fixes, and corrected POLYX balance/off-chain receipt handling for chain v8.
 sidebar_label: v30.1.0 → next
 id: v30-1-to-next
 tags:
@@ -14,11 +14,73 @@ This guide describes **unreleased** changes since **v30.1.0** of `@polymeshassoc
 
 ## Overview
 
-This release fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app, and corrects the **POLYX balance calculation** for chain v8 accounts with staked (held) funds. No code changes are required in consuming applications, though note the clarified meaning of `locked` in `AccountBalance` described below.
+This release adds registrar-gated DID registration, portfolio-level asset pre-approval, and several new settlement/asset getters. It also fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app, corrects the **POLYX balance calculation** for chain v8 accounts with staked (held) funds, and fixes **v8 off-chain settlement receipt** expiry propagation and encoding. No code changes are required in consuming applications, though note the clarified meaning of `locked` in `AccountBalance` described below.
+
+---
+
+## New features
+
+### `registerDid` — registrar-gated DID registration (v8 only)
+
+Implements the v8-only `identity.registerDid` extrinsic, letting an active DID Registrar register a DID for someone else's Account:
+
+```typescript
+const identity = await sdk.identities.registerDid({ targetAccount: '5G...' });
+```
+
+This complements the existing permissionless `Identities.selfRegisterDid` and the deprecated `registerIdentity` (`cddRegisterDid`), which no longer attaches a CDD claim as of v8. Calling this on a v7 chain, or targeting an Account that already has an Identity, raises a `PolymeshError`.
+
+### Portfolio-level asset pre-approval
+
+A Portfolio can now pre-approve receiving a specific asset, so incoming transfers of it auto-affirm without a manual affirm step — the portfolio-level counterpart to the existing Identity-level pre-approval:
+
+```typescript
+await portfolio.preApproveAsset({ asset });
+await portfolio.isAssetPreApproved(asset); // true
+await portfolio.removeAssetPreApproval({ asset });
+```
+
+### `Portfolio.preApprovedAssets` getter
+
+Lists all assets a Portfolio has pre-approved, paginated over the `preApprovedPortfolios` storage entries, mirroring `Identity.preApprovedAssets`.
+
+### Settlement getters: leg status and venue signer count
+
+- `Instruction.getLegStatus({ legId })` — returns the execution status of a specific leg in an Instruction.
+- `Venue.getSignerCount()` — returns the number of signers allowed by a Venue.
+
+### `unlockInstructionForExecution` — complete the lock/relock cycle
+
+`Instruction.unlockForExecution()` moves a `LockedForExecution` instruction back to `Pending`, and `Instruction.getRelockStatus()` exposes the mediator's last unlock timestamp, relock count, max relock count, and the on-chain relock cooldown window — completing the lock/relock flow that `lockForExecution` alone couldn't finish.
+
+### Ticker length validated against live chain config
+
+`reserveTicker`, `createAsset`, and `createNftCollection` now validate the ticker length against the chain's live `TickerConfig.maxTickerLength` instead of a hardcoded constant, so the SDK stays correct if the chain's configured max length changes.
+
+### `BaseAsset.getIssuedInFundingRound`
+
+Returns the total amount of an Asset issued in a given funding round:
+
+```typescript
+const issued = await asset.getIssuedInFundingRound('Series A');
+```
+
+### `Assets.getTickerRegistrationConfig`
+
+Returns the chain-wide rules used to validate ticker registrations — `maxTickerLength` and `registrationLength` (`null` if registrations don't expire).
 
 ---
 
 ## Bug fixes
+
+### Correct v8 off-chain settlement receipt expiry and encoding
+
+- `expiresAt` was computed and signed into the off-chain receipt payload but dropped before reaching `affirmWithReceipts`/`affirmWithReceiptsWithCount` — it's now forwarded into both the returned `OffChainAffirmationReceipt` and the raw on-chain receipt details.
+- The v8 signed payload now includes the chain's `genesis_hash` and length-prefixes the receipt label, matching the runtime's `ChainScopedMessage` encoding.
+- Fixed the byte order of the signed `expiresAt` value (it was missing the little-endian flag).
+- `signatureToMeshRuntimeMultiSignature` now uses correctly sized `[u8; 64]`/`[u8; 65]` byte arrays instead of a bare `U8aFixed`, which failed to resolve against a v8 chain's metadata registry.
+
+No action is needed from consumers — off-chain receipt affirmation on v8 chains simply works correctly now.
 
 ### Support signers that return a signed transaction (Ledger generic app)
 

--- a/changelogs/v30.1.0-v30.2.0.md
+++ b/changelogs/v30.1.0-v30.2.0.md
@@ -1,18 +1,20 @@
 ---
-title: SDK Changelog - v30.1.0 to next release
-description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes registrar-gated DID registration, portfolio-level asset pre-approval, new settlement/asset getters, Ledger signing fixes, and corrected POLYX balance/off-chain receipt handling for chain v8.
-sidebar_label: v30.1.0 → next
-id: v30-1-to-next
+title: SDK Changelog - v30.1.0 to v30.2.0
+description: Changes between Polymesh SDK v30.1.0 and v30.2.0. Includes registrar-gated DID registration, portfolio-level asset pre-approval, new settlement/asset getters, Ledger signing fixes, and corrected POLYX balance/off-chain receipt handling for chain v8.
+sidebar_label: v30.1.0 → v30.2.0
+id: v30-1-to-v30-2
 tags:
   - changelog
   - sdk
 ---
 
-This guide describes **unreleased** changes since **v30.1.0** of `@polymeshassociation/polymesh-sdk`. These will be included in the next release.
+This guide describes changes between **v30.1.0** and **v30.2.0** of `@polymeshassociation/polymesh-sdk`.
 
 ---
 
 ## Overview
+
+v30.2.0 is a **minor release** containing new features and bug fixes. There are **no breaking changes** — upgrading is a drop-in replacement for v30.1.0.
 
 This release adds registrar-gated DID registration, portfolio-level asset pre-approval, and several new settlement/asset getters. It also fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app, corrects the **POLYX balance calculation** for chain v8 accounts with staked (held) funds, and fixes **v8 off-chain settlement receipt** expiry propagation and encoding. No code changes are required in consuming applications, though note the clarified meaning of `locked` in `AccountBalance` described below.
 
@@ -126,3 +128,12 @@ clamped at zero, with the existential deposit (`0.000001 POLYX`) read from the c
 - `frozen` — the minimum balance (out of `total`) that must remain in the Account due to freezes/locks (e.g. vesting). May overlap with `reserved`: vested POLYX that is also bonded counts towards both. On v7 chains this is `max(miscFrozen, feeFrozen)`.
 
 These additions are backwards compatible for code that reads balances. Validations that consume `free` (`transferPolyx`, `bondPolyx`, transaction fee checks) now use the corrected value, so they no longer reject valid transactions for staking-heavy accounts.
+
+---
+
+## Version compatibility matrix
+
+| SDK version | Chain v7 | Chain v8 | Middleware V2     | Polkadot.js |
+| ----------- | -------- | -------- | ----------------- | ----------- |
+| v30.1.0     | ✅       | ✅       | ≥ v19.6.0-alpha.2 | 16.5.2      |
+| v30.2.0     | ✅       | ✅       | ≥ v19.6.0-alpha.2 | 16.5.2      |


### PR DESCRIPTION
### Description

Finalizes the pending changelog ahead of the `v30.2.0` release:

- Extends `changelogs/v30.1.0-next.md` (previously covering only the Ledger-signer and POLYX-balance fixes) to also document:
  - `registerDid` — registrar-gated DID registration (v8 only)
  - Portfolio-level asset pre-approval (`preApproveAsset` / `removeAssetPreApproval` / `isAssetPreApproved`)
  - `Portfolio.preApprovedAssets` getter
  - `Instruction.getLegStatus` / `Venue.getSignerCount`
  - `unlockInstructionForExecution` (`Instruction.unlockForExecution` + `getRelockStatus`)
  - Live ticker-length validation against chain `TickerConfig`
  - `BaseAsset.getIssuedInFundingRound`
  - `Assets.getTickerRegistrationConfig`
  - The previously undocumented v8 off-chain settlement receipt expiry/encoding fix
- Renames the file to `changelogs/v30.1.0-v30.2.0.md` and rewrites the frontmatter/intro/overview from "unreleased/pending" to released-changelog language, matching the existing `v30.0.0-v30.1.0.md` format, and adds the `v30.2.0` row to the version compatibility matrix.

`v30.2.0` is inferred from semantic-release's own commit-analyzer output — `develop`'s tip is currently tagged `v30.2.0-beta.5` (minor bump: several `feat:` commits since `v30.1.0`, no breaking changes). If additional commits land on `develop` before this merges to `master`, the version number in this file should be re-checked against the actual release tag before publishing.

Docs-only change, no code touched.

### Breaking Changes

None.

### JIRA Link

<!-- insert ticket -->

### Checklist

- [x] Updated the Readme.md (if required) — N/A, changelog only