### PR TITLE
Release v8 new features and fixes to master

### DIFF
--- a/changelogs/v30.0.0-v30.1.0.md
+++ b/changelogs/v30.0.0-v30.1.0.md
@@ -1,0 +1,81 @@
+---
+title: SDK Changelog - v30.0.0 to v30.1.0
+description: Changes between Polymesh SDK v30.0.0 and v30.1.0. Includes bug fixes and dependency updates.
+sidebar_label: v30.0.0 → v30.1.0
+id: v30-to-v30-1
+tags:
+  - changelog
+  - sdk
+---
+
+This guide describes changes between **v30.0.0** and **v30.1.0** of `@polymeshassociation/polymesh-sdk`.
+
+---
+
+## Overview
+
+v30.1.0 is a **minor release** containing bug fixes and a dependency update. There are **no breaking changes** — upgrading is a drop-in replacement for v30.0.0.
+
+---
+
+## Dependency updates
+
+| Package                               | v30.0.0 | v30.1.0    |
+| ------------------------------------- | ------- | ---------- |
+| `@polymeshassociation/polymesh-types` | ^7.4.0  | **^7.5.0** |
+
+---
+
+## Bug fixes
+
+### Asset transaction history pagination
+
+`assetTransactionQuery` (used by `getTransactionHistory()` on assets) was missing its pagination parameters, so `size` and `start` were ignored and the full result set was always requested from middleware. Pagination now works as documented:
+
+```typescript
+const { data, next } = await asset.getTransactionHistory({
+  size: new BigNumber(25),
+  start: new BigNumber(0),
+});
+```
+
+---
+
+### Transaction status change events
+
+`onStatusChange` listeners were only notified for the `Unapproved`, `Running`, and terminal statuses — the intermediate `Future` and `InBlock` statuses introduced in v30.0.0 (and `Idle`) were skipped. All status transitions now emit a `StatusChange` event, so progress monitoring like the following works as expected:
+
+```typescript
+tx.onStatusChange(transaction => {
+  if (transaction.status === TransactionStatus.InBlock) {
+    console.log('Transaction included in block, awaiting finalization');
+  }
+});
+```
+
+---
+
+### WebSocket selection in Cloudflare Workers
+
+Environments that expose both a native `WebSocket` and Node.js compatibility flags (e.g. Cloudflare Workers with `nodejs_compat`) caused the SDK's chain version check to import the Node `ws` package and fail with `ws does not work in the browser`. The SDK now prefers the native `WebSocket` whenever it exists and only falls back to `ws` when it does not.
+
+---
+
+### `Account.getTypeInfo()` smart contract check removed
+
+`Account.getTypeInfo()` no longer queries the `contracts` pallet, which is not part of the Polymesh runtime. The method will no longer return `AccountKeyType.SmartContract` (the enum value remains for compatibility but is never returned).
+
+---
+
+### Documentation build
+
+`rimraf` was added as a dev dependency so the docs build works from a clean checkout (internal tooling fix, no runtime impact).
+
+---
+
+## Version compatibility matrix
+
+| SDK version | Chain v7 | Chain v8 | Middleware V2     | Polkadot.js |
+| ----------- | -------- | -------- | ----------------- | ----------- |
+| v30.0.0     | ✅       | ✅       | ≥ v19.6.0-alpha.2 | 16.5.2      |
+| v30.1.0     | ✅       | ✅       | ≥ v19.6.0-alpha.2 | 16.5.2      |

--- a/changelogs/v30.1.0-next.md
+++ b/changelogs/v30.1.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v30.1.0 to next release
-description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes Ledger signing support fixes and corrected POLYX balance calculations for chain v8.
+description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes registrar-gated DID registration, portfolio-level asset pre-approval, new settlement/asset getters, Ledger signing fixes, and corrected POLYX balance/off-chain receipt handling for chain v8.
 sidebar_label: v30.1.0 → next
 id: v30-1-to-next
 tags:
@@ -14,11 +14,73 @@ This guide describes **unreleased** changes since **v30.1.0** of `@polymeshassoc
 
 ## Overview
 
-This release fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app, and corrects the **POLYX balance calculation** for chain v8 accounts with staked (held) funds. No code changes are required in consuming applications, though note the clarified meaning of `locked` in `AccountBalance` described below.
+This release adds registrar-gated DID registration, portfolio-level asset pre-approval, and several new settlement/asset getters. It also fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app, corrects the **POLYX balance calculation** for chain v8 accounts with staked (held) funds, and fixes **v8 off-chain settlement receipt** expiry propagation and encoding. No code changes are required in consuming applications, though note the clarified meaning of `locked` in `AccountBalance` described below.
+
+---
+
+## New features
+
+### `registerDid` — registrar-gated DID registration (v8 only)
+
+Implements the v8-only `identity.registerDid` extrinsic, letting an active DID Registrar register a DID for someone else's Account:
+
+```typescript
+const identity = await sdk.identities.registerDid({ targetAccount: '5G...' });
+```
+
+This complements the existing permissionless `Identities.selfRegisterDid` and the deprecated `registerIdentity` (`cddRegisterDid`), which no longer attaches a CDD claim as of v8. Calling this on a v7 chain, or targeting an Account that already has an Identity, raises a `PolymeshError`.
+
+### Portfolio-level asset pre-approval
+
+A Portfolio can now pre-approve receiving a specific asset, so incoming transfers of it auto-affirm without a manual affirm step — the portfolio-level counterpart to the existing Identity-level pre-approval:
+
+```typescript
+await portfolio.preApproveAsset({ asset });
+await portfolio.isAssetPreApproved(asset); // true
+await portfolio.removeAssetPreApproval({ asset });
+```
+
+### `Portfolio.preApprovedAssets` getter
+
+Lists all assets a Portfolio has pre-approved, paginated over the `preApprovedPortfolios` storage entries, mirroring `Identity.preApprovedAssets`.
+
+### Settlement getters: leg status and venue signer count
+
+- `Instruction.getLegStatus({ legId })` — returns the execution status of a specific leg in an Instruction.
+- `Venue.getSignerCount()` — returns the number of signers allowed by a Venue.
+
+### `unlockInstructionForExecution` — complete the lock/relock cycle
+
+`Instruction.unlockForExecution()` moves a `LockedForExecution` instruction back to `Pending`, and `Instruction.getRelockStatus()` exposes the mediator's last unlock timestamp, relock count, max relock count, and the on-chain relock cooldown window — completing the lock/relock flow that `lockForExecution` alone couldn't finish.
+
+### Ticker length validated against live chain config
+
+`reserveTicker`, `createAsset`, and `createNftCollection` now validate the ticker length against the chain's live `TickerConfig.maxTickerLength` instead of a hardcoded constant, so the SDK stays correct if the chain's configured max length changes.
+
+### `BaseAsset.getIssuedInFundingRound`
+
+Returns the total amount of an Asset issued in a given funding round:
+
+```typescript
+const issued = await asset.getIssuedInFundingRound('Series A');
+```
+
+### `Assets.getTickerRegistrationConfig`
+
+Returns the chain-wide rules used to validate ticker registrations — `maxTickerLength` and `registrationLength` (`null` if registrations don't expire).
 
 ---
 
 ## Bug fixes
+
+### Correct v8 off-chain settlement receipt expiry and encoding
+
+- `expiresAt` was computed and signed into the off-chain receipt payload but dropped before reaching `affirmWithReceipts`/`affirmWithReceiptsWithCount` — it's now forwarded into both the returned `OffChainAffirmationReceipt` and the raw on-chain receipt details.
+- The v8 signed payload now includes the chain's `genesis_hash` and length-prefixes the receipt label, matching the runtime's `ChainScopedMessage` encoding.
+- Fixed the byte order of the signed `expiresAt` value (it was missing the little-endian flag).
+- `signatureToMeshRuntimeMultiSignature` now uses correctly sized `[u8; 64]`/`[u8; 65]` byte arrays instead of a bare `U8aFixed`, which failed to resolve against a v8 chain's metadata registry.
+
+No action is needed from consumers — off-chain receipt affirmation on v8 chains simply works correctly now.
 
 ### Support signers that return a signed transaction (Ledger generic app)
 

--- a/changelogs/v30.1.0-next.md
+++ b/changelogs/v30.1.0-next.md
@@ -1,0 +1,41 @@
+---
+title: SDK Changelog - v30.1.0 to next release
+description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes Ledger signing support fixes.
+sidebar_label: v30.1.0 → next
+id: v30-1-to-next
+tags:
+  - changelog
+  - sdk
+---
+
+This guide describes **unreleased** changes since **v30.1.0** of `@polymeshassociation/polymesh-sdk`. These will be included in the next release.
+
+---
+
+## Overview
+
+This release fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app. There are **no breaking changes** and no code changes are required in consuming applications.
+
+---
+
+## Bug fixes
+
+### Support signers that return a signed transaction (Ledger generic app)
+
+Signing any transaction with a Ledger device via the Polkadot Generic Ledger app failed with:
+
+```
+The `signedTransaction` field may not be submitted when `withSignedTransaction` is disabled
+```
+
+The generic Ledger app requires the `CheckMetadataHash` signed extension, which means the wallet must rebuild the transaction (setting `mode` and `metadataHash`) before the device will sign it. The wallet then returns the rebuilt extrinsic in `SignerResult.signedTransaction`, which the Polkadot API rejects unless the caller opts in.
+
+The SDK now passes `withSignedTransaction: true` when signing, so signers that return a rebuilt `signedTransaction` are accepted and the rebuilt extrinsic is what gets submitted to the chain.
+
+**Details:**
+
+- **No impact on other signers** — software wallets and local keypairs return only a signature and behave exactly as before; the option merely permits the `signedTransaction` field, it does not request it.
+- **Call data is protected** — the SDK also sets `allowCallDataAlteration: false`, so a returned `signedTransaction` may only alter signed extensions (e.g. `mode`, `metadataHash`, era, nonce, tip). Any submission where the signer changed the transaction call itself is rejected with an error.
+- **Correct hash tracking** — because a rebuilt extrinsic can have a different hash than the one the SDK composed, the SDK now tracks the hash of the transaction actually submitted to the node. `txHash` on the transaction object always reflects the on-chain extrinsic.
+
+No migration steps are needed — transactions signed with Ledger devices simply work.

--- a/changelogs/v30.1.0-next.md
+++ b/changelogs/v30.1.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v30.1.0 to next release
-description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes Ledger signing support fixes.
+description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes Ledger signing support fixes and corrected POLYX balance calculations for chain v8.
 sidebar_label: v30.1.0 → next
 id: v30-1-to-next
 tags:
@@ -14,7 +14,7 @@ This guide describes **unreleased** changes since **v30.1.0** of `@polymeshassoc
 
 ## Overview
 
-This release fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app. There are **no breaking changes** and no code changes are required in consuming applications.
+This release fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app, and corrects the **POLYX balance calculation** for chain v8 accounts with staked (held) funds. No code changes are required in consuming applications, though note the clarified meaning of `locked` in `AccountBalance` described below.
 
 ---
 
@@ -39,3 +39,28 @@ The SDK now passes `withSignedTransaction: true` when signing, so signers that r
 - **Correct hash tracking** — because a rebuilt extrinsic can have a different hash than the one the SDK composed, the SDK now tracks the hash of the transaction actually submitted to the node. `txHash` on the transaction object always reflects the on-chain extrinsic.
 
 No migration steps are needed — transactions signed with Ledger devices simply work.
+
+### Correct POLYX balance calculation for chain v8 accounts with holds
+
+On chain v8, funds bonded for staking moved from locks on the `free` balance to **holds** tracked in `reserved`, and the single `frozen` value can legitimately exceed `free` (frozen funds may overlap with held funds). The SDK still calculated the spendable balance with the pre-v8 formula `free - frozen`, which produced **negative free balances** for staking accounts .
+
+`Account.getBalance` (and `accountBalance` internally) now follows the chain's rules:
+
+```bash
+free = chain free - max(frozen - reserved, existential deposit)
+```
+
+clamped at zero, with the existential deposit (`0.000001 POLYX`) read from the chain rather than hardcoded.
+
+**Field semantics (clarified):**
+
+- `free` — balance **guaranteed to be spendable** on transfers and fees. The existential deposit is always excluded, so a transaction paying up to `free` will never fail for balance reasons.
+- `locked` — everything unavailable: funds on hold (e.g. bonded for staking), frozen funds not covered by holds (e.g. vesting) and the existential deposit. Always equal to `total - free`. **Note:** previously this only reflected the chain's `frozen` value; it now also includes `reserved` funds, so staking accounts will report a larger `locked` value than before — this is the correct interpretation under v8 semantics.
+- `total` — all funds owned by the Account: `free + locked` (the chain's `free + reserved`).
+
+**New fields** on `AccountBalance` expose the underlying chain values for applications that want to present more detail:
+
+- `reserved` — funds placed on hold by the protocol (e.g. POLYX bonded for staking), released when e.g. unbonded and withdrawn.
+- `frozen` — the minimum balance (out of `total`) that must remain in the Account due to freezes/locks (e.g. vesting). May overlap with `reserved`: vested POLYX that is also bonded counts towards both. On v7 chains this is `max(miscFrozen, feeFrozen)`.
+
+These additions are backwards compatible for code that reads balances. Validations that consume `free` (`transferPolyx`, `bondPolyx`, transaction fee checks) now use the corrected value, so they no longer reject valid transactions for staking-heavy accounts.

--- a/changelogs/v30.1.0-v30.2.0.md
+++ b/changelogs/v30.1.0-v30.2.0.md
@@ -1,18 +1,20 @@
 ---
-title: SDK Changelog - v30.1.0 to next release
-description: Pending changes since Polymesh SDK v30.1.0, to be included in the next release. Includes registrar-gated DID registration, portfolio-level asset pre-approval, new settlement/asset getters, Ledger signing fixes, and corrected POLYX balance/off-chain receipt handling for chain v8.
-sidebar_label: v30.1.0 → next
-id: v30-1-to-next
+title: SDK Changelog - v30.1.0 to v30.2.0
+description: Changes between Polymesh SDK v30.1.0 and v30.2.0. Includes registrar-gated DID registration, portfolio-level asset pre-approval, new settlement/asset getters, Ledger signing fixes, and corrected POLYX balance/off-chain receipt handling for chain v8.
+sidebar_label: v30.1.0 → v30.2.0
+id: v30-1-to-v30-2
 tags:
   - changelog
   - sdk
 ---
 
-This guide describes **unreleased** changes since **v30.1.0** of `@polymeshassociation/polymesh-sdk`. These will be included in the next release.
+This guide describes changes between **v30.1.0** and **v30.2.0** of `@polymeshassociation/polymesh-sdk`.
 
 ---
 
 ## Overview
+
+v30.2.0 is a **minor release** containing new features and bug fixes. There are **no breaking changes** — upgrading is a drop-in replacement for v30.1.0.
 
 This release adds registrar-gated DID registration, portfolio-level asset pre-approval, and several new settlement/asset getters. It also fixes transaction signing with **Ledger hardware wallets** using the Polkadot Generic Ledger app, corrects the **POLYX balance calculation** for chain v8 accounts with staked (held) funds, and fixes **v8 off-chain settlement receipt** expiry propagation and encoding. No code changes are required in consuming applications, though note the clarified meaning of `locked` in `AccountBalance` described below.
 
@@ -126,3 +128,12 @@ clamped at zero, with the existential deposit (`0.000001 POLYX`) read from the c
 - `frozen` — the minimum balance (out of `total`) that must remain in the Account due to freezes/locks (e.g. vesting). May overlap with `reserved`: vested POLYX that is also bonded counts towards both. On v7 chains this is `max(miscFrozen, feeFrozen)`.
 
 These additions are backwards compatible for code that reads balances. Validations that consume `free` (`transferPolyx`, `bondPolyx`, transaction fee checks) now use the corrected value, so they no longer reject valid transactions for staking-heavy accounts.
+
+---
+
+## Version compatibility matrix
+
+| SDK version | Chain v7 | Chain v8 | Middleware V2     | Polkadot.js |
+| ----------- | -------- | -------- | ----------------- | ----------- |
+| v30.1.0     | ✅       | ✅       | ≥ v19.6.0-alpha.2 | 16.5.2      |
+| v30.2.0     | ✅       | ✅       | ≥ v19.6.0-alpha.2 | 16.5.2      |

--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -26,6 +26,7 @@ import {
   ReserveTickerParams,
   ResultSet,
   SubCallback,
+  TickerRegistrationConfig,
   TickerReservationStatus,
   TransferFundsParams,
   UnsubCallback,
@@ -36,6 +37,7 @@ import {
   meshMetadataSpecToMetadataSpec,
   stringToIdentityId,
   tickerToString,
+  u8ToBigNumber,
   u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -525,4 +527,28 @@ export class Assets {
    * @note To transfer between asset holders owned by separate DID use settlement instructions
    */
   public transferFunds: ProcedureMethod<TransferFundsParams, void>;
+
+  /**
+   * Gets the chain-wide rules used to validate ticker registrations
+   */
+  public async getTickerRegistrationConfig(): Promise<TickerRegistrationConfig> {
+    const {
+      context: {
+        polymeshApi: {
+          query: {
+            asset: { tickerConfig },
+          },
+        },
+      },
+    } = this;
+
+    const { maxTickerLength, registrationLength } = await tickerConfig();
+
+    return {
+      maxTickerLength: u8ToBigNumber(maxTickerLength),
+      registrationLength: registrationLength.isSome
+        ? u64ToBigNumber(registrationLength.unwrap())
+        : null,
+    };
+  }
 }

--- a/src/api/client/Identities.ts
+++ b/src/api/client/Identities.ts
@@ -10,6 +10,7 @@ import {
   createPortfolios,
   Identity,
   NumberedPortfolio,
+  registerDid,
   registerIdentity,
   revokeIdentityToCreatePortfolios,
   rotatePrimaryKey,
@@ -23,6 +24,7 @@ import {
   CreateChildIdentityParams,
   NoArgsProcedureMethod,
   ProcedureMethod,
+  RegisterDidParams,
   RegisterIdentityParams,
   RevokeIdentityToCreatePortfoliosParams,
   RotatePrimaryKeyParams,
@@ -50,6 +52,11 @@ export class Identities {
 
     this.selfRegisterDid = createProcedureMethod(
       { getProcedureAndArgs: () => [selfRegisterDid, undefined], voidArgs: true },
+      context
+    );
+
+    this.registerDid = createProcedureMethod(
+      { getProcedureAndArgs: args => [registerDid, args] },
       context
     );
 
@@ -140,6 +147,16 @@ export class Identities {
    * @throws if the signing Account is already linked to an Identity
    */
   public selfRegisterDid: NoArgsProcedureMethod<Identity>;
+
+  /**
+   * Register a new DID for the `targetAccount`
+   *
+   * @note the transaction signer must be an active DID Registrar
+   * @note unlike {@link registerIdentity}, this does not support secondary keys or CDD claims
+   *
+   * @throws if the `targetAccount` is already linked to an Identity
+   */
+  public registerDid: ProcedureMethod<RegisterDidParams, Identity>;
 
   /**
    * Get CDD Provider's attestation to change primary key

--- a/src/api/client/__tests__/Assets.ts
+++ b/src/api/client/__tests__/Assets.ts
@@ -723,6 +723,42 @@ describe('Assets Class', () => {
     });
   });
 
+  describe('method: getTickerRegistrationConfig', () => {
+    it('should return the chain-wide ticker registration rules', async () => {
+      const maxTickerLength = new BigNumber(12);
+      const registrationLength = new BigNumber(60 * 24 * 60 * 60 * 1000);
+
+      dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+        returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+          maxTickerLength: dsMockUtils.createMockU8(maxTickerLength),
+          registrationLength: dsMockUtils.createMockOption(
+            dsMockUtils.createMockU64(registrationLength)
+          ),
+        }),
+      });
+
+      const result = await assets.getTickerRegistrationConfig();
+
+      expect(result).toEqual({
+        maxTickerLength,
+        registrationLength,
+      });
+    });
+
+    it('should return a null registration length if tickers never expire', async () => {
+      dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+        returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+          maxTickerLength: dsMockUtils.createMockU8(new BigNumber(12)),
+          registrationLength: dsMockUtils.createMockOption(),
+        }),
+      });
+
+      const result = await assets.getTickerRegistrationConfig();
+
+      expect(result.registrationLength).toBeNull();
+    });
+  });
+
   describe('method: transferFunds', () => {
     it('should prepare the procedure and return the resulting transaction', async () => {
       const args = {

--- a/src/api/client/__tests__/Identities.ts
+++ b/src/api/client/__tests__/Identities.ts
@@ -139,6 +139,24 @@ describe('Identities Class', () => {
     });
   });
 
+  describe('method: registerDid', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const args = {
+        targetAccount: 'someTarget',
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Identity>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, context, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await identities.registerDid(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
   describe('method: selfRegisterDid', () => {
     it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
       const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Identity>;

--- a/src/api/client/__tests__/Network.ts
+++ b/src/api/client/__tests__/Network.ts
@@ -151,6 +151,8 @@ describe('Network Class', () => {
         free: new BigNumber(500000),
         locked: new BigNumber(0),
         total: new BigNumber(500000),
+        reserved: new BigNumber(0),
+        frozen: new BigNumber(0),
       };
       entityMockUtils.configureMocks({ accountOptions: { getBalance: fakeBalance } });
     });

--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -20,7 +20,6 @@ import {
 import { Mocked } from '~/testUtils/types';
 import {
   AccountBalance,
-  Balance,
   ErrorCode,
   ModuleName,
   MultiSigTx,
@@ -113,6 +112,8 @@ describe('Account class', () => {
         free: new BigNumber(100),
         locked: new BigNumber(10),
         total: new BigNumber(110),
+        reserved: new BigNumber(0),
+        frozen: new BigNumber(0),
       };
     });
 
@@ -132,7 +133,7 @@ describe('Account class', () => {
       const callback = jest.fn();
 
       context.accountBalance = jest.fn();
-      context.accountBalance.mockImplementation((_, cbFunc: (balance: Balance) => void) => {
+      context.accountBalance.mockImplementation((_, cbFunc: (balance: AccountBalance) => void) => {
         cbFunc(fakeResult);
         return unsubCallback;
       });

--- a/src/api/entities/Account/types.ts
+++ b/src/api/entities/Account/types.ts
@@ -6,11 +6,11 @@ import { EventIdentifier } from '~/types';
 
 export interface Balance {
   /**
-   * balance available for transferring and paying fees
+   * balance available for transferring
    */
   free: BigNumber;
   /**
-   * unavailable balance, either bonded for staking or locked for some other purpose
+   * unavailable balance, locked for some purpose (e.g. pending settlement instructions)
    */
   locked: BigNumber;
   /**
@@ -19,7 +19,44 @@ export interface Balance {
   total: BigNumber;
 }
 
-export type AccountBalance = Balance;
+/**
+ * POLYX balance of an Account
+ */
+export interface AccountBalance {
+  /**
+   * balance that is guaranteed to be spendable on transfers and transaction fees. Calculated according
+   *   to the chain's rules as `chain free - max(frozen - reserved, existential deposit)`
+   *
+   * @note this differs from the chain's raw `free` value, which still includes frozen funds. The
+   *   existential deposit (0.000001 POLYX) is always treated as unspendable, so this value is a
+   *   lower bound on what the Account can spend without risk of the transaction failing
+   */
+  free: BigNumber;
+  /**
+   * balance that is unavailable for spending. Made up of funds on hold (`reserved`, e.g. bonded for
+   *   staking), frozen funds not covered by holds (`frozen`) and the existential
+   *   deposit. Always equal to `total - free`
+   */
+  locked: BigNumber;
+  /**
+   * total balance owned by the Account, including unavailable funds. Equal to the chain's
+   *   `free + reserved`, and to `free + locked` as returned here
+   */
+  total: BigNumber;
+  /**
+   * balance placed on hold by the protocol, e.g. POLYX bonded for staking. Held funds are not part
+   *   of the chain's `free` balance and cannot be spent until released (e.g. unbonded and withdrawn).
+   *   Corresponds to the chain's raw `reserved` value
+   */
+  reserved: BigNumber;
+  /**
+   * minimum balance (out of `total`) that must remain in the Account due to freezes/locks.
+   *   Frozen funds may overlap with `reserved` funds. Corresponds to the chain's raw `frozen` value
+   *
+   * @note on v7 chains this is the maximum of the chain's `miscFrozen` and `feeFrozen` values
+   */
+  frozen: BigNumber;
+}
 
 /**
  * Distinguishes MultiSig and Smart Contract accounts

--- a/src/api/entities/Asset/Base/BaseAsset.ts
+++ b/src/api/entities/Asset/Base/BaseAsset.ts
@@ -54,6 +54,7 @@ import {
   bigNumberToU32,
   boolToBoolean,
   bytesToString,
+  fundingRoundToAssetFundingRound,
   identitiesSetToIdentities,
   identityIdToString,
   tickerToString,
@@ -535,6 +536,29 @@ export class BaseAsset extends Entity<UniqueIdentifiers, string> {
 
     const fundingRound = await asset.fundingRound(rawAssetId);
     return assembleResult(fundingRound);
+  }
+
+  /**
+   * Retrieve the total amount of the Asset issued in the given funding round
+   *
+   * @param fundingRound - name of the funding round to query
+   */
+  public async getIssuedInFundingRound(fundingRound: string): Promise<BigNumber> {
+    const {
+      context,
+      context: {
+        polymeshApi: {
+          query: { asset },
+        },
+      },
+    } = this;
+
+    const rawAssetId = assetToMeshAssetId(this, context);
+    const rawFundingRound = fundingRoundToAssetFundingRound(fundingRound, context);
+
+    const issued = await asset.issuedInFundingRound([rawAssetId, rawFundingRound]);
+
+    return balanceToBigNumber(issued);
   }
 
   /**

--- a/src/api/entities/Asset/__tests__/Fungible/index.ts
+++ b/src/api/entities/Asset/__tests__/Fungible/index.ts
@@ -398,6 +398,30 @@ describe('Fungible class', () => {
     });
   });
 
+  describe('method: getIssuedInFundingRound', () => {
+    it('should return the amount of the Asset issued in the given funding round', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const fundingRound = 'Series A';
+      const issuedAmount = new BigNumber(1000);
+
+      const context = dsMockUtils.getContextInstance();
+      const asset = new FungibleAsset({ assetId }, context);
+
+      const rawFundingRound = dsMockUtils.createMockBytes(fundingRound);
+      when(jest.spyOn(utilsConversionModule, 'fundingRoundToAssetFundingRound'))
+        .calledWith(fundingRound, context)
+        .mockReturnValue(rawFundingRound);
+
+      dsMockUtils.createQueryMock('asset', 'issuedInFundingRound', {
+        returnValue: dsMockUtils.createMockBalance(issuedAmount.shiftedBy(6)),
+      });
+
+      const result = await asset.getIssuedInFundingRound(fundingRound);
+
+      expect(result).toEqual(issuedAmount);
+    });
+  });
+
   describe('method: getIdentifiers', () => {
     let assetId: string;
     let isinValue: string;

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -262,6 +262,17 @@ export interface VenueFilteringDetails {
   allowedVenues: Venue[];
 }
 
+export interface TickerRegistrationConfig {
+  /**
+   * maximum allowed length for a ticker
+   */
+  maxTickerLength: BigNumber;
+  /**
+   * amount of time (in milliseconds) a ticker reservation is valid for before it expires, starting from the moment it is reserved. A null value means ticker reservations never expire
+   */
+  registrationLength: BigNumber | null;
+}
+
 /**
  * A metadata entry for which each NFT in the collection must have an entry for
  *

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -45,6 +45,7 @@ import {
   InstructionAffirmationOperation,
   InstructionStatus,
   InstructionType,
+  LegStatusType,
   NftLeg,
   OffChainLeg,
   SignerKeyRingType,
@@ -53,6 +54,7 @@ import {
 import { InstructionStatus as InternalInstructionStatus } from '~/types/internal';
 import { tuple } from '~/types/utils';
 import { hexToUuid } from '~/utils';
+import { DUMMY_ACCOUNT_ID } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as utilsInternalModule from '~/utils/internal';
 
@@ -2750,6 +2752,40 @@ describe('Instruction class', () => {
 
         expect(result).toEqual(AffirmationStatus.Pending);
       });
+    });
+  });
+
+  describe('method: getLegStatus', () => {
+    const legId = new BigNumber(2);
+
+    it('should return the execution status for a specific leg', async () => {
+      dsMockUtils.createQueryMock('settlement', 'instructionLegStatus', {
+        returnValue: dsMockUtils.createMockLegStatus('ExecutionPending'),
+      });
+
+      const result = await instruction.getLegStatus({ legId });
+
+      expect(result).toEqual({ type: LegStatusType.ExecutionPending });
+    });
+
+    it('should return the receipt details when the leg execution is to be skipped', async () => {
+      const address = DUMMY_ACCOUNT_ID;
+      const uid = new BigNumber(10);
+
+      dsMockUtils.createQueryMock('settlement', 'instructionLegStatus', {
+        returnValue: dsMockUtils.createMockLegStatus({
+          ExecutionToBeSkipped: [
+            dsMockUtils.createMockAccountId(address),
+            dsMockUtils.createMockU64(uid),
+          ],
+        }),
+      });
+
+      const result = await instruction.getLegStatus({ legId });
+
+      expect(result).toEqual(
+        expect.objectContaining({ type: LegStatusType.ExecutionToBeSkipped, uid })
+      );
     });
   });
 

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -303,6 +303,73 @@ describe('Instruction class', () => {
     });
   });
 
+  describe('method: getRelockStatus', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    let bigNumberToU64Spy: jest.SpyInstance;
+    const unlockedTime = new Date('2025-07-01');
+    const relockCooldown = new BigNumber(86400000);
+    const maxRelockCount = new BigNumber(3);
+    const relockCount = new BigNumber(1);
+
+    beforeAll(() => {
+      bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+      dsMockUtils.createQueryMock('settlement', 'unlockedTimestamp');
+      dsMockUtils.createQueryMock('settlement', 'instructionRelockCount');
+    });
+
+    beforeEach(() => {
+      when(bigNumberToU64Spy).calledWith(id, context).mockReturnValue(rawId);
+
+      dsMockUtils.setConstMock('settlement', 'relockCooldown', {
+        returnValue: dsMockUtils.createMockU64(relockCooldown),
+      });
+      dsMockUtils.setConstMock('settlement', 'maxRelockCount', {
+        returnValue: dsMockUtils.createMockU32(maxRelockCount),
+      });
+    });
+
+    it('should return all the details for an instruction that has been unlocked', async () => {
+      dsMockUtils
+        .getQueryMultiMock()
+        .mockResolvedValue([
+          dsMockUtils.createMockOption(
+            dsMockUtils.createMockU64(new BigNumber(unlockedTime.getTime()))
+          ),
+          dsMockUtils.createMockU32(relockCount),
+        ]);
+
+      const result = await instruction.getRelockStatus();
+
+      expect(result).toEqual({
+        unlockedAt: unlockedTime,
+        relockCount,
+        maxRelockCount,
+        cooldownEndsAt: new Date(unlockedTime.getTime() + relockCooldown.toNumber()),
+      });
+    });
+
+    it('should return all the details for an instruction that has never been unlocked', async () => {
+      dsMockUtils
+        .getQueryMultiMock()
+        .mockResolvedValue([
+          dsMockUtils.createMockOption(),
+          dsMockUtils.createMockU32(new BigNumber(0)),
+        ]);
+
+      const result = await instruction.getRelockStatus();
+
+      expect(result).toEqual({
+        unlockedAt: null,
+        relockCount: new BigNumber(0),
+        maxRelockCount,
+        cooldownEndsAt: null,
+      });
+    });
+  });
+
   describe('method: onStatusChange', () => {
     let bigNumberToU64Spy: jest.SpyInstance;
     let instructionStatusesMock: jest.Mock;
@@ -1535,6 +1602,31 @@ describe('Instruction class', () => {
         .mockResolvedValue(expectedTransaction);
 
       const tx = await instruction.lockForExecution();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: unlockForExecution', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<Instruction>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          {
+            args: { id },
+            transformer: undefined,
+          },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await instruction.unlockForExecution();
 
       expect(tx).toBe(expectedTransaction);
     });

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -1,9 +1,10 @@
-import { Option, StorageKey, u64 } from '@polkadot/types';
+import { Bytes, Option, StorageKey, u64 } from '@polkadot/types';
 import {
   PolymeshPrimitivesIdentityIdPortfolioId,
   PolymeshPrimitivesSettlementInstructionStatus,
   PolymeshPrimitivesSettlementLeg,
 } from '@polkadot/types/lookup';
+import { stringToU8a, u8aConcat } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -2683,6 +2684,13 @@ describe('Instruction class', () => {
       jest
         .spyOn(utilsConversionModule, 'dateToMoment')
         .mockReturnValue(dsMockUtils.createMockMoment(new BigNumber(1000)));
+
+      const label = stringToU8a('Polymesh Settlement Receipt');
+      when(context.createType)
+        .calledWith('Bytes', 'Polymesh Settlement Receipt')
+        .mockReturnValue({
+          toU8a: () => u8aConcat(new Uint8Array([label.length << 2]), label),
+        } as unknown as Bytes);
     });
 
     it('should throw an error for an invalid leg ID', () => {
@@ -2761,10 +2769,12 @@ describe('Instruction class', () => {
         ),
       });
 
+      const expiresAt = new Date();
+
       let result = await instruction.generateOffChainAffirmationReceipt({
         legId,
         uid,
-        expiresAt: new Date(),
+        expiresAt,
       });
 
       expect(result).toEqual({
@@ -2778,10 +2788,12 @@ describe('Instruction class', () => {
           value: '0xsignature',
         },
         metadata: undefined,
+        expiresAt,
       });
 
       const signer = 'someSigner';
       const metadata = 'some metadata';
+      const otherExpiresAt = new Date();
 
       result = await instruction.generateOffChainAffirmationReceipt({
         legId,
@@ -2789,7 +2801,7 @@ describe('Instruction class', () => {
         signer,
         signerKeyRingType: SignerKeyRingType.Ed25519,
         metadata,
-        expiresAt: new Date(),
+        expiresAt: otherExpiresAt,
       });
 
       expect(result).toEqual({
@@ -2801,6 +2813,7 @@ describe('Instruction class', () => {
           value: '0xsignature',
         },
         metadata,
+        expiresAt: otherExpiresAt,
       });
 
       expect(context.getSignature).toHaveBeenCalledWith({

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -13,6 +13,7 @@ import {
   InstructionStatus,
   InstructionStatusResult,
   Leg,
+  LegStatus,
   MediatorAffirmation,
   OffChainAffirmation,
 } from '~/api/entities/Instruction/types';
@@ -82,6 +83,7 @@ import {
   meshAffirmationStatusToAffirmationStatus,
   meshAssetHolderToAssetHolder,
   meshInstructionStatusToInstructionStatus,
+  meshLegStatusToLegStatus,
   meshNftToNftId,
   meshSettlementTypeToEndCondition,
   middlewareAffirmStatusToAffirmationStatus,
@@ -1327,6 +1329,33 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
     const rawAffirmStatus = await settlement.offChainAffirmations(rawId, rawLegId);
 
     return meshAffirmationStatusToAffirmationStatus(rawAffirmStatus);
+  }
+
+  /**
+   * Returns the execution status of a specific leg in this Instruction
+   *
+   * @param args.legId index of the leg whose status is to be fetched
+   */
+  public async getLegStatus(args: { legId: BigNumber }): Promise<LegStatus> {
+    const {
+      id,
+      context,
+      context: {
+        polymeshApi: {
+          query: { settlement },
+        },
+      },
+    } = this;
+
+    const { legId } = args;
+
+    const rawId = bigNumberToU64(id, context);
+
+    const rawLegId = bigNumberToU64(legId, context);
+
+    const rawLegStatus = await settlement.instructionLegStatus(rawId, rawLegId);
+
+    return meshLegStatusToLegStatus(rawLegStatus, context);
   }
 
   /**

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -9,6 +9,7 @@ import {
   AffirmationStatus,
   InstructionAffirmation,
   InstructionDetails,
+  InstructionRelockStatus,
   InstructionStatus,
   InstructionStatusResult,
   Leg,
@@ -17,6 +18,7 @@ import {
 } from '~/api/entities/Instruction/types';
 import { executeManualInstruction } from '~/api/procedures/executeManualInstruction';
 import { lockInstructionForExecution } from '~/api/procedures/lockInstructionForExecution';
+import { unlockInstructionForExecution } from '~/api/procedures/unlockInstructionForExecution';
 import {
   Account,
   Context,
@@ -90,6 +92,7 @@ import {
   momentToDate,
   stringToBytes,
   tickerToString,
+  u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
 import {
@@ -221,6 +224,14 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       },
       context
     );
+
+    this.unlockForExecution = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [unlockInstructionForExecution, { id }],
+        voidArgs: true,
+      },
+      context
+    );
   }
 
   /**
@@ -344,6 +355,59 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       lockedAt: null,
       expiry: null,
       unlocksAt: null,
+    };
+  }
+
+  /**
+   * Retrieve the relock cooldown status of the Instruction
+   *
+   * @note After a mediator unlocks an Instruction, they must wait for the relock cooldown period to
+   *   end before locking it again. `maxRelockCount` limits the total number of times an Instruction can be relocked.
+   */
+  public async getRelockStatus(): Promise<InstructionRelockStatus> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { settlement },
+          consts: {
+            settlement: { relockCooldown, maxRelockCount },
+          },
+        },
+      },
+      id,
+      context,
+    } = this;
+
+    const rawId = bigNumberToU64(id, context);
+
+    const [rawUnlockedTimestamp, rawRelockCount] = await requestMulti<
+      [typeof settlement.unlockedTimestamp, typeof settlement.instructionRelockCount]
+    >(context, [
+      [settlement.unlockedTimestamp, rawId],
+      [settlement.instructionRelockCount, rawId],
+    ]);
+
+    const relockCount = u32ToBigNumber(rawRelockCount);
+    const maxRelockCountValue = u32ToBigNumber(maxRelockCount);
+
+    if (rawUnlockedTimestamp.isSome) {
+      const unlockedAt = momentToDate(rawUnlockedTimestamp.unwrap());
+      const cooldown = u64ToBigNumber(relockCooldown);
+      const cooldownEndsAt = new Date(unlockedAt.getTime() + cooldown.toNumber());
+
+      return {
+        unlockedAt,
+        relockCount,
+        maxRelockCount: maxRelockCountValue,
+        cooldownEndsAt,
+      };
+    }
+
+    return {
+      unlockedAt: null,
+      relockCount,
+      maxRelockCount: maxRelockCountValue,
+      cooldownEndsAt: null,
     };
   }
 
@@ -959,6 +1023,13 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
    * @throws if any of the above conditions are not met
    */
   public lockForExecution: NoArgsProcedureMethod<Instruction>;
+
+  /**
+   * Unlocks an Instruction that is currently `LockedForExecution`, moving it back to `Pending`. Only a mediator of the instruction can unlock it.
+   *
+   * @note After unlocking, the mediator must wait for the relock cooldown period (see {@link getRelockStatus}) before locking the instruction again. This gives other parties time to reject the instruction if they wish to back out.
+   */
+  public unlockForExecution: NoArgsProcedureMethod<Instruction>;
 
   /**
    * @hidden

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -2,7 +2,7 @@ import {
   PolymeshPrimitivesSettlementInstructionStatus,
   PolymeshPrimitivesSettlementLeg,
 } from '@polkadot/types/lookup';
-import { hexAddPrefix, hexStripPrefix, stringToHex } from '@polkadot/util';
+import { hexAddPrefix, hexStripPrefix, stringToHex, u8aToHex } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 
 import {
@@ -88,6 +88,7 @@ import {
   middlewareInstructionToInstructionEndCondition,
   middlewareLegToLeg,
   momentToDate,
+  stringToBytes,
   tickerToString,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -1362,9 +1363,13 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
     } else {
       payloadStrings = [
         stringToHex('<Bytes>'),
+        context.polymeshApi.genesisHash.toHex(),
         rawUid.toHex(true),
-        stringToHex('Polymesh Settlement Receipt'),
-        dateToMoment(expiresAt!, context).toHex(),
+        // the chain encodes the label as a SCALE `&[u8]`, which is length
+        // prefixed - `Bytes.toHex()` strips that prefix, so `toU8a()` (the
+        // full wire encoding) has to be used instead
+        u8aToHex(stringToBytes('Polymesh Settlement Receipt', context).toU8a()),
+        dateToMoment(expiresAt!, context).toHex(true),
         rawId.toHex(true),
         rawLegId.toHex(true),
         senderIdentity.toHex(),
@@ -1391,6 +1396,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
         value: signatureValue,
       },
       metadata,
+      expiresAt,
     };
   }
 }

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -105,6 +105,25 @@ export enum ReceiverAffirmationRequirement {
   Required = 'Required',
 }
 
+export enum LegStatusType {
+  PendingTokenLock = 'PendingTokenLock',
+  ExecutionPending = 'ExecutionPending',
+  ExecutionToBeSkipped = 'ExecutionToBeSkipped',
+}
+
+export type LegStatus =
+  | {
+      type: LegStatusType.PendingTokenLock;
+    }
+  | {
+      type: LegStatusType.ExecutionPending;
+    }
+  | {
+      type: LegStatusType.ExecutionToBeSkipped;
+      signer: Account;
+      uid: BigNumber;
+    };
+
 export interface InstructionAffirmation {
   party: Identity | Account;
   status: AffirmationStatus;

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -168,6 +168,25 @@ export interface GroupedInvolvedInstructions {
   owned: Omit<GroupedInstructions, 'affirmed'>;
 }
 
+export interface InstructionRelockStatus {
+  /**
+   * The date and time when the instruction was last unlocked by a mediator, `null` if it has never been unlocked
+   */
+  unlockedAt: Date | null;
+  /**
+   * The number of times the instruction has been relocked
+   */
+  relockCount: BigNumber;
+  /**
+   * The maximum number of times the instruction can be relocked
+   */
+  maxRelockCount: BigNumber;
+  /**
+   * The date and time after which the instruction can be locked again, `null` if it has never been unlocked
+   */
+  cooldownEndsAt: Date | null;
+}
+
 export interface InstructionLockedInfo {
   /**
    * Whether the instruction is locked for execution

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -26,13 +26,21 @@ import {
   SettlementDirectionEnum,
 } from '~/types';
 import { tuple } from '~/types/utils';
-import { hexToUuid } from '~/utils';
+import { hexToUuid, uuidToHex } from '~/utils';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as utilsInternalModule from '~/utils/internal';
 
 jest.mock(
   '~/api/entities/Identity',
   require('~/testUtils/mocks/entities').mockIdentityModule('~/api/entities/Identity')
+);
+jest.mock(
+  '~/api/entities/Asset/Fungible',
+  require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+jest.mock(
+  '~/api/entities/Asset/NonFungible',
+  require('~/testUtils/mocks/entities').mockNftCollectionModule('~/api/entities/Asset/NonFungible')
 );
 jest.mock(
   '~/api/entities/NumberedPortfolio',
@@ -579,6 +587,45 @@ describe('Portfolio class', () => {
       const result = await portfolio.isAssetPreApproved(assetId);
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe('method: preApprovedAssets', () => {
+    let did: string;
+    let id: BigNumber;
+
+    beforeAll(() => {
+      did = 'someDid';
+      id = new BigNumber(1);
+      jest.spyOn(utilsConversionModule, 'portfolioIdToMeshPortfolioId').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return the list of pre-approved assets for the portfolio', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const rawAssetId = dsMockUtils.createMockAssetId(uuidToHex(assetId));
+      const rawPortfolioId = dsMockUtils.createMockPortfolioId({
+        did: dsMockUtils.createMockIdentityId(did),
+        kind: dsMockUtils.createMockPortfolioKind({
+          User: dsMockUtils.createMockU64(id),
+        }),
+      });
+
+      dsMockUtils.createQueryMock('portfolio', 'preApprovedPortfolios', {
+        entries: [tuple([rawPortfolioId, rawAssetId], dsMockUtils.createMockBool(true))],
+      });
+
+      const portfolio = new NonAbstract({ did, id }, context);
+
+      const result = await portfolio.preApprovedAssets();
+
+      expect(result).toEqual({
+        data: [expect.objectContaining({ id: assetId })],
+        next: null,
+      });
     });
   });
 

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -545,6 +545,43 @@ describe('Portfolio class', () => {
     });
   });
 
+  describe('method: isAssetPreApproved', () => {
+    let did: string;
+    let id: BigNumber;
+
+    beforeAll(() => {
+      did = 'someDid';
+      id = new BigNumber(1);
+      jest.spyOn(utilsConversionModule, 'portfolioIdToMeshPortfolioId').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return whether the asset is pre-approved or not', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const asset = entityMockUtils.getBaseAssetInstance({ assetId });
+      const rawAssetId = dsMockUtils.createMockAssetId(assetId);
+
+      jest.spyOn(utilsInternalModule, 'asBaseAsset').mockResolvedValue(asset);
+      const assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
+      when(assetToMeshAssetIdSpy)
+        .calledWith(expect.objectContaining({ id: assetId }), context)
+        .mockReturnValue(rawAssetId);
+
+      dsMockUtils
+        .createQueryMock('portfolio', 'preApprovedPortfolios')
+        .mockResolvedValue(dsMockUtils.createMockBool(true));
+
+      const portfolio = new NonAbstract({ did, id }, context);
+
+      const result = await portfolio.isAssetPreApproved(assetId);
+
+      expect(result).toBe(true);
+    });
+  });
+
   describe('method: moveFunds', () => {
     it('should prepare the procedure and return the resulting transaction', async () => {
       const args: MoveFundsParams = {
@@ -574,6 +611,46 @@ describe('Portfolio class', () => {
         .mockResolvedValue(expectedTransaction);
 
       const tx = await portfolio.quitCustody();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: preApproveAsset', () => {
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const portfolio = new NonAbstract({ did: 'someDid', id: new BigNumber(0) }, context);
+      const asset = entityMockUtils.getBaseAssetInstance({ assetId: 'SOME_ASSET' });
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          { args: { asset, portfolio, preApprove: true }, transformer: undefined },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await portfolio.preApproveAsset({ asset });
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: removeAssetPreApproval', () => {
+    it('should prepare the procedure and return the resulting transaction', async () => {
+      const portfolio = new NonAbstract({ did: 'someDid', id: new BigNumber(0) }, context);
+      const asset = entityMockUtils.getBaseAssetInstance({ assetId: 'SOME_ASSET' });
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          { args: { asset, portfolio, preApprove: false }, transformer: undefined },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await portfolio.removeAssetPreApproval({ asset });
 
       expect(tx).toBe(expectedTransaction);
     });

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -12,6 +12,7 @@ import {
   PortfolioCollection,
 } from '~/api/entities/Portfolio/types';
 import {
+  BaseAsset,
   Context,
   Entity,
   FungibleAsset,
@@ -21,6 +22,7 @@ import {
   NftCollection,
   PolymeshError,
   quitCustody,
+  togglePortfolioPreApproval,
 } from '~/internal';
 import { portfolioMovementsQuery } from '~/middleware/queries/portfolios';
 import { settlementsQuery } from '~/middleware/queries/settlements';
@@ -29,7 +31,9 @@ import { ErrorCode, MoveFundsParams, NoArgsProcedureMethod, ProcedureMethod } fr
 import { Ensured } from '~/types/utils';
 import {
   assetIdToString,
+  assetToMeshAssetId,
   balanceToBigNumber,
+  boolToBoolean,
   identityIdToString,
   portfolioIdToMeshPortfolioId,
   toHistoricalSettlements,
@@ -37,6 +41,7 @@ import {
 } from '~/utils/conversion';
 import {
   asAssetId,
+  asBaseAsset,
   asFungibleAsset,
   createProcedureMethod,
   getAssetIdForMiddleware,
@@ -99,6 +104,24 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
       { getProcedureAndArgs: () => [quitCustody, { portfolio: this }], voidArgs: true },
       context
     );
+    this.preApproveAsset = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [
+          togglePortfolioPreApproval,
+          { ...args, portfolio: this, preApprove: true },
+        ],
+      },
+      context
+    );
+    this.removeAssetPreApproval = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [
+          togglePortfolioPreApproval,
+          { ...args, portfolio: this, preApprove: false },
+        ],
+      },
+      context
+    );
   }
 
   /**
@@ -128,6 +151,31 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
     ]);
 
     return portfolioCustodian.isEqual(targetIdentity);
+  }
+
+  /**
+   * Returns whether or not this Portfolio has pre-approved a particular asset
+   */
+  public async isAssetPreApproved(asset: BaseAsset | string): Promise<boolean> {
+    const {
+      owner: { did },
+      _id: id,
+      context,
+      context: {
+        polymeshApi: {
+          query: { portfolio },
+        },
+      },
+    } = this;
+
+    const baseAsset = await asBaseAsset(asset, context);
+    const rawAssetId = assetToMeshAssetId(baseAsset, context);
+
+    const rawPortfolioId = portfolioIdToMeshPortfolioId({ did, number: id }, context);
+
+    const rawIsApproved = await portfolio.preApprovedPortfolios(rawPortfolioId, rawAssetId);
+
+    return boolToBoolean(rawIsApproved);
   }
 
   /**
@@ -319,6 +367,16 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
    *   - Portfolio Custodian
    */
   public quitCustody: NoArgsProcedureMethod<void>;
+
+  /**
+   * Pre-approves receiving an asset for this Portfolio. Receiving this asset in a settlement will not require manual affirmation
+   */
+  public preApproveAsset: ProcedureMethod<{ asset: BaseAsset | string }, void>;
+
+  /**
+   * Removes pre-approval of an asset for this Portfolio
+   */
+  public removeAssetPreApproval: ProcedureMethod<{ asset: BaseAsset | string }, void>;
 
   /**
    * Retrieve the custodian Identity of this Portfolio

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -27,7 +27,15 @@ import {
 import { portfolioMovementsQuery } from '~/middleware/queries/portfolios';
 import { settlementsQuery } from '~/middleware/queries/settlements';
 import { Query } from '~/middleware/types';
-import { ErrorCode, MoveFundsParams, NoArgsProcedureMethod, ProcedureMethod } from '~/types';
+import {
+  Asset,
+  ErrorCode,
+  MoveFundsParams,
+  NoArgsProcedureMethod,
+  PaginationOptions,
+  ProcedureMethod,
+  ResultSet,
+} from '~/types';
 import { Ensured } from '~/types/utils';
 import {
   assetIdToString,
@@ -40,12 +48,14 @@ import {
   u64ToBigNumber,
 } from '~/utils/conversion';
 import {
+  asAsset,
   asAssetId,
   asBaseAsset,
   asFungibleAsset,
   createProcedureMethod,
   getAssetIdForMiddleware,
   getIdentity,
+  requestPaginated,
   toHumanReadable,
 } from '~/utils/internal';
 
@@ -176,6 +186,42 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
     const rawIsApproved = await portfolio.preApprovedPortfolios(rawPortfolioId, rawAssetId);
 
     return boolToBoolean(rawIsApproved);
+  }
+
+  /**
+   * Returns a list of all assets this Portfolio has pre-approved. These assets will not require affirmation when being received in settlements
+   */
+  public async preApprovedAssets(paginationOpts?: PaginationOptions): Promise<ResultSet<Asset>> {
+    const {
+      owner: { did },
+      _id: id,
+      context,
+      context: {
+        polymeshApi: {
+          query: { portfolio },
+        },
+      },
+    } = this;
+
+    const rawPortfolioId = portfolioIdToMeshPortfolioId({ did, number: id }, context);
+
+    const { entries, lastKey: next } = await requestPaginated(portfolio.preApprovedPortfolios, {
+      arg: rawPortfolioId,
+      paginationOpts,
+    });
+
+    const data = await Promise.all(
+      entries.map(([storageKey]) => {
+        const {
+          args: [, rawAssetId],
+        } = storageKey;
+        const assetId = assetIdToString(rawAssetId);
+
+        return asAsset(assetId, context);
+      })
+    );
+
+    return { data, next };
   }
 
   /**

--- a/src/api/entities/Venue/__tests__/index.ts
+++ b/src/api/entities/Venue/__tests__/index.ts
@@ -409,6 +409,20 @@ describe('Venue class', () => {
     });
   });
 
+  describe('method: getSignerCount', () => {
+    it('should return the number of signers allowed by the Venue', async () => {
+      const count = new BigNumber(3);
+
+      dsMockUtils.createQueryMock('settlement', 'numberOfVenueSigners', {
+        returnValue: dsMockUtils.createMockU32(count),
+      });
+
+      const result = await venue.getSignerCount();
+
+      expect(result).toEqual(count);
+    });
+  });
+
   describe('method: addSigners', () => {
     afterAll(() => {
       jest.restoreAllMocks();

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -34,6 +34,7 @@ import {
   identityIdToString,
   meshVenueTypeToVenueType,
   middlewareInstructionToHistoricInstruction,
+  u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
 import { calculateNextKey, createProcedureMethod } from '~/utils/internal';
@@ -315,6 +316,25 @@ export class Venue extends Entity<UniqueIdentifiers, string> {
         },
       ]) => new Account({ address: accountIdToString(rawAccountId) }, context)
     );
+  }
+
+  /**
+   * Get the number of signers allowed by this Venue
+   */
+  public async getSignerCount(): Promise<BigNumber> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { settlement },
+        },
+      },
+      id,
+      context,
+    } = this;
+
+    const rawCount = await settlement.numberOfVenueSigners(bigNumberToU64(id, context));
+
+    return u32ToBigNumber(rawCount);
   }
 
   /**

--- a/src/api/procedures/__tests__/registerDid.ts
+++ b/src/api/procedures/__tests__/registerDid.ts
@@ -1,0 +1,166 @@
+import { AccountId } from '@polkadot/types/interfaces';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { when } from 'jest-when';
+
+import {
+  createRegisterDidResolver,
+  prepareRegisterDid,
+  registerDid,
+} from '~/api/procedures/registerDid';
+import { Context, Identity, PolymeshError, Procedure } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { ErrorCode, RegisterDidParams, RoleType, TxTags } from '~/types';
+import { PolymeshTx } from '~/types/internal';
+import * as utilsConversionModule from '~/utils/conversion';
+import * as utilsInternalModule from '~/utils/internal';
+
+jest.mock(
+  '~/api/entities/Account',
+  require('~/testUtils/mocks/entities').mockAccountModule('~/api/entities/Account')
+);
+
+describe('registerDid procedure', () => {
+  const targetAccount = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+  const rawAccountId = dsMockUtils.createMockAccountId(targetAccount);
+
+  let mockContext: Mocked<Context>;
+  let stringToAccountIdSpy: jest.SpyInstance<AccountId, [string, Context]>;
+  let registerDidTransaction: PolymeshTx<unknown[]>;
+  let proc: Procedure<RegisterDidParams, Identity, Record<string, unknown>>;
+
+  beforeAll(() => {
+    entityMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    dsMockUtils.initMocks();
+    stringToAccountIdSpy = jest.spyOn(utilsConversionModule, 'stringToAccountId');
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance({ isV7: false });
+    registerDidTransaction = dsMockUtils.createTxMock('identity', 'registerDid');
+    proc = procedureMockUtils.getInstance<RegisterDidParams, Identity>(mockContext);
+    jest.spyOn(utilsInternalModule, 'assertAddressValid').mockImplementation();
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should return a registerDid transaction spec', async () => {
+    entityMockUtils.configureMocks({
+      accountOptions: {
+        getIdentity: null,
+      },
+    });
+
+    const args = {
+      targetAccount,
+    };
+
+    when(stringToAccountIdSpy).calledWith(targetAccount, mockContext).mockReturnValue(rawAccountId);
+
+    const result = await prepareRegisterDid.call(proc, args);
+
+    expect(result).toEqual({
+      transaction: registerDidTransaction,
+      args: [rawAccountId],
+      resolver: expect.any(Function),
+    });
+  });
+
+  it('should throw if called for chain v7', () => {
+    mockContext = dsMockUtils.getContextInstance({ isV7: true });
+    proc = procedureMockUtils.getInstance<RegisterDidParams, Identity>(mockContext);
+
+    const args = {
+      targetAccount,
+    };
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.NotSupported,
+      message: 'registerDid is only supported in chain v8',
+    });
+
+    return expect(prepareRegisterDid.call(proc, args)).rejects.toThrow(expectedError);
+  });
+
+  it('should throw if the target Account already has an Identity', () => {
+    const identity = entityMockUtils.getIdentityInstance({
+      getPrimaryAccount: {
+        account: entityMockUtils.getAccountInstance({ address: targetAccount }),
+      },
+    });
+
+    entityMockUtils.getAccountInstance({ address: targetAccount, getIdentity: identity });
+
+    const args = {
+      targetAccount,
+    };
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message: 'The target account already has an identity',
+    });
+
+    return expect(prepareRegisterDid.call(proc, args)).rejects.toThrow(expectedError);
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', async () => {
+      const args = {
+        targetAccount,
+      };
+
+      const result = await registerDid().requiredAuthorizations(args);
+
+      expect(result).toEqual({
+        roles: [{ type: RoleType.DidRegistrar }],
+        permissions: {
+          assets: [],
+          portfolios: [],
+          transactions: [TxTags.identity.RegisterDid],
+        },
+      });
+    });
+  });
+});
+
+describe('createRegisterDidResolver', () => {
+  const filterEventRecordsSpy = jest.spyOn(utilsInternalModule, 'filterEventRecords');
+  const did = 'someDid';
+  const rawDid = dsMockUtils.createMockIdentityId(did);
+
+  beforeAll(() => {
+    entityMockUtils.initMocks({
+      identityOptions: {
+        did,
+      },
+    });
+  });
+
+  beforeEach(() => {
+    filterEventRecordsSpy.mockReturnValue([
+      dsMockUtils.createMockIEvent([rawDid, 'accountId', 'signingItem']),
+    ]);
+  });
+
+  afterEach(() => {
+    filterEventRecordsSpy.mockReset();
+  });
+
+  it('should return the new Identity', () => {
+    const fakeContext = {} as Context;
+
+    const result = createRegisterDidResolver(fakeContext)({} as ISubmittableResult);
+
+    expect(result.did).toEqual(did);
+  });
+});

--- a/src/api/procedures/__tests__/togglePortfolioPreApproval.ts
+++ b/src/api/procedures/__tests__/togglePortfolioPreApproval.ts
@@ -1,0 +1,214 @@
+import {
+  PolymeshPrimitivesAssetAssetId,
+  PolymeshPrimitivesIdentityIdPortfolioId,
+} from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareStorage,
+  prepareTogglePortfolioPreApproval,
+  Storage,
+} from '~/api/procedures/togglePortfolioPreApproval';
+import { BaseAsset, Context, NumberedPortfolio } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { PortfolioId, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+import * as utilsInternalModule from '~/utils/internal';
+
+jest.mock(
+  '~/api/entities/Asset/Fungible',
+  require('~/testUtils/mocks/entities').mockFungibleAssetModule('~/api/entities/Asset/Fungible')
+);
+jest.mock(
+  '~/api/entities/NumberedPortfolio',
+  require('~/testUtils/mocks/entities').mockNumberedPortfolioModule(
+    '~/api/entities/NumberedPortfolio'
+  )
+);
+
+describe('togglePortfolioPreApproval procedure', () => {
+  const did = 'someDid';
+  const id = new BigNumber(1);
+  const portfolioId: PortfolioId = { did, number: id };
+
+  let mockContext: Mocked<Context>;
+  let assetToMeshAssetIdSpy: jest.SpyInstance;
+  let portfolioIdToMeshPortfolioIdSpy: jest.SpyInstance;
+  let portfolioLikeToPortfolioIdSpy: jest.SpyInstance;
+  let asBaseAssetSpy: jest.SpyInstance;
+  let assetId: string;
+  let asset: BaseAsset;
+  let rawAssetId: PolymeshPrimitivesAssetAssetId;
+  let rawPortfolioId: PolymeshPrimitivesIdentityIdPortfolioId;
+  let portfolio: Mocked<NumberedPortfolio>;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
+    portfolioIdToMeshPortfolioIdSpy = jest.spyOn(
+      utilsConversionModule,
+      'portfolioIdToMeshPortfolioId'
+    );
+    portfolioLikeToPortfolioIdSpy = jest.spyOn(utilsConversionModule, 'portfolioLikeToPortfolioId');
+    asBaseAssetSpy = jest.spyOn(utilsInternalModule, 'asBaseAsset');
+    assetId = 'TEST';
+    asset = entityMockUtils.getBaseAssetInstance({ assetId });
+    rawAssetId = dsMockUtils.createMockTicker(assetId);
+    rawPortfolioId = dsMockUtils.createMockPortfolioId({
+      did: dsMockUtils.createMockIdentityId(did),
+      kind: dsMockUtils.createMockPortfolioKind({
+        User: dsMockUtils.createMockU64(id),
+      }),
+    });
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance();
+    portfolio = entityMockUtils.getNumberedPortfolioInstance({
+      did,
+      id,
+      isAssetPreApproved: false,
+    });
+    asBaseAssetSpy.mockResolvedValue(asset);
+    when(assetToMeshAssetIdSpy)
+      .calledWith(expect.objectContaining({ id: assetId }), mockContext)
+      .mockReturnValue(rawAssetId);
+    when(portfolioIdToMeshPortfolioIdSpy)
+      .calledWith(portfolioId, mockContext)
+      .mockReturnValue(rawPortfolioId);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if pre approving an asset that is already pre-approved', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      portfolioId,
+    });
+    portfolio.isAssetPreApproved.mockResolvedValue(true);
+
+    return expect(
+      prepareTogglePortfolioPreApproval.call(proc, {
+        portfolio,
+        asset,
+        preApprove: true,
+      })
+    ).rejects.toThrow('The Portfolio has already pre-approved the asset');
+  });
+
+  it('should throw an error if removing pre approval for an asset that is not pre-approved', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      portfolioId,
+    });
+
+    return expect(
+      prepareTogglePortfolioPreApproval.call(proc, {
+        portfolio,
+        asset,
+        preApprove: false,
+      })
+    ).rejects.toThrow('The Portfolio has not pre-approved the asset');
+  });
+
+  it('should return a pre approve portfolio transaction spec', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      portfolioId,
+    });
+
+    const transaction = dsMockUtils.createTxMock('portfolio', 'preApprovePortfolio');
+
+    const result = await prepareTogglePortfolioPreApproval.call(proc, {
+      portfolio,
+      asset,
+      preApprove: true,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawAssetId, rawPortfolioId],
+      resolver: undefined,
+    });
+  });
+
+  it('should return a remove portfolio pre approval transaction spec', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      portfolioId,
+    });
+    portfolio.isAssetPreApproved.mockResolvedValue(true);
+
+    const transaction = dsMockUtils.createTxMock('portfolio', 'removePortfolioPreApproval');
+
+    const result = await prepareTogglePortfolioPreApproval.call(proc, {
+      portfolio,
+      asset,
+      preApprove: false,
+    });
+
+    expect(result).toEqual({
+      transaction,
+      args: [rawAssetId, rawPortfolioId],
+      resolver: undefined,
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        portfolioId,
+      });
+      const boundFunc = getAuthorization.bind(proc);
+      const args: Params = {
+        portfolio,
+        asset,
+        preApprove: true,
+      };
+
+      expect(boundFunc(args)).toEqual({
+        permissions: {
+          transactions: [TxTags.portfolio.PreApprovePortfolio],
+          assets: [],
+          portfolios: [portfolio],
+        },
+      });
+
+      args.preApprove = false;
+
+      expect(boundFunc(args)).toEqual({
+        permissions: {
+          transactions: [TxTags.portfolio.RemovePortfolioPreApproval],
+          assets: [],
+          portfolios: [portfolio],
+        },
+      });
+    });
+  });
+
+  describe('prepareStorage', () => {
+    it('should return the portfolio id', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext);
+      const boundFunc = prepareStorage.bind(proc);
+
+      when(portfolioLikeToPortfolioIdSpy).calledWith(portfolio).mockReturnValue(portfolioId);
+
+      const result = boundFunc({ portfolio, asset, preApprove: true });
+
+      expect(result).toEqual({
+        portfolioId,
+      });
+    });
+  });
+});

--- a/src/api/procedures/__tests__/unlockInstructionForExecution.ts
+++ b/src/api/procedures/__tests__/unlockInstructionForExecution.ts
@@ -1,0 +1,140 @@
+import { u64 } from '@polkadot/types';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import {
+  getAuthorization,
+  Params,
+  prepareUnlockInstructionForExecution,
+} from '~/api/procedures/unlockInstructionForExecution';
+import * as procedureUtilsModule from '~/api/procedures/utils';
+import { Context, Instruction } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { AffirmationStatus, TxTags } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Instruction',
+  require('~/testUtils/mocks/entities').mockInstructionModule('~/api/entities/Instruction')
+);
+
+describe('unlockInstructionForExecution procedure', () => {
+  const id = new BigNumber(1);
+  const rawInstructionId = dsMockUtils.createMockU64(id);
+
+  let mockContext: Mocked<Context>;
+  let bigNumberToU64Spy: jest.SpyInstance<u64, [BigNumber, Context]>;
+
+  let unlockInstructionTxMock: jest.Mock;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+
+    bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
+
+    jest.spyOn(procedureUtilsModule, 'assertInstructionValidForUnlocking').mockImplementation();
+  });
+
+  beforeEach(() => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          { identity: entityMockUtils.getIdentityInstance(), status: AffirmationStatus.Affirmed },
+        ],
+      },
+    });
+
+    unlockInstructionTxMock = dsMockUtils.createTxMock('settlement', 'unlockInstruction');
+
+    mockContext = dsMockUtils.getContextInstance();
+    when(bigNumberToU64Spy).calledWith(id, mockContext).mockReturnValue(rawInstructionId);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if signer is not a mediator', () => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          {
+            identity: entityMockUtils.getIdentityInstance({ did: 'randomDid' }),
+            status: AffirmationStatus.Affirmed,
+          },
+        ],
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    return expect(
+      prepareUnlockInstructionForExecution.call(proc, {
+        id,
+      })
+    ).rejects.toThrow('Only mediators can unlock instructions for execution');
+  });
+
+  it('should throw an error if mediator affirmation has expired', () => {
+    entityMockUtils.configureMocks({
+      instructionOptions: {
+        getMediators: [
+          {
+            identity: entityMockUtils.getIdentityInstance(),
+            status: AffirmationStatus.Affirmed,
+            expiry: new Date('2022/01/01'),
+          },
+        ],
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    return expect(
+      prepareUnlockInstructionForExecution.call(proc, {
+        id,
+      })
+    ).rejects.toThrow('Mediator affirmation has expired');
+  });
+
+  it('should return a transaction spec on successful unlocking', async () => {
+    const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext);
+
+    const result = await prepareUnlockInstructionForExecution.call(proc, {
+      id,
+    });
+
+    expect(result).toEqual({
+      transaction: unlockInstructionTxMock,
+      args: [rawInstructionId],
+      resolver: expect.objectContaining({ id }),
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, Instruction>(mockContext, { id });
+      const boundFunc = getAuthorization.bind(proc);
+
+      const result = boundFunc();
+
+      expect(result).toEqual({
+        permissions: {
+          assets: [],
+          portfolios: [],
+          transactions: [TxTags.settlement.UnlockInstruction],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/__tests__/utils.ts
+++ b/src/api/procedures/__tests__/utils.ts
@@ -12,6 +12,7 @@ import {
   assertInstructionValid,
   assertInstructionValidForLocking,
   assertInstructionValidForManualExecution,
+  assertInstructionValidForUnlocking,
   assertPortfolioExists,
   assertRequirementsNotTooComplex,
   assertSecondaryAccounts,
@@ -258,6 +259,38 @@ describe('assertInstructionValidForLocking', () => {
       assertInstructionValidForLocking({
         status: InstructionStatus.Pending,
         type: InstructionType.SettleAfterLock,
+      } as InstructionDetails)
+    ).not.toThrow();
+  });
+});
+
+describe('assertInstructionValidForUnlocking', () => {
+  it('should throw an error if instruction is not in pending or failed state', () => {
+    expect(() =>
+      assertInstructionValidForUnlocking({
+        status: InstructionStatus.Success,
+      } as InstructionDetails)
+    ).toThrow('The Instruction has already been executed');
+
+    expect(() =>
+      assertInstructionValidForUnlocking({
+        status: InstructionStatus.Rejected,
+      } as InstructionDetails)
+    ).toThrow('The Instruction has already been executed');
+  });
+
+  it('should throw an error if the instruction is not locked for execution', () => {
+    expect(() =>
+      assertInstructionValidForUnlocking({
+        status: InstructionStatus.Pending,
+      } as InstructionDetails)
+    ).toThrow('The Instruction is not locked for execution');
+  });
+
+  it('should not throw an error for valid instruction', () => {
+    expect(() =>
+      assertInstructionValidForUnlocking({
+        status: InstructionStatus.LockedForExecution,
       } as InstructionDetails)
     ).not.toThrow();
   });

--- a/src/api/procedures/createAsset.ts
+++ b/src/api/procedures/createAsset.ts
@@ -42,6 +42,7 @@ import {
   stringToTicker,
 } from '~/utils/conversion';
 import {
+  assertTickerLengthValid,
   checkTxType,
   isAllowedCharacters,
   optionize,
@@ -272,6 +273,7 @@ export async function prepareCreateAsset(
   let rawTicker: PolymeshPrimitivesTicker | undefined;
 
   if (ticker) {
+    await assertTickerLengthValid(ticker, context);
     rawTicker = stringToTicker(ticker, context);
   }
 

--- a/src/api/procedures/createNftCollection.ts
+++ b/src/api/procedures/createNftCollection.ts
@@ -45,6 +45,7 @@ import {
   stringToTicker,
 } from '~/utils/conversion';
 import {
+  assertTickerLengthValid,
   checkTxType,
   isAllowedCharacters,
   optionize,
@@ -190,6 +191,7 @@ export async function prepareCreateNftCollection(
 
   if (ticker) {
     assertTickerOk(ticker);
+    await assertTickerLengthValid(ticker, context);
   }
 
   const internalNftType = getInternalNftType(customTypeData, nftType);

--- a/src/api/procedures/registerDid.ts
+++ b/src/api/procedures/registerDid.ts
@@ -1,0 +1,77 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+
+import { Context, Identity, PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, RegisterDidParams, RoleType, TxTags } from '~/types';
+import { ExtrinsicParams, TransactionSpec } from '~/types/internal';
+import { identityIdToString, stringToAccountId } from '~/utils/conversion';
+import { asAccount, filterEventRecords } from '~/utils/internal';
+
+/**
+ * @hidden
+ */
+export const createRegisterDidResolver =
+  (context: Context) =>
+  (receipt: ISubmittableResult): Identity => {
+    const [record] = filterEventRecords(receipt, 'identity', 'DidCreated');
+
+    const { data } = record!;
+
+    const did = identityIdToString(data[0]);
+
+    return new Identity({ did }, context);
+  };
+
+/**
+ * @hidden
+ */
+export async function prepareRegisterDid(
+  this: Procedure<RegisterDidParams, Identity>,
+  args: RegisterDidParams
+): Promise<TransactionSpec<Identity, ExtrinsicParams<'identity', 'registerDid'>>> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    context,
+  } = this;
+  const { targetAccount } = args;
+
+  if (context.isV7) {
+    throw new PolymeshError({
+      code: ErrorCode.NotSupported,
+      message: 'registerDid is only supported in chain v8',
+    });
+  }
+
+  const account = asAccount(targetAccount, context);
+
+  const identityExists = await account.getIdentity();
+
+  if (identityExists) {
+    throw new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message: 'The target account already has an identity',
+    });
+  }
+
+  const rawTargetAccount = stringToAccountId(account.address, context);
+
+  return {
+    transaction: tx.identity.registerDid,
+    args: [rawTargetAccount],
+    resolver: createRegisterDidResolver(context),
+  };
+}
+
+/**
+ * @hidden
+ */
+export const registerDid = (): Procedure<RegisterDidParams, Identity> =>
+  new Procedure(prepareRegisterDid, {
+    roles: [{ type: RoleType.DidRegistrar }],
+    permissions: {
+      assets: [],
+      portfolios: [],
+      transactions: [TxTags.identity.RegisterDid],
+    },
+  });

--- a/src/api/procedures/reserveTicker.ts
+++ b/src/api/procedures/reserveTicker.ts
@@ -4,7 +4,7 @@ import { Context, PolymeshError, Procedure, TickerReservation } from '~/internal
 import { ErrorCode, ReserveTickerParams, RoleType, TickerReservationStatus, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import { stringToTicker, tickerToString } from '~/utils/conversion';
-import { filterEventRecords, isAllowedCharacters } from '~/utils/internal';
+import { assertTickerLengthValid, filterEventRecords, isAllowedCharacters } from '~/utils/internal';
 
 /**
  * @hidden
@@ -42,6 +42,8 @@ export async function prepareReserveTicker(
       message: 'New Tickers can only contain alphanumeric values "_", "-", ".", and "/"',
     });
   }
+
+  await assertTickerLengthValid(ticker, context);
 
   const rawTicker = stringToTicker(ticker, context);
 

--- a/src/api/procedures/togglePortfolioPreApproval.ts
+++ b/src/api/procedures/togglePortfolioPreApproval.ts
@@ -1,0 +1,110 @@
+import {
+  BaseAsset,
+  DefaultPortfolio,
+  NumberedPortfolio,
+  PolymeshError,
+  Procedure,
+} from '~/internal';
+import { ErrorCode, PortfolioId, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import {
+  assetToMeshAssetId,
+  portfolioIdToMeshPortfolioId,
+  portfolioLikeToPortfolioId,
+} from '~/utils/conversion';
+import { asBaseAsset } from '~/utils/internal';
+
+/**
+ * @hidden
+ */
+export interface Params {
+  portfolio: DefaultPortfolio | NumberedPortfolio;
+  asset: BaseAsset | string;
+  preApprove: boolean;
+}
+
+export interface Storage {
+  portfolioId: PortfolioId;
+}
+
+/**
+ * @hidden
+ */
+export async function prepareTogglePortfolioPreApproval(
+  this: Procedure<Params, void, Storage>,
+  args: Params
+): Promise<TransactionSpec<void, ExtrinsicParams<'portfolio', 'preApprovePortfolio'>>> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    storage: { portfolioId },
+    context,
+  } = this;
+  const { portfolio, asset, preApprove } = args;
+
+  const baseAsset = await asBaseAsset(asset, context);
+  const isPreApproved = await portfolio.isAssetPreApproved(baseAsset);
+
+  if (isPreApproved === preApprove) {
+    const message = isPreApproved
+      ? 'The Portfolio has already pre-approved the asset'
+      : 'The Portfolio has not pre-approved the asset';
+    throw new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message,
+      data: { portfolioId, assetId: baseAsset.id },
+    });
+  }
+
+  const rawAssetId = assetToMeshAssetId(baseAsset, context);
+  const rawPortfolioId = portfolioIdToMeshPortfolioId(portfolioId, context);
+
+  const transaction = preApprove
+    ? tx.portfolio.preApprovePortfolio
+    : tx.portfolio.removePortfolioPreApproval;
+
+  return {
+    transaction,
+    args: [rawAssetId, rawPortfolioId],
+    resolver: undefined,
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void, Storage>,
+  { preApprove, portfolio }: Params
+): ProcedureAuthorization {
+  return {
+    permissions: {
+      transactions: [
+        preApprove
+          ? TxTags.portfolio.PreApprovePortfolio
+          : TxTags.portfolio.RemovePortfolioPreApproval,
+      ],
+      assets: [],
+      portfolios: [portfolio],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export function prepareStorage(
+  this: Procedure<Params, void, Storage>,
+  { portfolio }: Params
+): Storage {
+  return {
+    portfolioId: portfolioLikeToPortfolioId(portfolio),
+  };
+}
+
+/**
+ * @hidden
+ */
+export const togglePortfolioPreApproval = (): Procedure<Params, void, Storage> =>
+  new Procedure(prepareTogglePortfolioPreApproval, getAuthorization, prepareStorage);

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1002,6 +1002,13 @@ export interface RegisterIdentityParams {
   expiry?: Date;
 }
 
+export interface RegisterDidParams {
+  /**
+   * The Account that should function as the primary key of the newly created Identity. Can be ss58 encoded address or an instance of Account
+   */
+  targetAccount: string | Account;
+}
+
 export interface AttestPrimaryKeyRotationParams {
   /**
    * The Account that will be attested to become the primary key of the `identity`. Can be ss58 encoded address or an instance of Account

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1213,6 +1213,10 @@ export interface OffChainAffirmationReceipt {
    * (optional) Metadata value that can be used to attach messages to the receipt
    */
   metadata: string | undefined;
+  /**
+   * Timestamp at which the receipt expires. Mandatory from chain 8.x onwards
+   */
+  expiresAt?: Date | undefined;
 }
 
 export type AffirmInstructionParams = {

--- a/src/api/procedures/unlockInstructionForExecution.ts
+++ b/src/api/procedures/unlockInstructionForExecution.ts
@@ -1,0 +1,89 @@
+import BigNumber from 'bignumber.js';
+
+import { assertInstructionValidForUnlocking } from '~/api/procedures/utils';
+import { Instruction, PolymeshError, Procedure } from '~/internal';
+import { ErrorCode, TxTags } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { bigNumberToU64 } from '~/utils/conversion';
+
+/**
+ * @hidden
+ */
+export type Params = {
+  id: BigNumber;
+};
+
+/**
+ * @hidden
+ */
+export async function prepareUnlockInstructionForExecution(
+  this: Procedure<Params, Instruction>,
+  args: Params
+): Promise<TransactionSpec<Instruction, ExtrinsicParams<'settlementTx', 'unlockInstruction'>>> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: { settlement: settlementTx },
+      },
+    },
+    context,
+  } = this;
+
+  const { id } = args;
+
+  const instruction = new Instruction({ id }, context);
+
+  const [{ did: signerDid }, instructionDetails, mediatorAffirmations] = await Promise.all([
+    context.getSigningIdentity(),
+    instruction.detailsFromChain(),
+    instruction.getMediators(),
+  ]);
+
+  assertInstructionValidForUnlocking(instructionDetails);
+
+  const mediatorWithAffirmation = mediatorAffirmations.find(
+    ({ identity: { did } }) => did === signerDid
+  );
+
+  if (!mediatorWithAffirmation) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Only mediators can unlock instructions for execution',
+      data: { signer: signerDid, instructionId: id.toString() },
+    });
+  }
+
+  if (mediatorWithAffirmation.expiry && mediatorWithAffirmation.expiry < new Date()) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Mediator affirmation has expired',
+    });
+  }
+
+  const rawInstructionId = bigNumberToU64(id, context);
+
+  return {
+    transaction: settlementTx.unlockInstruction,
+    resolver: instruction,
+    args: [rawInstructionId],
+  };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(this: Procedure<Params, Instruction>): ProcedureAuthorization {
+  return {
+    permissions: {
+      transactions: [TxTags.settlement.UnlockInstruction],
+      assets: [],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const unlockInstructionForExecution = (): Procedure<Params, Instruction> =>
+  new Procedure(prepareUnlockInstructionForExecution, getAuthorization);

--- a/src/api/procedures/utils.ts
+++ b/src/api/procedures/utils.ts
@@ -152,6 +152,25 @@ export function assertInstructionValidForLocking(details: InstructionDetails): v
 /**
  * @hidden
  */
+export function assertInstructionValidForUnlocking(details: InstructionDetails): void {
+  const { status } = details;
+
+  assertInstructionIsNotPruned(status);
+
+  if (status !== InstructionStatus.LockedForExecution) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The Instruction is not locked for execution',
+      data: {
+        currentStatus: status,
+      },
+    });
+  }
+}
+
+/**
+ * @hidden
+ */
 export async function assertPortfolioExists(
   portfolioId: PortfolioId,
   context: Context

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -379,32 +379,50 @@ export class Context {
       data: { free: rawFree, miscFrozen, feeFrozen, reserved: rawReserved },
     }: AccountInfo): AccountBalance => {
       /*
-       * The chain's "free" balance is the balance that isn't locked. Here we calculate it so
-       * the free balance is what the Account is able to spend
+       * On v7 chains, frozen funds are carved out of the chain's "free" balance, so the spendable
+       * balance is the free balance minus the largest freeze, minus anything reserved
        */
       const reserved = balanceToBigNumber(rawReserved);
       const total = balanceToBigNumber(rawFree).plus(reserved);
-      const locked = BigNumber.max(balanceToBigNumber(miscFrozen), balanceToBigNumber(feeFrozen));
+      const frozen = BigNumber.max(balanceToBigNumber(miscFrozen), balanceToBigNumber(feeFrozen));
+      const free = total.minus(frozen).minus(reserved);
       return {
         total,
-        locked,
-        free: total.minus(locked).minus(reserved),
+        locked: total.minus(free),
+        free,
+        reserved,
+        frozen,
       };
     };
 
     const v8AssembleResult = ({ data }: FrameSystemAccountInfo): AccountBalance => {
-      const { free: rawFree, frozen: feeFrozen, reserved: rawReserved } = data;
+      const { free: rawFree, frozen: rawFrozen, reserved: rawReserved } = data;
+      const {
+        consts: {
+          balances: { existentialDeposit },
+        },
+      } = this.polymeshApi;
       /*
-       * The chain's "free" balance is the balance that isn't locked. Here we calculate it so
-       * the free balance is what the Account is able to spend
+       * The chain's "free" balance still includes frozen funds, while funds on hold (e.g. bonded
+       * for staking) are tracked in "reserved". Frozen funds can overlap with funds on hold, so
+       * the spendable balance is calculated as per the chain's rules:
+       *   transferable = free - max(frozen - reserved, ED)
        */
       const reserved = balanceToBigNumber(rawReserved);
-      const total = balanceToBigNumber(rawFree).plus(reserved);
-      const locked = balanceToBigNumber(feeFrozen);
+      const chainFree = balanceToBigNumber(rawFree);
+      const total = chainFree.plus(reserved);
+      const frozen = balanceToBigNumber(rawFrozen);
+      const untouchable = BigNumber.max(
+        frozen.minus(reserved),
+        balanceToBigNumber(existentialDeposit)
+      );
+      const free = BigNumber.max(chainFree.minus(untouchable), 0);
       return {
         total,
-        locked,
-        free: total.minus(locked).minus(reserved),
+        locked: total.minus(free),
+        free,
+        reserved,
+        frozen,
       };
     };
 

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -2,6 +2,7 @@
 import { EventEmitter } from 'events';
 
 import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { SignerOptions } from '@polkadot/api-base/types';
 import { ISubmittableResult, Signer as PolkadotSigner } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
@@ -397,86 +398,98 @@ export abstract class PolymeshTransactionBase<
 
     const txWithArgs = this.composeTx();
 
+    const signerOptions = {
+      nonce,
+      /*
+       * allows signers (e.g. Ledger devices signing via the generic app) to return a modified
+       *   `signedTransaction`, which is required when signed extensions like `CheckMetadataHash` alter the payload
+       */
+      withSignedTransaction: true,
+      /*
+       * a returned `signedTransaction` may only alter signed extensions (e.g. `mode`, `metadataHash`).
+       *   The API will reject any submission where the signer changed the call data itself
+       */
+      allowCallDataAlteration: false,
+      ...(signer && { signer }),
+      ...(era !== undefined ? { era } : {}),
+    };
+
     if (context.supportsSubscription()) {
       return new Promise((resolve, reject) => {
         let settingBlockData = Promise.resolve();
-        const gettingUnsub = txWithArgs.signAndSend(
-          signingAddress,
-          { nonce, ...(signer && { signer }), ...(era !== undefined ? { era } : {}) },
-          receipt => {
-            const { status } = receipt;
-            let isLastCallback = false;
-            let unsubscribing = Promise.resolve();
-            let extrinsicFailedEvent;
+        const gettingUnsub = txWithArgs.signAndSend(signingAddress, signerOptions, receipt => {
+          const { status } = receipt;
+          let isLastCallback = false;
+          let unsubscribing = Promise.resolve();
+          let extrinsicFailedEvent;
 
-            if (status.isFuture) {
-              this.updateStatus(TransactionStatus.Future);
-            } else if (receipt.isCompleted) {
-              // isCompleted implies status is one of: isFinalized, isInBlock or isError
-              if (receipt.isInBlock) {
-                const inBlockHash = status.asInBlock;
-                /*
-                 * this must be done to ensure that the block hash and number are set before the success event
-                 *   is emitted, and at the same time. We do not resolve or reject the containing promise until this
-                 *   one resolves
-                 */
-                settingBlockData = defusePromise(
-                  this.context.polymeshApi.rpc.chain.getBlock(inBlockHash).then(({ block }) => {
-                    this.blockHash = hashToString(inBlockHash);
-                    this.blockNumber = u32ToBigNumber(block.header.number.unwrap());
-
-                    // we know that the index has to be set by the time the transaction is included in a block
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    this.txIndex = new BigNumber(receipt.txIndex!);
-                    this.updateStatus(TransactionStatus.InBlock);
-                  })
-                );
-
-                // if the extrinsic failed due to an on-chain error, we should handle it in a special way
-                [extrinsicFailedEvent] = filterEventRecords(
-                  receipt,
-                  'system',
-                  'ExtrinsicFailed',
-                  true
-                );
-                // extrinsic failed so we can unsubscribe
-                isLastCallback = !!extrinsicFailedEvent;
-              } else {
-                // isFinalized || isError so we know we can unsubscribe
-                isLastCallback = true;
-              }
-
-              if (isLastCallback) {
-                unsubscribing = gettingUnsub.then((unsub: UnsubCallback) => {
-                  unsub();
-                });
-              }
-
+          if (status.isFuture) {
+            this.updateStatus(TransactionStatus.Future);
+          } else if (receipt.isCompleted) {
+            // isCompleted implies status is one of: isFinalized, isInBlock or isError
+            if (receipt.isInBlock) {
+              const inBlockHash = status.asInBlock;
               /*
-               * Promise chain that handles all sub-promises in this pass through the signAndSend callback.
-               * Primarily for consistent error handling
+               * this must be done to ensure that the block hash and number are set before the success event
+               *   is emitted, and at the same time. We do not resolve or reject the containing promise until this
+               *   one resolves
                */
-              let finishing = Promise.resolve();
+              settingBlockData = defusePromise(
+                this.context.polymeshApi.rpc.chain.getBlock(inBlockHash).then(({ block }) => {
+                  this.blockHash = hashToString(inBlockHash);
+                  this.blockNumber = u32ToBigNumber(block.header.number.unwrap());
 
-              if (extrinsicFailedEvent) {
-                const { data } = extrinsicFailedEvent;
+                  // we know that the index has to be set by the time the transaction is included in a block
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  this.txIndex = new BigNumber(receipt.txIndex!);
+                  this.updateStatus(TransactionStatus.InBlock);
+                })
+              );
 
-                finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
-                  const error = handleExtrinsicFailure(data[0]);
-                  reject(error);
-                });
-              } else if (receipt.isFinalized) {
-                finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
-                  this.handleExtrinsicSuccess(resolve, reject, receipt);
-                });
-              } else if (receipt.isError) {
-                reject(new PolymeshError({ code: ErrorCode.TransactionAborted }));
-              }
-
-              finishing.catch((err: Error) => reject(err));
+              // if the extrinsic failed due to an on-chain error, we should handle it in a special way
+              [extrinsicFailedEvent] = filterEventRecords(
+                receipt,
+                'system',
+                'ExtrinsicFailed',
+                true
+              );
+              // extrinsic failed so we can unsubscribe
+              isLastCallback = !!extrinsicFailedEvent;
+            } else {
+              // isFinalized || isError so we know we can unsubscribe
+              isLastCallback = true;
             }
+
+            if (isLastCallback) {
+              unsubscribing = gettingUnsub.then((unsub: UnsubCallback) => {
+                unsub();
+              });
+            }
+
+            /*
+             * Promise chain that handles all sub-promises in this pass through the signAndSend callback.
+             * Primarily for consistent error handling
+             */
+            let finishing = Promise.resolve();
+
+            if (extrinsicFailedEvent) {
+              const { data } = extrinsicFailedEvent;
+
+              finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
+                const error = handleExtrinsicFailure(data[0]);
+                reject(error);
+              });
+            } else if (receipt.isFinalized) {
+              finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
+                this.handleExtrinsicSuccess(resolve, reject, receipt);
+              });
+            } else if (receipt.isError) {
+              reject(new PolymeshError({ code: ErrorCode.TransactionAborted }));
+            }
+
+            finishing.catch((err: Error) => reject(err));
           }
-        );
+        });
 
         gettingUnsub
           .then(() => {
@@ -489,50 +502,68 @@ export abstract class PolymeshTransactionBase<
           });
       });
     } else {
-      const startingBlock = await context.getLatestBlock();
-
-      await txWithArgs
-        .signAndSend(signingAddress, {
-          nonce,
-          ...(signer && { signer }),
-          ...(era !== undefined ? { era } : {}),
-        })
-        .then(() => {
-          this.setIsRunningStatus(txWithArgs.hash.toString());
-        })
-        .catch((err: Error) => {
-          const error = handleTransactionSubmissionError(err);
-
-          throw new PolymeshError(error);
-        });
-
-      const finalizedReceipt = await pollForTransactionFinalization(
-        txWithArgs.hash,
-        startingBlock,
-        context
-      );
-
-      this.blockHash = hashToString(finalizedReceipt.status.asFinalized);
-      this.blockNumber = u32ToBigNumber(finalizedReceipt.blockNumber!);
-      this.txIndex = new BigNumber(finalizedReceipt.txIndex!);
-
-      // if the extrinsic failed due to an on-chain error, we should handle it in a special way
-      const [extrinsicFailedEvent] = filterEventRecords(
-        finalizedReceipt,
-        'system',
-        'ExtrinsicFailed',
-        true
-      );
-
-      if (extrinsicFailedEvent) {
-        const { data } = extrinsicFailedEvent;
-        const error = handleExtrinsicFailure(data[0]);
-
-        throw error;
-      }
-
-      return finalizedReceipt;
+      return this.runViaPolling(txWithArgs, signerOptions);
     }
+  }
+
+  /**
+   * @hidden
+   *
+   * Sign and submit the transaction, then poll for its finalization. Used when the
+   *   node connection does not support subscriptions
+   */
+  private async runViaPolling(
+    txWithArgs: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    signerOptions: Partial<SignerOptions>
+  ): Promise<ISubmittableResult> {
+    const { signingAddress, context } = this;
+
+    const startingBlock = await context.getLatestBlock();
+
+    /*
+     * the resolved hash is used instead of `txWithArgs.hash` because a signer may return a modified
+     *   `signedTransaction` (e.g. Ledger devices signing via the generic app), in which case the
+     *   submitted extrinsic's hash can differ from the locally composed one
+     */
+    const submittedTxHash = await txWithArgs
+      .signAndSend(signingAddress, signerOptions)
+      .then(txHash => {
+        this.setIsRunningStatus(txHash.toString());
+
+        return txHash;
+      })
+      .catch((err: Error) => {
+        const error = handleTransactionSubmissionError(err);
+
+        throw new PolymeshError(error);
+      });
+
+    const finalizedReceipt = await pollForTransactionFinalization(
+      submittedTxHash,
+      startingBlock,
+      context
+    );
+
+    this.blockHash = hashToString(finalizedReceipt.status.asFinalized);
+    this.blockNumber = u32ToBigNumber(finalizedReceipt.blockNumber!);
+    this.txIndex = new BigNumber(finalizedReceipt.txIndex!);
+
+    // if the extrinsic failed due to an on-chain error, we should handle it in a special way
+    const [extrinsicFailedEvent] = filterEventRecords(
+      finalizedReceipt,
+      'system',
+      'ExtrinsicFailed',
+      true
+    );
+
+    if (extrinsicFailedEvent) {
+      const { data } = extrinsicFailedEvent;
+      const error = handleExtrinsicFailure(data[0]);
+
+      throw error;
+    }
+
+    return finalizedReceipt;
   }
 
   /**

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -380,6 +380,13 @@ describe('Context class', () => {
     const free = new BigNumber(100);
     const reserved = new BigNumber(40);
     const frozen = new BigNumber(25);
+    const existentialDeposit = new BigNumber(1);
+
+    beforeEach(() => {
+      dsMockUtils.setConstMock('balances', 'existentialDeposit', {
+        returnValue: dsMockUtils.createMockBalance(existentialDeposit),
+      });
+    });
 
     it('should throw if there is no signing Account and no Account is passed', async () => {
       const context = await Context.create({
@@ -413,9 +420,11 @@ describe('Context class', () => {
 
       const result = await context.accountBalance();
       expect(result).toEqual({
-        free: free.minus(frozen).shiftedBy(-6),
-        locked: frozen.shiftedBy(-6),
+        free: free.minus(existentialDeposit).shiftedBy(-6),
+        locked: reserved.plus(existentialDeposit).shiftedBy(-6),
         total: free.plus(reserved).shiftedBy(-6),
+        reserved: reserved.shiftedBy(-6),
+        frozen: frozen.shiftedBy(-6),
       });
     });
 
@@ -439,9 +448,71 @@ describe('Context class', () => {
 
       const result = await context.accountBalance('someAddress');
       expect(result).toEqual({
-        free: free.minus(frozen).shiftedBy(-6),
-        locked: frozen.shiftedBy(-6),
+        free: free.minus(existentialDeposit).shiftedBy(-6),
+        locked: reserved.plus(existentialDeposit).shiftedBy(-6),
         total: free.plus(reserved).shiftedBy(-6),
+        reserved: reserved.shiftedBy(-6),
+        frozen: frozen.shiftedBy(-6),
+      });
+    });
+
+    it('should deduct the frozen amount not covered by the reserved balance from the free balance', async () => {
+      const frozenOverReserved = new BigNumber(75);
+      const returnValue = dsMockUtils.createMockAccountInfo({
+        nonce: dsMockUtils.createMockIndex(),
+        refcount: dsMockUtils.createMockRefCount(),
+        data: dsMockUtils.createMockAccountData({
+          free,
+          reserved,
+          frozen: frozenOverReserved,
+        }),
+      });
+
+      dsMockUtils.createQueryMock('system', 'account', { returnValue });
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      const result = await context.accountBalance('someAddress');
+      expect(result).toEqual({
+        free: free.minus(frozenOverReserved.minus(reserved)).shiftedBy(-6),
+        locked: reserved.plus(frozenOverReserved.minus(reserved)).shiftedBy(-6),
+        total: free.plus(reserved).shiftedBy(-6),
+        reserved: reserved.shiftedBy(-6),
+        frozen: frozenOverReserved.shiftedBy(-6),
+      });
+    });
+
+    it('should return a zero free balance for a fully staked Account', async () => {
+      const stakedFree = new BigNumber(1);
+      const stakedReserved = new BigNumber(150909701126);
+      const stakedFrozen = new BigNumber(133054349116);
+      const returnValue = dsMockUtils.createMockAccountInfo({
+        nonce: dsMockUtils.createMockIndex(),
+        refcount: dsMockUtils.createMockRefCount(),
+        data: dsMockUtils.createMockAccountData({
+          free: stakedFree,
+          reserved: stakedReserved,
+          frozen: stakedFrozen,
+        }),
+      });
+
+      dsMockUtils.createQueryMock('system', 'account', { returnValue });
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      const result = await context.accountBalance('someAddress');
+      expect(result).toEqual({
+        free: new BigNumber(0),
+        locked: stakedFree.plus(stakedReserved).shiftedBy(-6),
+        total: stakedFree.plus(stakedReserved).shiftedBy(-6),
+        reserved: stakedReserved.shiftedBy(-6),
+        frozen: stakedFrozen.shiftedBy(-6),
       });
     });
 
@@ -474,9 +545,11 @@ describe('Context class', () => {
 
       expect(result).toEqual(unsubCallback);
       expect(callback).toHaveBeenCalledWith({
-        free: free.minus(frozen).shiftedBy(-6),
-        locked: frozen.shiftedBy(-6),
+        free: free.minus(existentialDeposit).shiftedBy(-6),
+        locked: reserved.plus(existentialDeposit).shiftedBy(-6),
         total: free.plus(reserved).shiftedBy(-6),
+        reserved: reserved.shiftedBy(-6),
+        frozen: frozen.shiftedBy(-6),
       });
     });
   });

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -726,7 +726,11 @@ describe('Polymesh Transaction Base class', () => {
       await tx.run();
       expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
         txSpec.signingAddress,
-        expect.objectContaining({ era: 0 }),
+        expect.objectContaining({
+          era: 0,
+          withSignedTransaction: true,
+          allowCallDataAlteration: false,
+        }),
         expect.any(Function)
       );
     });
@@ -810,7 +814,12 @@ describe('Polymesh Transaction Base class', () => {
       const result = await tx.run();
       expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
         txSpec.signingAddress,
-        expect.objectContaining({ nonce: -1, signer: 'signer' })
+        expect.objectContaining({
+          nonce: -1,
+          signer: 'signer',
+          withSignedTransaction: true,
+          allowCallDataAlteration: false,
+        })
       );
 
       expect(tx.blockHash).toEqual('blockHash');
@@ -891,7 +900,13 @@ describe('Polymesh Transaction Base class', () => {
       await tx.run();
       expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
         txSpec.signingAddress,
-        expect.objectContaining({ nonce: -1, signer: 'signer', era: 0 })
+        expect.objectContaining({
+          nonce: -1,
+          signer: 'signer',
+          era: 0,
+          withSignedTransaction: true,
+          allowCallDataAlteration: false,
+        })
       );
     });
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -47,6 +47,7 @@ export {
   Params as ModifyAssetTrustedClaimIssuersParams,
 } from '~/api/procedures/modifyAssetTrustedClaimIssuers';
 export { registerIdentity } from '~/api/procedures/registerIdentity';
+export { registerDid } from '~/api/procedures/registerDid';
 export { selfRegisterDid } from '~/api/procedures/selfRegisterDid';
 export { createChildIdentity } from '~/api/procedures/createChildIdentity';
 export { createChildIdentities } from '~/api/procedures/createChildIdentities';

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -181,6 +181,7 @@ export { setMultiSigAdmin } from '~/api/procedures/setMultiSigAdmin';
 export { setVenueFiltering } from '~/api/procedures/setVenueFiltering';
 export { registerCustomClaimType } from '~/api/procedures/registerCustomClaimType';
 export { toggleAssetPreApproval } from '~/api/procedures/toggleAssetPreApproval';
+export { togglePortfolioPreApproval } from '~/api/procedures/togglePortfolioPreApproval';
 export { setMandatoryReceiverAffirmation } from '~/api/procedures/setMandatoryReceiverAffirmation';
 export { allowIdentityToCreatePortfolios } from '~/api/procedures/allowIdentityToCreatePortfolios';
 export { revokeIdentityToCreatePortfolios } from '~/api/procedures/revokeIdentityToCreatePortfolios';

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -441,7 +441,8 @@ let errorMock: jest.Mock;
 type StatusCallback = (receipt: ISubmittableResult) => void;
 
 interface TxMockData {
-  statusCallback: StatusCallback;
+  // not set when the transaction was submitted via the promise (no callback) form of `signAndSend`
+  statusCallback?: StatusCallback;
   unsubCallback: UnsubCallback;
   status: MockTxStatus;
   resolved: boolean;
@@ -1387,7 +1388,7 @@ export function createTxMock<
     meta = { args: [] },
   } = opts;
 
-  const mockHandleSend = (cb: StatusCallback): Promise<unknown> => {
+  const mockHandleSend = (cb?: StatusCallback): Promise<unknown> => {
     if (autoResolve === MockTxStatus.Rejected) {
       return Promise.reject(new Error('Cancelled'));
     }
@@ -1402,11 +1403,12 @@ export function createTxMock<
       status: null as unknown as MockTxStatus,
     });
 
-    if (autoResolve) {
+    if (autoResolve && cb) {
       process.nextTick(() => cb(statusToReceipt(autoResolve)));
     }
 
-    return new Promise(resolve => setImmediate(() => resolve(unsubCallback)));
+    // when no status callback is passed (promise form), `signAndSend` resolves with the submitted tx hash
+    return new Promise(resolve => setImmediate(() => resolve(cb ? unsubCallback : tx)));
   };
 
   const mockSend = jest.fn().mockImplementation((cb: StatusCallback) => {
@@ -1801,7 +1803,7 @@ export function updateTxStatus<
     });
   }
 
-  txMockData.statusCallback(statusToReceipt(status, failReason));
+  txMockData.statusCallback?.(statusToReceipt(status, failReason));
 }
 
 /**

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -136,6 +136,7 @@ import {
   PolymeshPrimitivesSettlementInstruction,
   PolymeshPrimitivesSettlementInstructionStatus,
   PolymeshPrimitivesSettlementLeg,
+  PolymeshPrimitivesSettlementLegStatus,
   PolymeshPrimitivesSettlementMediatorAffirmationStatus,
   PolymeshPrimitivesSettlementSettlementType,
   PolymeshPrimitivesSettlementVenueType,
@@ -3490,6 +3491,16 @@ export const createMockAffirmationStatus = (
   authorizationStatus?: 'Unknown' | 'Pending' | 'Affirmed'
 ): MockCodec<PolymeshPrimitivesSettlementAffirmationStatus> => {
   return createMockEnum<PolymeshPrimitivesSettlementAffirmationStatus>(authorizationStatus);
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
+export const createMockLegStatus = (
+  legStatus?: 'PendingTokenLock' | 'ExecutionPending' | { ExecutionToBeSkipped: [AccountId, u64] }
+): MockCodec<PolymeshPrimitivesSettlementLegStatus> => {
+  return createMockEnum<PolymeshPrimitivesSettlementLegStatus>(legStatus);
 };
 
 /**

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -450,7 +450,7 @@ interface TxMockData {
 interface ContextOptions {
   did?: string;
   withSigningManager?: boolean;
-  balance?: AccountBalance;
+  balance?: Partial<AccountBalance>;
   subsidy?: SubsidyWithAllowance;
   hasRoles?: boolean;
   checkRoles?: CheckRolesResult;
@@ -704,6 +704,8 @@ const defaultContextOptions: ContextOptions = {
     free: new BigNumber(100),
     locked: new BigNumber(10),
     total: new BigNumber(110),
+    reserved: new BigNumber(0),
+    frozen: new BigNumber(0),
   },
   hasRoles: true,
   checkRoles: {
@@ -1844,7 +1846,7 @@ export function throwOnApiCreation(error?: unknown): void {
  *
  * @param balance - new account balance
  */
-export function setContextAccountBalance(balance: AccountBalance): void {
+export function setContextAccountBalance(balance: Partial<AccountBalance>): void {
   mockInstanceContainer.contextInstance.accountBalance.mockResolvedValue(balance as any);
 }
 

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -279,6 +279,7 @@ interface NumberedPortfolioOptions extends EntityOptions {
   getCollections?: EntityGetter<PortfolioCollection[]>;
   getCustodian?: EntityGetter<Identity>;
   isCustodiedBy?: EntityGetter<boolean>;
+  isAssetPreApproved?: EntityGetter<boolean>;
 }
 
 interface DefaultPortfolioOptions extends EntityOptions {
@@ -288,6 +289,7 @@ interface DefaultPortfolioOptions extends EntityOptions {
   getCollections?: EntityGetter<PortfolioCollection[]>;
   getCustodian?: EntityGetter<Identity>;
   isCustodiedBy?: EntityGetter<boolean>;
+  isAssetPreApproved?: EntityGetter<boolean>;
 }
 
 interface CustomPermissionGroupOptions extends EntityOptions {
@@ -1649,6 +1651,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
     getCollections!: jest.Mock;
     getCustodian!: jest.Mock;
     isCustodiedBy!: jest.Mock;
+    isAssetPreApproved!: jest.Mock;
 
     /**
      * @hidden
@@ -1669,6 +1672,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
       this.getCollections = createEntityGetterMock(opts.getCollections);
       this.getCustodian = createEntityGetterMock(opts.getCustodian);
       this.isCustodiedBy = createEntityGetterMock(opts.isCustodiedBy);
+      this.isAssetPreApproved = createEntityGetterMock(opts.isAssetPreApproved);
     }
   },
   () => ({
@@ -1686,6 +1690,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
     did: 'someDid',
     getCustodian: getIdentityInstance(),
     isCustodiedBy: true,
+    isAssetPreApproved: false,
     toHuman: {
       did: 'someDid',
       id: '1',
@@ -1703,6 +1708,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
     getCollections!: jest.Mock;
     getCustodian!: jest.Mock;
     isCustodiedBy!: jest.Mock;
+    isAssetPreApproved!: jest.Mock;
 
     /**
      * @hidden
@@ -1722,6 +1728,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
       this.getCollections = createEntityGetterMock(opts.getCollections);
       this.getCustodian = createEntityGetterMock(opts.getCustodian);
       this.isCustodiedBy = createEntityGetterMock(opts.isCustodiedBy);
+      this.isAssetPreApproved = createEntityGetterMock(opts.isAssetPreApproved);
     }
   },
   () => ({
@@ -1738,6 +1745,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
     did: 'someDid',
     getCustodian: getIdentityInstance(),
     isCustodiedBy: true,
+    isAssetPreApproved: false,
     toHuman: {
       did: 'someDid',
     },

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -243,7 +243,7 @@ interface AccountOptions extends EntityOptions {
   address?: string;
   key?: string;
   isFrozen?: EntityGetter<boolean>;
-  getBalance?: EntityGetter<AccountBalance>;
+  getBalance?: EntityGetter<Partial<AccountBalance>>;
   getIdentity?: EntityGetter<Identity | null>;
   getTransactionHistory?: EntityGetter<ExtrinsicData[]>;
   hasPermissions?: EntityGetter<boolean>;
@@ -914,6 +914,8 @@ const MockAccountClass = createMockEntityClass<AccountOptions>(
       free: new BigNumber(100),
       locked: new BigNumber(10),
       total: new BigNumber(110),
+      reserved: new BigNumber(0),
+      frozen: new BigNumber(0),
     },
     getTransactionHistory: [],
     getIdentity: getIdentityInstance(),
@@ -2212,6 +2214,8 @@ const MockMultiSigClass = createMockEntityClass<MultiSigOptions>(
       free: new BigNumber(100),
       locked: new BigNumber(10),
       total: new BigNumber(110),
+      reserved: new BigNumber(0),
+      frozen: new BigNumber(0),
     },
     getTransactionHistory: [],
     getIdentity: getIdentityInstance(),

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -12014,12 +12014,14 @@ describe('signatureToMeshRuntimeMultiSignature', () => {
 
     const signature = 'someSignature';
 
-    const fakeSignature = 'fakeSignature' as unknown as U8aFixed;
+    const fakeEcdsaSignature = 'fakeEcdsaSignature' as unknown as U8aFixed;
+    const fakeOtherSignature = 'fakeOtherSignature' as unknown as U8aFixed;
 
-    when(context.createType).calledWith('U8aFixed', signature).mockReturnValue(fakeSignature);
+    when(context.createType).calledWith('[u8;65]', signature).mockReturnValue(fakeEcdsaSignature);
+    when(context.createType).calledWith('[u8;64]', signature).mockReturnValue(fakeOtherSignature);
 
     when(context.createType)
-      .calledWith('SpRuntimeMultiSignature', { Ecdsa: fakeSignature })
+      .calledWith('SpRuntimeMultiSignature', { Ecdsa: fakeEcdsaSignature })
       .mockReturnValue(fakeResult);
 
     let result = signatureToMeshRuntimeMultiSignature(SignerKeyRingType.Ecdsa, signature, context);
@@ -12027,7 +12029,7 @@ describe('signatureToMeshRuntimeMultiSignature', () => {
     expect(result).toEqual(fakeResult);
 
     when(context.createType)
-      .calledWith('SpRuntimeMultiSignature', { Ed25519: fakeSignature })
+      .calledWith('SpRuntimeMultiSignature', { Ed25519: fakeOtherSignature })
       .mockReturnValue(fakeResult);
 
     result = signatureToMeshRuntimeMultiSignature(SignerKeyRingType.Ed25519, signature, context);
@@ -12035,7 +12037,7 @@ describe('signatureToMeshRuntimeMultiSignature', () => {
     expect(result).toEqual(fakeResult);
 
     when(context.createType)
-      .calledWith('SpRuntimeMultiSignature', { Sr25519: fakeSignature })
+      .calledWith('SpRuntimeMultiSignature', { Sr25519: fakeOtherSignature })
       .mockReturnValue(fakeResult);
 
     result = signatureToMeshRuntimeMultiSignature(SignerKeyRingType.Sr25519, signature, context);
@@ -12150,8 +12152,8 @@ describe('receiptDetailsToMeshReceiptDetails', () => {
     dsMockUtils.cleanup();
   });
 
-  it('should create receipt details', () => {
-    const context = dsMockUtils.getContextInstance();
+  it('should create receipt details on a v7 chain without expiresAt', () => {
+    const context = dsMockUtils.getContextInstance({ isV7: true });
     const instructionId = new BigNumber(1);
     const receipt: OffChainAffirmationReceipt = {
       uid: new BigNumber(1),
@@ -12189,6 +12191,69 @@ describe('receiptDetailsToMeshReceiptDetails', () => {
     const result = receiptDetailsToMeshReceiptDetails([receipt], instructionId, context);
 
     expect(result).toEqual(fakeResult);
+  });
+
+  it('should create receipt details on a v8 chain with expiresAt forwarded', () => {
+    const context = dsMockUtils.getContextInstance({ isV7: false });
+    const instructionId = new BigNumber(1);
+    const expiresAt = new Date('2030/01/01');
+    const receipt: OffChainAffirmationReceipt = {
+      uid: new BigNumber(1),
+      legId: new BigNumber(0),
+      signer: '5EYCAe5ijAx5xEfZdpCna3grUpY1M9M5vLUH5vpmwV1EnaYR',
+      signature: {
+        type: SignerKeyRingType.Sr25519,
+        value: '0xsomevalue',
+      },
+      metadata: 'Random metadata',
+      expiresAt,
+    };
+    const fakeKey = 'fakeKey' as unknown as PolymeshPrimitivesSettlementReceiptDetails;
+    const fakeResult =
+      'fakeMetadataKeys' as unknown as Vec<PolymeshPrimitivesSettlementReceiptDetails>;
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesSettlementReceiptDetails', {
+        uid: bigNumberToU64(receipt.uid, context),
+        instructionId: bigNumberToU64(instructionId, context),
+        legId: bigNumberToU64(receipt.legId, context),
+        signer: stringToAccountId(receipt.signer as string, context),
+        signature: signatureToMeshRuntimeMultiSignature(
+          receipt.signature.type,
+          receipt.signature.value,
+          context
+        ),
+        expiresAt: dateToMoment(expiresAt, context),
+        metadata: offChainMetadataToMeshReceiptMetadata(receipt.metadata as string, context),
+      })
+      .mockReturnValue(fakeKey);
+
+    when(context.createType)
+      .calledWith('Vec<PolymeshPrimitivesSettlementReceiptDetails>', [fakeKey])
+      .mockReturnValue(fakeResult);
+
+    const result = receiptDetailsToMeshReceiptDetails([receipt], instructionId, context);
+
+    expect(result).toEqual(fakeResult);
+  });
+
+  it('should throw an error if expiresAt is missing on a v8 chain', () => {
+    const context = dsMockUtils.getContextInstance({ isV7: false });
+    const instructionId = new BigNumber(1);
+    const receipt: OffChainAffirmationReceipt = {
+      uid: new BigNumber(1),
+      legId: new BigNumber(0),
+      signer: '5EYCAe5ijAx5xEfZdpCna3grUpY1M9M5vLUH5vpmwV1EnaYR',
+      signature: {
+        type: SignerKeyRingType.Sr25519,
+        value: '0xsomevalue',
+      },
+      metadata: 'Random metadata',
+    };
+
+    expect(() => receiptDetailsToMeshReceiptDetails([receipt], instructionId, context)).toThrow(
+      '`expiresAt` is mandatory from chain 8.x'
+    );
   });
 });
 

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -162,6 +162,7 @@ import {
   KnownAssetType,
   KnownNftType,
   Leg,
+  LegStatusType,
   MetadataLockStatus,
   MetadataType,
   ModuleName,
@@ -318,6 +319,7 @@ import {
   meshCorporateBallotMetaToCorporateBallotMeta,
   meshCorporateBallotMotionToCorporateBallotMotion,
   meshInstructionStatusToInstructionStatus,
+  meshLegStatusToLegStatus,
   meshMetadataKeyToMetadataKey,
   meshMetadataSpecToMetadataSpec,
   meshMetadataValueToMetadataValue,
@@ -7232,6 +7234,54 @@ describe('meshAffirmationStatusToAffirmationStatus', () => {
 
     result = meshAffirmationStatusToAffirmationStatus(authorizationStatus);
     expect(result).toEqual(fakeResult);
+  });
+});
+
+describe('meshLegStatusToLegStatus', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  it('should convert a polkadot LegStatus object to a LegStatus', () => {
+    const context = dsMockUtils.getContextInstance();
+
+    let legStatus = dsMockUtils.createMockLegStatus('PendingTokenLock');
+
+    let result = meshLegStatusToLegStatus(legStatus, context);
+    expect(result).toEqual({ type: LegStatusType.PendingTokenLock });
+
+    legStatus = dsMockUtils.createMockLegStatus('ExecutionPending');
+
+    result = meshLegStatusToLegStatus(legStatus, context);
+    expect(result).toEqual({ type: LegStatusType.ExecutionPending });
+
+    const address = DUMMY_ACCOUNT_ID;
+    const uid = new BigNumber(10);
+
+    legStatus = dsMockUtils.createMockLegStatus({
+      ExecutionToBeSkipped: [
+        dsMockUtils.createMockAccountId(address),
+        dsMockUtils.createMockU64(uid),
+      ],
+    });
+
+    result = meshLegStatusToLegStatus(legStatus, context);
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: LegStatusType.ExecutionToBeSkipped,
+        uid,
+      })
+    );
+    expect((result as { signer: Account }).signer).toBeInstanceOf(Account);
+    expect((result as { signer: Account }).signer.address).toBe(address);
   });
 });
 

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -98,6 +98,7 @@ import {
   assertMetaLength,
   assertNoPendingAuthorizationExists,
   assertStatIsSet,
+  assertTickerLengthValid,
   assertTickerValid,
   calculateNextKey,
   calculateRawStakingPayee,
@@ -1789,6 +1790,52 @@ describe('assertTickerValid', () => {
     const ticker = 'FAKE_TICKER';
 
     expect(() => assertTickerValid(ticker)).not.toThrow();
+  });
+});
+
+describe('assertTickerLengthValid', () => {
+  it('should throw an error if the ticker length exceeds the chain configured max ticker length', async () => {
+    const context = dsMockUtils.getContextInstance();
+    const maxTickerLength = new BigNumber(6);
+
+    dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+      returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+        maxTickerLength: dsMockUtils.createMockU8(maxTickerLength),
+        registrationLength: dsMockUtils.createMockOption(),
+      }),
+    });
+
+    await expect(assertTickerLengthValid('TOO_LONG', context)).rejects.toThrow(
+      `Ticker length must be between 1 and ${maxTickerLength.toString()} characters`
+    );
+  });
+
+  it('should throw an error if the ticker is empty', async () => {
+    const context = dsMockUtils.getContextInstance();
+
+    dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+      returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+        maxTickerLength: dsMockUtils.createMockU8(new BigNumber(12)),
+        registrationLength: dsMockUtils.createMockOption(),
+      }),
+    });
+
+    await expect(assertTickerLengthValid('', context)).rejects.toThrow(
+      'Ticker length must be between 1 and 12 characters'
+    );
+  });
+
+  it('should not throw an error if the ticker length is within the chain configured max ticker length', async () => {
+    const context = dsMockUtils.getContextInstance();
+
+    dsMockUtils.createQueryMock('asset', 'tickerConfig', {
+      returnValue: dsMockUtils.createMockTickerRegistrationConfig({
+        maxTickerLength: dsMockUtils.createMockU8(new BigNumber(12)),
+        registrationLength: dsMockUtils.createMockOption(),
+      }),
+    });
+
+    await expect(assertTickerLengthValid('FAKE_TICKER', context)).resolves.not.toThrow();
   });
 });
 

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -78,6 +78,7 @@ import {
   PolymeshPrimitivesSettlementAssetCount,
   PolymeshPrimitivesSettlementInstructionStatus,
   PolymeshPrimitivesSettlementLeg,
+  PolymeshPrimitivesSettlementLegStatus,
   PolymeshPrimitivesSettlementMediatorAffirmationStatus,
   PolymeshPrimitivesSettlementReceiptDetails,
   PolymeshPrimitivesSettlementReceiptMetadata,
@@ -252,6 +253,8 @@ import {
   KnownAssetType,
   KnownNftType,
   Leg,
+  LegStatus,
+  LegStatusType,
   MediatorAffirmation,
   MetadataKeyId,
   MetadataLockStatus,
@@ -3410,6 +3413,30 @@ export function meshAffirmationStatusToAffirmationStatus(
   }
 
   return AffirmationStatus.Affirmed;
+}
+
+/**
+ * @hidden
+ */
+export function meshLegStatusToLegStatus(
+  status: PolymeshPrimitivesSettlementLegStatus,
+  context: Context
+): LegStatus {
+  if (status.isPendingTokenLock) {
+    return { type: LegStatusType.PendingTokenLock };
+  }
+
+  if (status.isExecutionPending) {
+    return { type: LegStatusType.ExecutionPending };
+  }
+
+  const [rawSigner, rawUid] = status.asExecutionToBeSkipped;
+
+  return {
+    type: LegStatusType.ExecutionToBeSkipped,
+    signer: new Account({ address: accountIdToString(rawSigner) }, context),
+    uid: u64ToBigNumber(rawUid),
+  };
 }
 
 /**

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -5726,8 +5726,13 @@ export function signatureToMeshRuntimeMultiSignature(
       // assume sr 25519
       rawValue = context.createType('SpCoreSr25519Signature', value);
     }
+  } else if (type === SignerKeyRingType.Ecdsa) {
+    // Ecdsa signatures are 65 bytes (64 byte signature + 1 byte recovery ID)
+    rawValue = context.createType('[u8;65]', value);
   } else {
-    rawValue = context.createType('U8aFixed', value);
+    // Ed25519 and Sr25519 signatures are both 64 bytes. A bare 'U8aFixed' does
+    // not resolve against chain v8's metadata-derived type registry.
+    rawValue = context.createType('[u8;64]', value);
   }
 
   return context.createType('SpRuntimeMultiSignature', {
@@ -5767,18 +5772,28 @@ export function receiptDetailsToMeshReceiptDetails(
   context: Context
 ): Vec<PolymeshPrimitivesSettlementReceiptDetails> {
   const rawInstructionId = bigNumberToU64(instructionId, context);
-  const rawReceiptDetails = receiptDetails.map(({ legId, uid, signer, signature, metadata }) => {
-    const { address: signerAddress } = asAccount(signer, context);
+  const rawReceiptDetails = receiptDetails.map(
+    ({ legId, uid, signer, signature, metadata, expiresAt }) => {
+      const { address: signerAddress } = asAccount(signer, context);
 
-    return context.createType('PolymeshPrimitivesSettlementReceiptDetails', {
-      uid: bigNumberToU64(uid, context),
-      instructionId: rawInstructionId,
-      legId: bigNumberToU64(legId, context),
-      signer: stringToAccountId(signerAddress, context),
-      signature: signatureToMeshRuntimeMultiSignature(signature.type, signature.value, context),
-      metadata: optionize(offChainMetadataToMeshReceiptMetadata)(metadata, context),
-    });
-  });
+      if (!expiresAt && !context.isV7) {
+        throw new PolymeshError({
+          code: ErrorCode.UnmetPrerequisite,
+          message: '`expiresAt` is mandatory from chain 8.x',
+        });
+      }
+
+      return context.createType('PolymeshPrimitivesSettlementReceiptDetails', {
+        uid: bigNumberToU64(uid, context),
+        instructionId: rawInstructionId,
+        legId: bigNumberToU64(legId, context),
+        signer: stringToAccountId(signerAddress, context),
+        signature: signatureToMeshRuntimeMultiSignature(signature.type, signature.value, context),
+        ...(!context.isV7 && { expiresAt: dateToMoment(expiresAt!, context) }),
+        metadata: optionize(offChainMetadataToMeshReceiptMetadata)(metadata, context),
+      });
+    }
+  );
 
   return context.createType('Vec<PolymeshPrimitivesSettlementReceiptDetails>', rawReceiptDetails);
 }

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -134,6 +134,7 @@ import {
   stringToTicker,
   tickerToString,
   transferRestrictionTypeToStatOpType,
+  u8ToBigNumber,
   u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -997,6 +998,36 @@ export function assertTickerValid(ticker: string): void {
     throw new PolymeshError({
       code: ErrorCode.ValidationError,
       message: 'Ticker cannot contain lower case letters',
+    });
+  }
+}
+
+/**
+ * @hidden
+ *
+ * Validates a ticker's length against the chain's current ticker registration rules.
+ *
+ * @note this is distinct from {@link assertTickerValid}, which enforces the fixed 12 byte
+ *   width of the on chain `Ticker` type. `maxTickerLength` is a separate, governance
+ *   configurable ceiling (never greater than 12) used to validate new ticker registrations
+ */
+export async function assertTickerLengthValid(ticker: string, context: Context): Promise<void> {
+  const {
+    polymeshApi: {
+      query: {
+        asset: { tickerConfig },
+      },
+    },
+  } = context;
+
+  const { maxTickerLength: rawMaxTickerLength } = await tickerConfig();
+  const maxTickerLength = u8ToBigNumber(rawMaxTickerLength);
+
+  if (!ticker.length || maxTickerLength.lt(ticker.length)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: `Ticker length must be between 1 and ${maxTickerLength.toString()} characters`,
+      data: { maxTickerLength },
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5840,30 +5840,30 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -8270,9 +8270,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.3
-  resolution: "fast-uri@npm:3.1.3"
-  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
   languageName: node
   linkType: hard
 
@@ -9599,9 +9599,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 
@@ -11043,7 +11043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"launch-editor@npm:^2.6.1":
+"launch-editor@npm:^2.14.1":
   version: 2.14.1
   resolution: "launch-editor@npm:2.14.1"
   dependencies:
@@ -11210,11 +11210,11 @@ __metadata:
   linkType: hard
 
 "linkify-it@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "linkify-it@npm:5.0.1"
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: "npm:^2.0.0"
-  checksum: 10c0/d06d04f1ed03be131740fc900a5e74ea1f49886b052213599e306d469d5ffe2303db76dd8f771de9f28e2b0b38852de22ec46ae597d245f8b66439b0ceb19b10
+  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
   languageName: node
   linkType: hard
 
@@ -16113,16 +16113,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.23.0, undici@npm:^6.25.0":
-  version: 6.27.0
-  resolution: "undici@npm:6.27.0"
-  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10c0/3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
   languageName: node
   linkType: hard
 
 "undici@npm:^7.0.0":
-  version: 7.28.0
-  resolution: "undici@npm:7.28.0"
-  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
   languageName: node
   linkType: hard
 
@@ -16457,8 +16457,8 @@ __metadata:
   linkType: hard
 
 "webpack-dev-server@npm:^5.2.1":
-  version: 5.2.5
-  resolution: "webpack-dev-server@npm:5.2.5"
+  version: 5.2.6
+  resolution: "webpack-dev-server@npm:5.2.6"
   dependencies:
     "@types/bonjour": "npm:^3.5.13"
     "@types/connect-history-api-fallback": "npm:^1.5.4"
@@ -16478,7 +16478,7 @@ __metadata:
     graceful-fs: "npm:^4.2.6"
     http-proxy-middleware: "npm:^2.0.9"
     ipaddr.js: "npm:^2.1.0"
-    launch-editor: "npm:^2.6.1"
+    launch-editor: "npm:^2.14.1"
     open: "npm:^10.0.3"
     p-retry: "npm:^6.2.0"
     schema-utils: "npm:^4.2.0"
@@ -16497,7 +16497,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 10c0/8963b3533197ebd820456f3cb14d9234ba4dff10412eb11200b8099c501559abf7a700e9a5d4136f17929374b61c1af5c6ef597471ea45b97ba6ca69a12e5ca8
+  checksum: 10c0/8240a52d7eee2ca156a708f1533236e24dae9ebd0794fb17c98cfd77804e2384d9b402e8778d6453e53542a8e99647335f0002e319ac6b9d13aa6ff1b4f4bf5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This release bundles several new read/write capabilities for settlements, portfolios, tickers, and DID registration, plus two chain-v8 correctness fixes and a dependency bump.

**New features**

- **`registerDid` procedure** (`src/api/procedures/registerDid.ts`) — implements the v8-only `identity.registerDid` extrinsic, letting an active DID Registrar register a DID for someone else's account. Complements the existing permissionless `selfRegisterDid` and the deprecated `registerIdentity`/`cddRegisterDid` (which no longer attaches a CDD claim as of v8). Throws `NotSupported` on v7 chains and `NoDataChange` if the target account already has an identity.
- **Portfolio-level asset pre-approval** (`src/api/entities/Portfolio/index.ts`) — new `preApproveAsset` / `removeAssetPreApproval` procedure methods and an `isAssetPreApproved` check, mirroring the existing Identity-level pre-approval. Lets a Portfolio auto-affirm incoming transfers of a specific asset without a manual affirm step.
- **`Portfolio.preApprovedAssets` getter** — lists all assets a Portfolio has pre-approved, paginated over the `preApprovedPortfolios` storage, mirroring `Identity.preApprovedAssets`.
- **Instruction/Venue settlement getters** (`src/api/entities/Instruction/index.ts`, `src/api/entities/Venue/index.ts`) — `Instruction.getLegStatus({ legId })` returns the execution status of a specific leg; `Venue.getSignerCount()` returns the number of signers allowed by the venue.
- **`unlockInstructionForExecution`** (`src/api/entities/Instruction/index.ts`) — `Instruction.unlockForExecution` moves a `LockedForExecution` instruction back to `Pending`, and `Instruction.getRelockStatus` exposes the mediator's last unlock timestamp, relock count, and the on-chain relock cooldown window — completing the lock/relock flow that `lockForExecution` alone couldn't finish.
- **Ticker length validation against live chain config** (`src/api/procedures/utils.ts`) — `reserveTicker`, `createAsset`, and `createNftCollection` now validate the ticker length against the chain's live `TickerConfig` (`assertTickerLengthValid`) instead of a hardcoded constant.
- **`BaseAsset.getIssuedInFundingRound(fundingRound)`** — returns the total amount of an asset issued in a given funding round.
- **`Assets.getTickerRegistrationConfig()`** — returns the chain-wide `maxTickerLength` / `registrationLength` rules used to validate ticker registrations.

**Bug fixes**

- **v8 off-chain settlement receipt expiry & encoding** (`src/base/PolymeshTransactionBase.ts`) — `expiresAt` is now forwarded into the returned `OffChainAffirmationReceipt` and the raw on-chain receipt (previously computed/signed but dropped before reaching `affirmWithReceipts(WithCount)`); the v8 signed payload now includes `genesis_hash` and a length-prefixed receipt label to match the runtime's `ChainScopedMessage` encoding; fixed byte order (little-endian) of the signed `expiresAt`; and `signatureToMeshRuntimeMultiSignature` now uses correctly sized `[u8;64]`/`[u8;65]` arrays instead of a bare `U8aFixed`, which failed to resolve against a v8 chain's metadata registry.
- **v8 POLYX balance calculation** — corrected for accounts with staked/held funds; `free` now follows `chain free - max(frozen - reserved, existential deposit)` (clamped at zero) instead of the pre-v8 `free - frozen`, which produced negative balances for staking accounts. `AccountBalance` gains `reserved` and `frozen` fields; `locked` now equals `total - free` and correctly includes `reserved` funds (previously only reflected `frozen`), so staking accounts will report a larger `locked` value than before — this is the correct v8 semantics, not a regression.
- **Signers that return a signed transaction (Ledger generic app)** — the SDK now passes `withSignedTransaction: true` when signing so wallets that rebuild and return the extrinsic (required by `CheckMetadataHash` on the Polkadot Generic Ledger app) are accepted; `allowCallDataAlteration: false` still guards against a signer altering the call itself; `txHash` now tracks the hash of the extrinsic actually submitted, not the one the SDK originally composed.

**Chore**

- Bumped `undici`, `ip-address`, `brace-expansion`, `fast-uri`, `linkify-it`, and `webpack-dev-server` (with `launch-editor`'s descriptor moving in step) within existing `package.json` ranges to satisfy open Dependabot PRs.

**Docs**

- Added `changelogs/v30.0.0-v30.1.0.md` (v30.0.0 → v30.1.0, already released).
- Added `changelogs/v30.1.0-v30.2.0.md` covering every feature and fix in this PR, in released-changelog format (includes the version compatibility matrix).

### Breaking Changes

None. All changes are additive or corrective; existing consumers are unaffected except for the noted `AccountBalance.locked` value change (a correction, not an API shape change).

### JIRA Link

<!-- insert ticket -->

### Checklist

- [x] Updated the Readme.md (if required) — N/A, covered by `changelogs/v30.1.0-v30.2.0.md`