### PR TITLE
feat: 🎸 allow transferFunds between asset holders on different DIDs

### DIFF
--- a/.github/workflows/authenticate-commits.yml
+++ b/.github/workflows/authenticate-commits.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch (e.g. feat branch)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # needed for full branch context
 
@@ -66,7 +66,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22.x'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,10 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22.x'
       - name: install dependencies
@@ -24,7 +24,7 @@ jobs:
           yarn build:docs
           yarn build:sdk-docs
       - name: determine branch name
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         id: setBranch
         with:
           script: |
@@ -59,10 +59,10 @@ jobs:
     name: Readme
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22.x'
       - name: install dependencies

--- a/.github/workflows/generate-next-preview.yml
+++ b/.github/workflows/generate-next-preview.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -413,7 +413,7 @@ jobs:
 
       - name: Report release blocked due to conflicts
         if: steps.discovery.outputs.found == 'true' && steps.validation.outputs.all_clean == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -531,7 +531,7 @@ jobs:
 
       - name: Report stale branches
         if: steps.staleness.outputs.stale_found == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,10 +10,10 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22.x'
       - name: install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22.x"
       - name: install dependencies
@@ -29,10 +29,10 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22.x"
       - name: install dependencies
@@ -46,7 +46,7 @@ jobs:
           mv coverage/clover.xml coverage/clover-${{matrix.shard}}.xml
           mv coverage/lcov.info coverage/lcov-${{matrix.shard}}.info
           mv coverage/coverage-final.json coverage/coverage-${{matrix.shard}}.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: coverage-artifacts-${{ matrix.shard }}-${{ strategy.job-index }}
           path: coverage/
@@ -56,8 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: coverage-artifacts-*
           merge-multiple: true
@@ -85,10 +85,10 @@ jobs:
       pull-requests: write # @semantic-release/github comments on merged PRs
       id-token: write # OIDC token for npm trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22.x"
       - name: install dependencies

--- a/.github/workflows/validate-bc-branches.yml
+++ b/.github/workflows/validate-bc-branches.yml
@@ -90,7 +90,7 @@ jobs:
           fi
 
       - name: Check for number conflicts
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/changelogs/v30.2.0-next.md
+++ b/changelogs/v30.2.0-next.md
@@ -71,6 +71,7 @@ Use this checklist when upgrading from v30.2.0.
 8. Update any code matching on the changed error message strings (see [Error message changes](#7-error-message-changes))
 9. Migrate from `TxGroup.CddRegistration` to `TxGroup.DidRegistration` (see [Deprecated APIs](#deprecated-apis))
 10. Remove usage of `ScopeClaimProof`, `AddInvestorUniquenessClaimParams`, `ModifyPrimaryIssuanceAgentParams` and `ModifyCorporateActionsAgentParams` (see [Removed types describing extrinsics that no longer exist](#8-removed-types-describing-extrinsics-that-no-longer-exist))
+11. Update any code that types `Assets.transferFunds`'s result as `void` (see [`Assets.transferFunds` return type changed](#9-assetstransferfunds-return-type-changed))
 
 ---
 
@@ -228,6 +229,15 @@ The `modifyCorporateActionsAgent` procedure is removed alongside them. Its only 
 
 In `testUtils`, the three Asset entity mocks no longer default a `primaryIssuanceAgents: []` field. `AssetDetails` has no such field, so the default was never read — but a test asserting on a whole mock object with `toEqual` will need it dropped from the expectation.
 
+### 9. `Assets.transferFunds` return type changed
+
+`Assets.transferFunds` now resolves to `Instruction | undefined` instead of `void`, reflecting that the underlying `settlement.transferFunds` extrinsic can leave a pending settlement instruction rather than always settling immediately (see [Cross-identity `Assets.transferFunds`](#cross-identity-assetstransferfunds) below).
+
+- `undefined` — the transfer settled immediately, exactly as before (same-DID transfer, or the receiving Identity has automatic affirmation and settled in the same transaction).
+- an `Instruction` — the transfer created a settlement instruction that is still `Pending` the receiving Identity's affirmation.
+
+Code that calls `transferFunds` and ignores the result is unaffected. Code that types the result as `void` (e.g. an explicitly annotated intermediate variable) needs updating.
+
 ---
 
 ## Deprecated APIs
@@ -261,6 +271,26 @@ These paths previously branched on `context.isV7` and are now unconditional:
 ---
 
 ## New features
+
+### Cross-identity `Assets.transferFunds`
+
+`Assets.transferFunds` no longer requires `from` and `to` to belong to the same Identity. The underlying `settlement.transferFunds` extrinsic already supports this on chain: it authorizes the source (allowance for an `Account`, custody for a `Portfolio`), creates a settlement instruction, and auto-affirms it on behalf of the sender. If the receiving Identity has automatic affirmation (the default), the instruction settles immediately in the same transaction. Otherwise it's left `Pending`, awaiting the receiver's separate affirmation via the normal `Instruction.affirm()` flow.
+
+```typescript
+const result = await sdk.assets.transferFunds({
+  from: aliceDefaultPortfolio, // or an Account
+  to: bobDefaultPortfolio, // a different Identity's Portfolio or Account
+  asset,
+  amount: new BigNumber(100),
+});
+
+if (result) {
+  // a pending Instruction — bob must affirm before the transfer settles
+  await result.details(); // status: 'Pending'
+}
+```
+
+See [`Assets.transferFunds` return type changed](#9-assetstransferfunds-return-type-changed) for the accompanying return-type change.
 
 ### `Asset.checkpoints.schedules.getNextCheckpoint` getter
 

--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -7,6 +7,7 @@ import {
   createNftCollection,
   FungibleAsset,
   Identity,
+  Instruction,
   NftCollection,
   PolymeshError,
   registerCustomAssetType,
@@ -520,13 +521,13 @@ export class Assets {
   }
 
   /**
-   * Transfer funds between two asset holders (Account or Portfolio) owned by same identity.
+   * Transfer funds between two asset holders (Account or Portfolio), which may be owned by the same or different identities.
    *
    * @note When `from` account is of type account and the caller is the subsidizer of `from` account, there should be allowance available for transfer and for each transfer said amount is decremented.
    *
-   * @note To transfer between asset holders owned by separate DID use settlement instructions
+   * @note When `from` and `to` belong to different identities, this creates a settlement instruction that is immediately affirmed on behalf of `from`. If the caller's identity doesn't also own `to`, the instruction remains pending until the receiver affirms it (a resolved {@link api/entities/Instruction!Instruction | Instruction} is returned in that case). If both sides are affirmed, the transfer settles immediately and `undefined` is returned.
    */
-  public transferFunds: ProcedureMethod<TransferFundsParams, void>;
+  public transferFunds: ProcedureMethod<TransferFundsParams, Instruction | undefined>;
 
   /**
    * Gets the chain-wide rules used to validate ticker registrations

--- a/src/api/procedures/__tests__/addInstruction.ts
+++ b/src/api/procedures/__tests__/addInstruction.ts
@@ -1474,6 +1474,28 @@ describe('createAddInstructionResolver', () => {
     const result = createAddInstructionResolver(fakeContext)({} as ISubmittableResult);
 
     expect(result[0]!.id).toEqual(id);
+
+    expect(filterEventRecordsSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'settlement',
+      'InstructionCreated',
+      undefined
+    );
+  });
+
+  it('should forward skipError to filterEventRecords, returning an empty array when no event was emitted', () => {
+    filterEventRecordsSpy.mockReturnValue([]);
+    const fakeContext = {} as Context;
+
+    const result = createAddInstructionResolver(fakeContext, true)({} as ISubmittableResult);
+
+    expect(result).toEqual([]);
+    expect(filterEventRecordsSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'settlement',
+      'InstructionCreated',
+      true
+    );
   });
 });
 

--- a/src/api/procedures/__tests__/transferFunds.ts
+++ b/src/api/procedures/__tests__/transferFunds.ts
@@ -1,5 +1,7 @@
+import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
+import * as addInstructionModule from '~/api/procedures/addInstruction';
 import {
   getAuthorization,
   prepareStorage,
@@ -7,12 +9,18 @@ import {
   Storage,
 } from '~/api/procedures/transferFunds';
 import * as procedureUtilsModule from '~/api/procedures/utils';
-import { Account, Context, NumberedPortfolio } from '~/internal';
+import { Account, Context, Instruction, NumberedPortfolio } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import { PortfolioBalance, TransferFundsParams, TxTags } from '~/types';
+import { isResolverFunction, MaybeResolverFunction } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as typeguardsModule from '~/utils/typeguards';
+
+const callResolver = async (
+  resolver: MaybeResolverFunction<Instruction | undefined>
+): Promise<Instruction | undefined> =>
+  isResolverFunction(resolver) ? resolver({} as ISubmittableResult) : resolver;
 
 jest.mock(
   '~/api/entities/NumberedPortfolio',
@@ -51,6 +59,7 @@ describe('transferFunds procedure', () => {
   let nftMovementToPortfolioFundSpy: jest.SpyInstance;
   let getAssetHolderDidSpy: jest.SpyInstance;
   let isFungibleLegBuilderSpy: jest.SpyInstance;
+  let createAddInstructionResolverSpy: jest.SpyInstance;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -75,6 +84,10 @@ describe('transferFunds procedure', () => {
     nftMovementToPortfolioFundSpy = jest.spyOn(utilsConversionModule, 'nftMovementToPortfolioFund');
     getAssetHolderDidSpy = jest.spyOn(procedureUtilsModule, 'getAssetHolderDid');
     isFungibleLegBuilderSpy = jest.spyOn(typeguardsModule, 'isFungibleLegBuilder');
+    createAddInstructionResolverSpy = jest.spyOn(
+      addInstructionModule,
+      'createAddInstructionResolver'
+    );
   });
 
   beforeEach(() => {
@@ -120,7 +133,11 @@ describe('transferFunds procedure', () => {
     it('should throw an error if from and to asset holders are the same', async () => {
       fromPortfolioHolder.isEqual.mockReturnValue(true);
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'someDid',
@@ -141,7 +158,11 @@ describe('transferFunds procedure', () => {
       getAssetHolderDidSpy.mockReset();
       getAssetHolderDidSpy.mockResolvedValueOnce('someDid').mockResolvedValueOnce(undefined);
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'someDid',
@@ -158,31 +179,12 @@ describe('transferFunds procedure', () => {
       ).rejects.toThrow('Unable to retrieve the DID from one or both asset holders');
     });
 
-    it('should throw an error if DIDs are different', async () => {
-      getAssetHolderDidSpy.mockReset();
-      getAssetHolderDidSpy.mockResolvedValueOnce('someDid').mockResolvedValueOnce('otherDid');
-
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
-        fromHolder: fromPortfolioHolder,
-        toHolder: toPortfolioHolder,
-        signingDid: 'someDid',
-        signingAccount: 'someAccount',
-      });
-
-      await expect(
-        prepareTransferFunds.call(proc, {
-          from: fromPortfolioHolder,
-          to: toPortfolioHolder,
-          asset: 'SOME_ASSET',
-          amount: new BigNumber(100),
-        })
-      ).rejects.toThrow(
-        'For transferring funds between different DIDs, use `Settlements.addInstruction` method instead.'
-      );
-    });
-
     it('should throw an error if amount is less than or equal to 0 for a fungible leg', async () => {
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'someDid',
@@ -204,7 +206,11 @@ describe('transferFunds procedure', () => {
         { free: new BigNumber(50) } as PortfolioBalance,
       ]);
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'someDid',
@@ -224,7 +230,11 @@ describe('transferFunds procedure', () => {
     it('should throw an error if sender has no balance record for a fungible leg', async () => {
       fromPortfolioHolder.getAssetBalances.mockResolvedValue([]);
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'someDid',
@@ -241,11 +251,45 @@ describe('transferFunds procedure', () => {
       ).rejects.toThrow('Sender has insufficient balance to cover the transfer');
     });
 
+    it('should check the balance of a Portfolio source even when it belongs to a different DID than the signer (cross-DID custody transfer)', async () => {
+      // fromPortfolioHolder's DID ('someDid') differs from the signer's DID ('otherDid') -
+      // e.g. a custodian moving funds out of a portfolio they don't own
+      fromPortfolioHolder.getAssetBalances.mockResolvedValue([
+        { free: new BigNumber(50) } as PortfolioBalance,
+      ]);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        signingDid: 'otherDid',
+        signingAccount: 'someOtherAccount',
+      });
+
+      await expect(
+        prepareTransferFunds.call(proc, {
+          from: fromPortfolioHolder,
+          to: toPortfolioHolder,
+          asset: 'SOME_ASSET',
+          amount: new BigNumber(100),
+        })
+      ).rejects.toThrow('Sender has insufficient balance to cover the transfer');
+
+      expect(fromPortfolioHolder.getAssetBalances).toHaveBeenCalled();
+    });
+
     it('should throw an error if spender has insufficient allowance for a fungible leg', async () => {
       const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
       asset.getAllowance.mockResolvedValue(new BigNumber(50));
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromAccountHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'otherDid',
@@ -267,8 +311,14 @@ describe('transferFunds procedure', () => {
       asset.getAllowance.mockResolvedValue(new BigNumber(150));
 
       fungibleMovementToPortfolioFundSpy.mockResolvedValue('rawFund');
+      const instruction = { id: new BigNumber(1) } as Instruction;
+      createAddInstructionResolverSpy.mockReturnValue(() => [instruction]);
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromAccountHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'otherDid',
@@ -284,11 +334,10 @@ describe('transferFunds procedure', () => {
         amount: new BigNumber(100),
       });
 
-      expect(result).toEqual({
-        transaction,
-        args: ['someMeshAssetHolder', 'someMeshAssetHolder', 'rawFund'],
-        resolver: undefined,
-      });
+      expect(result.transaction).toBe(transaction);
+      expect(result.args).toEqual(['someMeshAssetHolder', 'someMeshAssetHolder', 'rawFund']);
+      await expect(callResolver(result.resolver)).resolves.toBe(instruction);
+      expect(createAddInstructionResolverSpy).toHaveBeenCalledWith(mockContext, true);
     });
 
     it('should return a transfer funds transaction spec for fungible assets', async () => {
@@ -301,8 +350,13 @@ describe('transferFunds procedure', () => {
       fungibleMovementToPortfolioFundSpy.mockResolvedValue('rawFund');
       assetHolderLikeToAssetHolderIdSpy.mockReturnValue('someHolderId');
       assetHolderIdToMeshAssetHolderSpy.mockReturnValue('rawHolder');
+      createAddInstructionResolverSpy.mockReturnValue(() => []);
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'someDid',
@@ -318,11 +372,9 @@ describe('transferFunds procedure', () => {
         amount: new BigNumber(100),
       });
 
-      expect(result).toEqual({
-        transaction,
-        args: ['rawHolder', 'rawHolder', 'rawFund'],
-        resolver: undefined,
-      });
+      expect(result.transaction).toBe(transaction);
+      expect(result.args).toEqual(['rawHolder', 'rawHolder', 'rawFund']);
+      await expect(callResolver(result.resolver)).resolves.toBeUndefined();
     });
 
     it('should return a transfer funds transaction spec for NFT assets', async () => {
@@ -332,8 +384,13 @@ describe('transferFunds procedure', () => {
       nftMovementToPortfolioFundSpy.mockResolvedValue('rawNftFund');
       assetHolderLikeToAssetHolderIdSpy.mockReturnValue('someHolderId');
       assetHolderIdToMeshAssetHolderSpy.mockReturnValue('rawHolder');
+      createAddInstructionResolverSpy.mockReturnValue(() => []);
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
         signingDid: 'someDid',
@@ -349,11 +406,49 @@ describe('transferFunds procedure', () => {
         nfts: [new BigNumber(1)],
       });
 
-      expect(result).toEqual({
-        transaction,
-        args: ['rawHolder', 'rawHolder', 'rawNftFund'],
-        resolver: undefined,
+      expect(result.transaction).toBe(transaction);
+      expect(result.args).toEqual(['rawHolder', 'rawHolder', 'rawNftFund']);
+    });
+
+    it('should return a transfer funds transaction spec for a cross-DID portfolio transfer, leaving the instruction pending', async () => {
+      const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
+
+      getAssetHolderDidSpy.mockReset();
+      getAssetHolderDidSpy.mockResolvedValueOnce('someDid').mockResolvedValueOnce('otherDid');
+
+      fromPortfolioHolder.getAssetBalances.mockResolvedValue([
+        { free: new BigNumber(150) } as PortfolioBalance,
+      ]);
+
+      fungibleMovementToPortfolioFundSpy.mockResolvedValue('rawFund');
+      assetHolderLikeToAssetHolderIdSpy.mockReturnValue('someHolderId');
+      assetHolderIdToMeshAssetHolderSpy.mockReturnValue('rawHolder');
+      const instruction = { id: new BigNumber(1) } as Instruction;
+      createAddInstructionResolverSpy.mockReturnValue(() => [instruction]);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
       });
+
+      const transaction = dsMockUtils.createTxMock('settlement', 'transferFunds');
+
+      const result = await prepareTransferFunds.call(proc, {
+        from: fromPortfolioHolder,
+        to: toPortfolioHolder,
+        asset,
+        amount: new BigNumber(100),
+      });
+
+      expect(result.transaction).toBe(transaction);
+      expect(result.args).toEqual(['rawHolder', 'rawHolder', 'rawFund']);
+      await expect(callResolver(result.resolver)).resolves.toBe(instruction);
     });
   });
 
@@ -370,7 +465,11 @@ describe('transferFunds procedure', () => {
 
       assetHolderLikeToAssetHolderSpy.mockReturnValueOnce(from).mockReturnValueOnce(to);
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext);
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext);
 
       const result = await prepareStorage.call(proc, {
         from,
@@ -389,14 +488,20 @@ describe('transferFunds procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return the appropriate roles and permissions', () => {
+    it('should return the appropriate roles and permissions, excluding an Account toHolder', async () => {
       const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
         did: 'someDid',
         id: new BigNumber(1),
       });
       const toHolder = entityMockUtils.getAccountInstance({ address: 'someAccount' });
 
-      const proc = procedureMockUtils.getInstance<TransferFundsParams, void, Storage>(mockContext, {
+      getAssetHolderDidSpy.mockResolvedValue('someDid');
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
         fromHolder,
         toHolder,
         signingDid: 'someDid',
@@ -405,10 +510,78 @@ describe('transferFunds procedure', () => {
 
       const boundFunc = getAuthorization.bind(proc);
 
-      expect(boundFunc()).toEqual({
+      await expect(boundFunc()).resolves.toEqual({
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
           portfolios: [fromHolder],
+          assets: [],
+        },
+      });
+    });
+
+    it('should exclude a Portfolio toHolder owned by a different DID than the signer', async () => {
+      const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'someDid',
+        id: new BigNumber(1),
+      });
+      const toHolder = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'otherDid',
+        id: new BigNumber(2),
+      });
+
+      getAssetHolderDidSpy.mockResolvedValue('otherDid');
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder,
+        toHolder,
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      const boundFunc = getAuthorization.bind(proc);
+
+      await expect(boundFunc()).resolves.toEqual({
+        permissions: {
+          transactions: [TxTags.settlement.TransferFunds],
+          portfolios: [fromHolder],
+          assets: [],
+        },
+      });
+    });
+
+    it('should include a Portfolio toHolder owned by the same DID as the signer', async () => {
+      const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'someDid',
+        id: new BigNumber(1),
+      });
+      const toHolder = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'someDid',
+        id: new BigNumber(2),
+      });
+
+      getAssetHolderDidSpy.mockResolvedValue('someDid');
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder,
+        toHolder,
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      const boundFunc = getAuthorization.bind(proc);
+
+      await expect(boundFunc()).resolves.toEqual({
+        permissions: {
+          transactions: [TxTags.settlement.TransferFunds],
+          portfolios: [fromHolder, toHolder],
           assets: [],
         },
       });

--- a/src/api/procedures/__tests__/transferFunds.ts
+++ b/src/api/procedures/__tests__/transferFunds.ts
@@ -17,10 +17,10 @@ import { isResolverFunction, MaybeResolverFunction } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as typeguardsModule from '~/utils/typeguards';
 
-const callResolver = async (
+const callResolver = (
   resolver: MaybeResolverFunction<Instruction | undefined>
 ): Promise<Instruction | undefined> =>
-  isResolverFunction(resolver) ? resolver({} as ISubmittableResult) : resolver;
+  Promise.resolve(isResolverFunction(resolver) ? resolver({} as ISubmittableResult) : resolver);
 
 jest.mock(
   '~/api/entities/NumberedPortfolio',

--- a/src/api/procedures/__tests__/transferFunds.ts
+++ b/src/api/procedures/__tests__/transferFunds.ts
@@ -64,6 +64,7 @@ describe('transferFunds procedure', () => {
   let asAssetIdSpy: jest.SpyInstance;
   let getOwnerSpy: jest.SpyInstance;
   let isLockedSpy: jest.SpyInstance;
+  let filterEventRecordsSpy: jest.SpyInstance;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -95,6 +96,7 @@ describe('transferFunds procedure', () => {
     asAssetIdSpy = jest.spyOn(utilsInternalModule, 'asAssetId');
     getOwnerSpy = jest.spyOn(Nft.prototype, 'getOwner');
     isLockedSpy = jest.spyOn(Nft.prototype, 'isLocked');
+    filterEventRecordsSpy = jest.spyOn(utilsInternalModule, 'filterEventRecords');
   });
 
   beforeEach(() => {
@@ -103,6 +105,8 @@ describe('transferFunds procedure', () => {
     assetHolderLikeToAssetHolderIdSpy.mockReturnValue('someAssetHolderId');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     isFungibleLegBuilderSpy.mockResolvedValue((leg: any) => 'amount' in leg);
+    // no `SettlementManuallyExecuted` event by default - the created instruction stays pending
+    filterEventRecordsSpy.mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -609,6 +613,57 @@ describe('transferFunds procedure', () => {
       expect(result.transaction).toBe(transaction);
       expect(result.args).toEqual(['rawHolder', 'rawHolder', 'rawFund']);
       await expect(callResolver(result.resolver)).resolves.toBe(instruction);
+    });
+
+    it('should resolve to undefined when a cross-DID instruction is created but also executed inline', async () => {
+      // `InstructionCreated` fires whether or not the instruction also settles within the same
+      // transaction (e.g. the caller is also the receiver and both sides end up affirmed) - only
+      // `SettlementManuallyExecuted` distinguishes an already-settled instruction from a pending one
+      const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
+
+      getAssetHolderDidSpy.mockReset();
+      getAssetHolderDidSpy.mockResolvedValueOnce('someDid').mockResolvedValueOnce('otherDid');
+
+      fromPortfolioHolder.getAssetBalances.mockResolvedValue([
+        { free: new BigNumber(150) } as PortfolioBalance,
+      ]);
+
+      fungibleMovementToPortfolioFundSpy.mockResolvedValue('rawFund');
+      assetHolderLikeToAssetHolderIdSpy.mockReturnValue('someHolderId');
+      assetHolderIdToMeshAssetHolderSpy.mockReturnValue('rawHolder');
+      const instruction = { id: new BigNumber(1) } as Instruction;
+      createAddInstructionResolverSpy.mockReturnValue(() => [instruction]);
+      filterEventRecordsSpy.mockReturnValue([
+        dsMockUtils.createMockIEvent(['someDid', dsMockUtils.createMockU64(new BigNumber(1))]),
+      ]);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      dsMockUtils.createTxMock('settlement', 'transferFunds');
+
+      const result = await prepareTransferFunds.call(proc, {
+        from: fromPortfolioHolder,
+        to: toPortfolioHolder,
+        asset,
+        amount: new BigNumber(100),
+      });
+
+      await expect(callResolver(result.resolver)).resolves.toBeUndefined();
+      expect(filterEventRecordsSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'settlement',
+        'SettlementManuallyExecuted',
+        true
+      );
     });
   });
 

--- a/src/api/procedures/__tests__/transferFunds.ts
+++ b/src/api/procedures/__tests__/transferFunds.ts
@@ -62,6 +62,8 @@ describe('transferFunds procedure', () => {
   let isFungibleLegBuilderSpy: jest.SpyInstance;
   let createAddInstructionResolverSpy: jest.SpyInstance;
   let asAssetIdSpy: jest.SpyInstance;
+  let asFungibleAssetSpy: jest.SpyInstance;
+  let stringToAssetIdSpy: jest.SpyInstance;
   let getOwnerSpy: jest.SpyInstance;
   let isLockedSpy: jest.SpyInstance;
   let filterEventRecordsSpy: jest.SpyInstance;
@@ -94,6 +96,8 @@ describe('transferFunds procedure', () => {
       'createAddInstructionResolver'
     );
     asAssetIdSpy = jest.spyOn(utilsInternalModule, 'asAssetId');
+    asFungibleAssetSpy = jest.spyOn(utilsInternalModule, 'asFungibleAsset');
+    stringToAssetIdSpy = jest.spyOn(utilsConversionModule, 'stringToAssetId');
     getOwnerSpy = jest.spyOn(Nft.prototype, 'getOwner');
     isLockedSpy = jest.spyOn(Nft.prototype, 'isLocked');
     filterEventRecordsSpy = jest.spyOn(utilsInternalModule, 'filterEventRecords');
@@ -107,6 +111,7 @@ describe('transferFunds procedure', () => {
     isFungibleLegBuilderSpy.mockResolvedValue((leg: any) => 'amount' in leg);
     // no `SettlementManuallyExecuted` event by default - the created instruction stays pending
     filterEventRecordsSpy.mockReturnValue([]);
+    getAssetHolderDidSpy.mockResolvedValue('someDid');
   });
 
   afterEach(() => {
@@ -120,7 +125,7 @@ describe('transferFunds procedure', () => {
     dsMockUtils.cleanup();
   });
 
-  describe('prepareMoveFunds', () => {
+  describe('prepareTransferFunds', () => {
     let fromAccountHolder: Mocked<Account>;
     let fromPortfolioHolder: Mocked<NumberedPortfolio>;
     let toPortfolioHolder: Mocked<NumberedPortfolio>;
@@ -138,7 +143,6 @@ describe('transferFunds procedure', () => {
 
       fromPortfolioHolder.isEqual.mockReturnValue(false);
       fromAccountHolder.isEqual.mockReturnValue(false);
-      getAssetHolderDidSpy.mockResolvedValue('someDid');
     });
 
     it('should throw an error if from and to asset holders are the same', async () => {
@@ -151,6 +155,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -166,9 +172,6 @@ describe('transferFunds procedure', () => {
     });
 
     it('should throw an error if DID cannot be retrieved from one or both asset holders', async () => {
-      getAssetHolderDidSpy.mockReset();
-      getAssetHolderDidSpy.mockResolvedValueOnce('someDid').mockResolvedValueOnce(undefined);
-
       const proc = procedureMockUtils.getInstance<
         TransferFundsParams,
         Instruction | undefined,
@@ -176,6 +179,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: undefined,
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -198,6 +203,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -224,6 +231,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -248,6 +257,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -276,6 +287,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'otherDid',
         signingAccount: 'someOtherAccount',
       });
@@ -303,6 +316,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromAccountHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'otherDid',
         signingAccount: 'someOtherAccount',
       });
@@ -328,6 +343,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromAccountHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         // same DID as fromAccountHolder's, but a different signing key
         signingDid: 'someDid',
         signingAccount: 'someOtherAccount',
@@ -357,6 +374,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromAccountHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'otherDid',
         signingAccount: 'someOtherAccount',
       });
@@ -382,6 +401,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromAccountHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'otherDid',
         signingAccount: 'someOtherAccount',
       });
@@ -412,6 +433,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -444,6 +467,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -478,6 +503,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromAccountHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'otherDid',
         signingAccount: 'someOtherAccount',
       });
@@ -516,6 +543,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -557,6 +586,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -577,9 +608,6 @@ describe('transferFunds procedure', () => {
     it('should return a transfer funds transaction spec for a cross-DID portfolio transfer, leaving the instruction pending', async () => {
       const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
 
-      getAssetHolderDidSpy.mockReset();
-      getAssetHolderDidSpy.mockResolvedValueOnce('someDid').mockResolvedValueOnce('otherDid');
-
       fromPortfolioHolder.getAssetBalances.mockResolvedValue([
         { free: new BigNumber(150) } as PortfolioBalance,
       ]);
@@ -597,6 +625,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'otherDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -621,9 +651,6 @@ describe('transferFunds procedure', () => {
       // `SettlementManuallyExecuted` distinguishes an already-settled instruction from a pending one
       const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
 
-      getAssetHolderDidSpy.mockReset();
-      getAssetHolderDidSpy.mockResolvedValueOnce('someDid').mockResolvedValueOnce('otherDid');
-
       fromPortfolioHolder.getAssetBalances.mockResolvedValue([
         { free: new BigNumber(150) } as PortfolioBalance,
       ]);
@@ -644,6 +671,8 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder: fromPortfolioHolder,
         toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'otherDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
@@ -665,6 +694,122 @@ describe('transferFunds procedure', () => {
         true
       );
     });
+
+    it('should resolve the Asset before checking the allowance when an Asset ID is passed', async () => {
+      const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
+      asset.getAllowance.mockResolvedValue(new BigNumber(50));
+      asFungibleAssetSpy.mockResolvedValue(asset);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromAccountHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
+        signingDid: 'otherDid',
+        signingAccount: 'someOtherAccount',
+      });
+
+      await expect(
+        prepareTransferFunds.call(proc, {
+          from: fromAccountHolder,
+          to: toPortfolioHolder,
+          asset: '12341234-1234-1234-1234-123412341234',
+          amount: new BigNumber(100),
+        })
+      ).rejects.toThrow('Spender has insufficient allowance to cover the transfer');
+
+      expect(asFungibleAssetSpy).toHaveBeenCalledWith(
+        '12341234-1234-1234-1234-123412341234',
+        mockContext
+      );
+    });
+
+    it('should pass the memo to the fund for a fungible leg', async () => {
+      const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
+
+      fromPortfolioHolder.getAssetBalances.mockResolvedValue([
+        { free: new BigNumber(150) } as PortfolioBalance,
+      ]);
+
+      fungibleMovementToPortfolioFundSpy.mockResolvedValue('rawFund');
+      createAddInstructionResolverSpy.mockReturnValue(() => []);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      dsMockUtils.createTxMock('settlement', 'transferFunds');
+
+      const amount = new BigNumber(100);
+
+      await prepareTransferFunds.call(proc, {
+        from: fromPortfolioHolder,
+        to: toPortfolioHolder,
+        asset,
+        amount,
+        memo: 'someMemo',
+      });
+
+      expect(fungibleMovementToPortfolioFundSpy).toHaveBeenCalledWith(
+        { asset, amount, memo: 'someMemo' },
+        mockContext
+      );
+    });
+
+    it('should pass the memo to the fund for an NFT leg', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const asset = entityMockUtils.getNftCollectionInstance({ assetId });
+      const nfts = [new BigNumber(1)];
+
+      asAssetIdSpy.mockResolvedValue(assetId);
+      getOwnerSpy.mockResolvedValue(fromPortfolioHolder as unknown as AssetHolder);
+      isLockedSpy.mockResolvedValue(false);
+      fromPortfolioHolder.isEqual.mockImplementation(other => other === fromPortfolioHolder);
+
+      nftMovementToPortfolioFundSpy.mockResolvedValue('rawNftFund');
+      createAddInstructionResolverSpy.mockReturnValue(() => []);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      dsMockUtils.createTxMock('settlement', 'transferFunds');
+
+      await prepareTransferFunds.call(proc, {
+        from: fromPortfolioHolder,
+        to: toPortfolioHolder,
+        asset,
+        nfts,
+        memo: 'someMemo',
+      });
+
+      expect(nftMovementToPortfolioFundSpy).toHaveBeenCalledWith(
+        { asset, nfts, memo: 'someMemo' },
+        mockContext
+      );
+    });
   });
 
   describe('prepareStorage', () => {
@@ -674,11 +819,13 @@ describe('transferFunds procedure', () => {
         id: new BigNumber(1),
       });
       const to = entityMockUtils.getNumberedPortfolioInstance({
-        did: 'someDid',
+        did: 'otherDid',
         id: new BigNumber(2),
       });
 
       assetHolderLikeToAssetHolderSpy.mockReturnValueOnce(from).mockReturnValueOnce(to);
+      getAssetHolderDidSpy.mockReset();
+      getAssetHolderDidSpy.mockResolvedValueOnce('someDid').mockResolvedValueOnce('otherDid');
 
       const proc = procedureMockUtils.getInstance<
         TransferFundsParams,
@@ -696,21 +843,183 @@ describe('transferFunds procedure', () => {
       expect(result).toEqual({
         fromHolder: from,
         toHolder: to,
+        fromDid: 'someDid',
+        toDid: 'otherDid',
         signingDid: 'someDid',
         signingAccount: mockContext.getSigningAccount().address,
       });
     });
-  });
 
-  describe('getAuthorization', () => {
-    it('should return the appropriate roles and permissions, excluding an Account toHolder', async () => {
-      const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
+    it('should key off the acting Account and its Identity when signing through a MultiSig', async () => {
+      // a MultiSig proposal is dispatched with the MultiSig as the origin, so the chain sees the
+      // MultiSig's Identity, not the Identity of the key that signs the proposal
+      const from = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'multiSigDid',
+        id: new BigNumber(1),
+      });
+      const to = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'someDid',
+        id: new BigNumber(2),
+      });
+
+      assetHolderLikeToAssetHolderSpy.mockReturnValueOnce(from).mockReturnValueOnce(to);
+      getAssetHolderDidSpy.mockReset();
+      getAssetHolderDidSpy.mockResolvedValueOnce('multiSigDid').mockResolvedValueOnce('someDid');
+
+      const multiSigAccount = entityMockUtils.getAccountInstance({
+        address: 'multiSigAddress',
+        getIdentity: entityMockUtils.getIdentityInstance({ did: 'multiSigDid' }),
+      });
+      mockContext.getActingAccount.mockResolvedValue(multiSigAccount);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext);
+
+      const result = await prepareStorage.call(proc, {
+        from,
+        to,
+        asset: 'SOME_ASSET',
+        amount: new BigNumber(100),
+      });
+
+      expect(result).toEqual({
+        fromHolder: from,
+        toHolder: to,
+        fromDid: 'multiSigDid',
+        toDid: 'someDid',
+        signingDid: 'multiSigDid',
+        signingAccount: 'multiSigAddress',
+      });
+    });
+
+    it('should throw an error if the acting Account has no associated Identity', async () => {
+      const from = entityMockUtils.getNumberedPortfolioInstance({
         did: 'someDid',
         id: new BigNumber(1),
       });
-      const toHolder = entityMockUtils.getAccountInstance({ address: 'someAccount' });
+      const to = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'someDid',
+        id: new BigNumber(2),
+      });
 
-      getAssetHolderDidSpy.mockResolvedValue('someDid');
+      assetHolderLikeToAssetHolderSpy.mockReturnValueOnce(from).mockReturnValueOnce(to);
+
+      const actingAccount = entityMockUtils.getAccountInstance({
+        address: 'someAddress',
+        getIdentity: null,
+      });
+      mockContext.getActingAccount.mockResolvedValue(actingAccount);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext);
+
+      await expect(
+        prepareStorage.call(proc, {
+          from,
+          to,
+          asset: 'SOME_ASSET',
+          amount: new BigNumber(100),
+        })
+      ).rejects.toThrow('The acting Account does not have an associated Identity');
+    });
+  });
+
+  describe('getAuthorization', () => {
+    const args: TransferFundsParams = {
+      from: 'someAccount',
+      to: 'someOtherAccount',
+      asset: 'SOME_ASSET',
+      amount: new BigNumber(100),
+    };
+
+    let fromPortfolioHolder: Mocked<NumberedPortfolio>;
+    let toPortfolioHolder: Mocked<NumberedPortfolio>;
+
+    beforeEach(() => {
+      fromPortfolioHolder = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'someDid',
+        id: new BigNumber(1),
+        isCustodiedBy: true,
+      });
+      toPortfolioHolder = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'someDid',
+        id: new BigNumber(2),
+        isCustodiedBy: true,
+      });
+
+      asAssetIdSpy.mockClear();
+      asAssetIdSpy.mockResolvedValue('12341234-1234-1234-1234-123412341234');
+      stringToAssetIdSpy.mockReturnValue('rawAssetId');
+    });
+
+    it('should require the source Portfolio permission and custody, without the destination, for a same-DID transfer', async () => {
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      const boundFunc = getAuthorization.bind(proc);
+
+      await expect(boundFunc(args)).resolves.toEqual({
+        roles: true,
+        permissions: {
+          transactions: [TxTags.settlement.TransferFunds],
+          portfolios: [fromPortfolioHolder],
+          assets: [],
+        },
+      });
+
+      // the destination is never checked on the same-DID path, so its affirmation requirement
+      // doesn't need to be fetched
+      expect(asAssetIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('should return a failure message if the signing Identity is not the custodian of the source Portfolio', async () => {
+      fromPortfolioHolder.isCustodiedBy.mockResolvedValue(false);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      const boundFunc = getAuthorization.bind(proc);
+
+      await expect(boundFunc(args)).resolves.toEqual({
+        roles: 'The signing Identity must be the custodian of the origin Portfolio',
+        permissions: {
+          transactions: [TxTags.settlement.TransferFunds],
+          portfolios: [fromPortfolioHolder],
+          assets: [],
+        },
+      });
+
+      expect(fromPortfolioHolder.isCustodiedBy).toHaveBeenCalledWith({ identity: 'someDid' });
+    });
+
+    it('should not require custody when the source is an Account', async () => {
+      const fromHolder = entityMockUtils.getAccountInstance({ address: 'someAccount' });
 
       const proc = procedureMockUtils.getInstance<
         TransferFundsParams,
@@ -718,33 +1027,67 @@ describe('transferFunds procedure', () => {
         Storage
       >(mockContext, {
         fromHolder,
-        toHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc()).resolves.toEqual({
+      await expect(boundFunc(args)).resolves.toEqual({
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
-          portfolios: [fromHolder],
+          portfolios: [],
           assets: [],
         },
       });
     });
 
-    it('should exclude a Portfolio toHolder owned by a different DID than the signer', async () => {
-      const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
-        did: 'someDid',
-        id: new BigNumber(1),
-      });
+    it('should exclude a destination owned by a different Identity than the signer', async () => {
       const toHolder = entityMockUtils.getNumberedPortfolioInstance({
         did: 'otherDid',
         id: new BigNumber(2),
       });
 
-      getAssetHolderDidSpy.mockResolvedValue('otherDid');
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder,
+        fromDid: 'someDid',
+        toDid: 'otherDid',
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      const boundFunc = getAuthorization.bind(proc);
+
+      await expect(boundFunc(args)).resolves.toEqual({
+        roles: true,
+        permissions: {
+          transactions: [TxTags.settlement.TransferFunds],
+          portfolios: [fromPortfolioHolder],
+          assets: [],
+        },
+      });
+    });
+
+    it("should include a cross-DID destination owned by the signer's Identity when the receiver has to affirm", async () => {
+      const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'otherDid',
+        id: new BigNumber(1),
+        isCustodiedBy: true,
+      });
+
+      // the receiver has opted into mandatory affirmation, so the chain affirms on their behalf
+      // and runs the destination's custody/permission checks
+      dsMockUtils.createCallMock('settlementApi', 'getReceiverAffirmationRequirement', {
+        returnValue: { isAutomatic: false },
+      });
 
       const proc = procedureMockUtils.getInstance<
         TransferFundsParams,
@@ -752,14 +1095,55 @@ describe('transferFunds procedure', () => {
         Storage
       >(mockContext, {
         fromHolder,
-        toHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'otherDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc()).resolves.toEqual({
+      await expect(boundFunc(args)).resolves.toEqual({
+        roles: true,
+        permissions: {
+          transactions: [TxTags.settlement.TransferFunds],
+          portfolios: [fromHolder, toPortfolioHolder],
+          assets: [],
+        },
+      });
+    });
+
+    it("should exclude a cross-DID destination owned by the signer's Identity when it is auto-affirmed", async () => {
+      const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
+        did: 'otherDid',
+        id: new BigNumber(1),
+        isCustodiedBy: true,
+      });
+
+      // auto-affirmation is decided by the receiver alone, so the chain never affirms the
+      // destination and never checks it
+      dsMockUtils.createCallMock('settlementApi', 'getReceiverAffirmationRequirement', {
+        returnValue: { isAutomatic: true },
+      });
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'otherDid',
+        toDid: 'someDid',
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      const boundFunc = getAuthorization.bind(proc);
+
+      await expect(boundFunc(args)).resolves.toEqual({
+        roles: true,
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
           portfolios: [fromHolder],
@@ -768,17 +1152,17 @@ describe('transferFunds procedure', () => {
       });
     });
 
-    it('should include a Portfolio toHolder owned by the same DID as the signer', async () => {
+    it('should exclude an Account destination from the Portfolio permissions', async () => {
       const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
-        did: 'someDid',
+        did: 'otherDid',
         id: new BigNumber(1),
+        isCustodiedBy: true,
       });
-      const toHolder = entityMockUtils.getNumberedPortfolioInstance({
-        did: 'someDid',
-        id: new BigNumber(2),
-      });
+      const toHolder = entityMockUtils.getAccountInstance({ address: 'someAccount' });
 
-      getAssetHolderDidSpy.mockResolvedValue('someDid');
+      dsMockUtils.createCallMock('settlementApi', 'getReceiverAffirmationRequirement', {
+        returnValue: { isAutomatic: false },
+      });
 
       const proc = procedureMockUtils.getInstance<
         TransferFundsParams,
@@ -787,16 +1171,19 @@ describe('transferFunds procedure', () => {
       >(mockContext, {
         fromHolder,
         toHolder,
+        fromDid: 'otherDid',
+        toDid: 'someDid',
         signingDid: 'someDid',
         signingAccount: 'someAccount',
       });
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc()).resolves.toEqual({
+      await expect(boundFunc(args)).resolves.toEqual({
+        roles: true,
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
-          portfolios: [fromHolder, toHolder],
+          portfolios: [fromHolder],
           assets: [],
         },
       });

--- a/src/api/procedures/__tests__/transferFunds.ts
+++ b/src/api/procedures/__tests__/transferFunds.ts
@@ -9,12 +9,13 @@ import {
   Storage,
 } from '~/api/procedures/transferFunds';
 import * as procedureUtilsModule from '~/api/procedures/utils';
-import { Account, Context, Instruction, NumberedPortfolio } from '~/internal';
+import { Account, Context, Instruction, Nft, NumberedPortfolio } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { PortfolioBalance, TransferFundsParams, TxTags } from '~/types';
+import { AssetHolder, PortfolioBalance, TransferFundsParams, TxTags } from '~/types';
 import { isResolverFunction, MaybeResolverFunction } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
+import * as utilsInternalModule from '~/utils/internal';
 import * as typeguardsModule from '~/utils/typeguards';
 
 const callResolver = (
@@ -60,6 +61,9 @@ describe('transferFunds procedure', () => {
   let getAssetHolderDidSpy: jest.SpyInstance;
   let isFungibleLegBuilderSpy: jest.SpyInstance;
   let createAddInstructionResolverSpy: jest.SpyInstance;
+  let asAssetIdSpy: jest.SpyInstance;
+  let getOwnerSpy: jest.SpyInstance;
+  let isLockedSpy: jest.SpyInstance;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -88,6 +92,9 @@ describe('transferFunds procedure', () => {
       addInstructionModule,
       'createAddInstructionResolver'
     );
+    asAssetIdSpy = jest.spyOn(utilsInternalModule, 'asAssetId');
+    getOwnerSpy = jest.spyOn(Nft.prototype, 'getOwner');
+    isLockedSpy = jest.spyOn(Nft.prototype, 'isLocked');
   });
 
   beforeEach(() => {
@@ -306,9 +313,155 @@ describe('transferFunds procedure', () => {
       ).rejects.toThrow('Spender has insufficient allowance to cover the transfer');
     });
 
+    it('should require an allowance check whenever the signing Account differs from the source Account, even when both belong to the same DID', async () => {
+      const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
+      asset.getAllowance.mockResolvedValue(new BigNumber(50));
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromAccountHolder,
+        toHolder: toPortfolioHolder,
+        // same DID as fromAccountHolder's, but a different signing key
+        signingDid: 'someDid',
+        signingAccount: 'someOtherAccount',
+      });
+
+      await expect(
+        prepareTransferFunds.call(proc, {
+          from: fromAccountHolder,
+          to: toPortfolioHolder,
+          asset,
+          amount: new BigNumber(100),
+        })
+      ).rejects.toThrow('Spender has insufficient allowance to cover the transfer');
+    });
+
+    it('should still check the source balance even when a sufficient allowance is granted', async () => {
+      const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
+      asset.getAllowance.mockResolvedValue(new BigNumber(150));
+      fromAccountHolder.getAssetBalances.mockResolvedValue([
+        { free: new BigNumber(50) } as PortfolioBalance,
+      ]);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromAccountHolder,
+        toHolder: toPortfolioHolder,
+        signingDid: 'otherDid',
+        signingAccount: 'someOtherAccount',
+      });
+
+      await expect(
+        prepareTransferFunds.call(proc, {
+          from: fromAccountHolder,
+          to: toPortfolioHolder,
+          asset,
+          amount: new BigNumber(100),
+        })
+      ).rejects.toThrow('Sender has insufficient balance to cover the transfer');
+    });
+
+    it('should throw an error if a non-owning Account tries to transfer NFTs', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const asset = entityMockUtils.getNftCollectionInstance({ assetId });
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromAccountHolder,
+        toHolder: toPortfolioHolder,
+        signingDid: 'otherDid',
+        signingAccount: 'someOtherAccount',
+      });
+
+      await expect(
+        prepareTransferFunds.call(proc, {
+          from: fromAccountHolder,
+          to: toPortfolioHolder,
+          asset,
+          nfts: [new BigNumber(1)],
+        })
+      ).rejects.toThrow(
+        'Only the owning key can transfer NFTs from an Account. Allowances do not apply to NFTs'
+      );
+    });
+
+    it('should throw an error if an NFT is not owned by the sender or is locked', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const asset = entityMockUtils.getNftCollectionInstance({ assetId });
+
+      asAssetIdSpy.mockResolvedValue(assetId);
+      getOwnerSpy.mockResolvedValue(null);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      await expect(
+        prepareTransferFunds.call(proc, {
+          from: fromPortfolioHolder,
+          to: toPortfolioHolder,
+          asset,
+          nfts: [new BigNumber(1)],
+        })
+      ).rejects.toThrow(
+        'Some of the NFTs are not owned by the sender, are locked, or do not exist'
+      );
+    });
+
+    it('should throw an error if an owned NFT is locked', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const asset = entityMockUtils.getNftCollectionInstance({ assetId });
+
+      asAssetIdSpy.mockResolvedValue(assetId);
+      getOwnerSpy.mockResolvedValue(fromPortfolioHolder as unknown as AssetHolder);
+      isLockedSpy.mockResolvedValue(true);
+      fromPortfolioHolder.isEqual.mockImplementation(other => other === fromPortfolioHolder);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: fromPortfolioHolder,
+        toHolder: toPortfolioHolder,
+        signingDid: 'someDid',
+        signingAccount: 'someAccount',
+      });
+
+      await expect(
+        prepareTransferFunds.call(proc, {
+          from: fromPortfolioHolder,
+          to: toPortfolioHolder,
+          asset,
+          nfts: [new BigNumber(1)],
+        })
+      ).rejects.toThrow(
+        'Some of the NFTs are not owned by the sender, are locked, or do not exist'
+      );
+    });
+
     it('should return a transfer funds transaction spec when fromHolder is an Account with sufficient allowance', async () => {
       const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
       asset.getAllowance.mockResolvedValue(new BigNumber(150));
+      fromAccountHolder.getAssetBalances.mockResolvedValue([
+        { free: new BigNumber(150) } as PortfolioBalance,
+      ]);
 
       fungibleMovementToPortfolioFundSpy.mockResolvedValue('rawFund');
       const instruction = { id: new BigNumber(1) } as Instruction;
@@ -380,6 +533,13 @@ describe('transferFunds procedure', () => {
     it('should return a transfer funds transaction spec for NFT assets', async () => {
       const assetId = '12341234-1234-1234-1234-123412341234';
       const asset = entityMockUtils.getNftCollectionInstance({ assetId });
+
+      asAssetIdSpy.mockResolvedValue(assetId);
+      getOwnerSpy.mockResolvedValue(fromPortfolioHolder as unknown as AssetHolder);
+      isLockedSpy.mockResolvedValue(false);
+      // isEqual is also used for the "same holder" guard against toHolder, so only report
+      // equality when compared against itself (the NFT ownership check)
+      fromPortfolioHolder.isEqual.mockImplementation(other => other === fromPortfolioHolder);
 
       nftMovementToPortfolioFundSpy.mockResolvedValue('rawNftFund');
       assetHolderLikeToAssetHolderIdSpy.mockReturnValue('someHolderId');

--- a/src/api/procedures/addInstruction.ts
+++ b/src/api/procedures/addInstruction.ts
@@ -128,9 +128,9 @@ type InternalAddInstructionParams = [
  * @hidden
  */
 export const createAddInstructionResolver =
-  (context: Context) =>
+  (context: Context, skipError?: true) =>
   (receipt: ISubmittableResult): Instruction[] => {
-    const events = filterEventRecords(receipt, 'settlement', 'InstructionCreated');
+    const events = filterEventRecords(receipt, 'settlement', 'InstructionCreated', skipError);
 
     const result = events.map(
       ({ data }) => new Instruction({ id: u64ToBigNumber(data[2]) }, context)

--- a/src/api/procedures/transferFunds.ts
+++ b/src/api/procedures/transferFunds.ts
@@ -22,7 +22,7 @@ import {
   fungibleMovementToPortfolioFund,
   nftMovementToPortfolioFund,
 } from '~/utils/conversion';
-import { asAssetId, asNftId } from '~/utils/internal';
+import { asAssetId, asNftId, filterEventRecords } from '~/utils/internal';
 import { isFungibleLegBuilder } from '~/utils/typeguards';
 
 export interface Storage {
@@ -191,8 +191,26 @@ export async function prepareTransferFunds(
   return {
     transaction: settlement.transferFunds,
     args: [rawFrom, rawTo, rawFund],
-    resolver: (receipt): Instruction | undefined =>
-      createAddInstructionResolver(context, true)(receipt)[0],
+    resolver: (receipt): Instruction | undefined => {
+      const [instruction] = createAddInstructionResolver(context, true)(receipt);
+      if (!instruction) {
+        return undefined;
+      }
+
+      // `settlement.InstructionCreated` fires whether or not the instruction is also executed
+      // inline within this same transaction (e.g. when the caller is also the receiver and both
+      // sides end up affirmed), so a settled instruction still resolves an `Instruction` above.
+      // `SettlementManuallyExecuted` only fires on that inline-execution path, so its presence
+      // means the instruction is already done rather than still pending.
+      const [executed] = filterEventRecords(
+        receipt,
+        'settlement',
+        'SettlementManuallyExecuted',
+        true
+      );
+
+      return executed ? undefined : instruction;
+    },
   };
 }
 

--- a/src/api/procedures/transferFunds.ts
+++ b/src/api/procedures/transferFunds.ts
@@ -1,10 +1,12 @@
 import { PolymeshPrimitivesPortfolioFund } from '@polkadot/types/lookup';
 
+import { createAddInstructionResolver } from '~/api/procedures/addInstruction';
 import { getAssetHolderDid } from '~/api/procedures/utils';
 import {
   Account,
   Context,
   DefaultPortfolio,
+  Instruction,
   NumberedPortfolio,
   PolymeshError,
   Procedure,
@@ -59,19 +61,9 @@ export async function getFund(
       });
     }
 
-    // when sender and receiver DID are same we need to only check asset balance has for either account or portfolio
-    if (fromDid === signingDid) {
-      const [balance] = await fromHolder.getAssetBalances({ assets: [asset] });
-      if (!balance || balance.free.lt(amount)) {
-        throw new PolymeshError({
-          code: ErrorCode.UnmetPrerequisite,
-          message: 'Sender has insufficient balance to cover the transfer',
-          data: {
-            balance,
-          },
-        });
-      }
-    } else if (fromHolder instanceof Account) {
+    // spender mode only applies to Account sources where the signer isn't the owner; Portfolio
+    // sources are always authorized via custody on-chain, regardless of the owning DID
+    if (fromHolder instanceof Account && fromDid !== signingDid) {
       const allowance = await asset.getAllowance({ owner: fromHolder, spender: signingAccount });
 
       if (allowance.lt(amount)) {
@@ -80,6 +72,17 @@ export async function getFund(
           message: 'Spender has insufficient allowance to cover the transfer',
           data: {
             allowance,
+          },
+        });
+      }
+    } else {
+      const [balance] = await fromHolder.getAssetBalances({ assets: [asset] });
+      if (!balance || balance.free.lt(amount)) {
+        throw new PolymeshError({
+          code: ErrorCode.UnmetPrerequisite,
+          message: 'Sender has insufficient balance to cover the transfer',
+          data: {
+            balance,
           },
         });
       }
@@ -104,9 +107,11 @@ export async function getFund(
  * @hidden
  */
 export async function prepareTransferFunds(
-  this: Procedure<TransferFundsParams, void, Storage>,
+  this: Procedure<TransferFundsParams, Instruction | undefined, Storage>,
   args: TransferFundsParams
-): Promise<TransactionSpec<void, ExtrinsicParams<'settlement', 'transferFunds'>>> {
+): Promise<
+  TransactionSpec<Instruction | undefined, ExtrinsicParams<'settlement', 'transferFunds'>>
+> {
   const {
     context: {
       polymeshApi: {
@@ -141,14 +146,6 @@ export async function prepareTransferFunds(
     });
   }
 
-  if (fromDid !== toDid) {
-    throw new PolymeshError({
-      code: ErrorCode.ValidationError,
-      message:
-        'For transferring funds between different DIDs, use `Settlements.addInstruction` method instead.',
-    });
-  }
-
   const rawFrom = assetHolderIdToMeshAssetHolder(
     assetHolderLikeToAssetHolderId(fromHolder),
     context
@@ -159,23 +156,32 @@ export async function prepareTransferFunds(
   return {
     transaction: settlement.transferFunds,
     args: [rawFrom, rawTo, rawFund],
-    resolver: undefined,
+    resolver: (receipt): Instruction | undefined =>
+      createAddInstructionResolver(context, true)(receipt)[0],
   };
 }
 
 /**
  * @hidden
  */
-export function getAuthorization(
-  this: Procedure<TransferFundsParams, void, Storage>
-): ProcedureAuthorization {
+export async function getAuthorization(
+  this: Procedure<TransferFundsParams, Instruction | undefined, Storage>
+): Promise<ProcedureAuthorization> {
   const {
-    storage: { fromHolder, toHolder },
+    context,
+    storage: { fromHolder, toHolder, signingDid },
   } = this;
 
-  const portfolios = [fromHolder, toHolder].filter(
-    holder => !(holder instanceof Account)
-  ) as unknown as (DefaultPortfolio | NumberedPortfolio)[];
+  const toDid = await getAssetHolderDid(toHolder, context);
+
+  // the signer always authorizes/affirms the source; the destination is only auto-affirmed
+  // (and thus requires permission) when the signer's own identity also owns it
+  const holders = [fromHolder, ...(toDid === signingDid ? [toHolder] : [])];
+
+  const portfolios = holders.filter(holder => !(holder instanceof Account)) as unknown as (
+    | DefaultPortfolio
+    | NumberedPortfolio
+  )[];
 
   return {
     permissions: {
@@ -190,7 +196,7 @@ export function getAuthorization(
  * @hidden
  */
 export async function prepareStorage(
-  this: Procedure<TransferFundsParams, void, Storage>,
+  this: Procedure<TransferFundsParams, Instruction | undefined, Storage>,
   { from, to }: TransferFundsParams
 ): Promise<Storage> {
   const { context } = this;
@@ -214,5 +220,5 @@ export async function prepareStorage(
 /**
  * @hidden
  */
-export const transferFunds = (): Procedure<TransferFundsParams, void, Storage> =>
+export const transferFunds = (): Procedure<TransferFundsParams, Instruction | undefined, Storage> =>
   new Procedure(prepareTransferFunds, getAuthorization, prepareStorage);

--- a/src/api/procedures/transferFunds.ts
+++ b/src/api/procedures/transferFunds.ts
@@ -3,16 +3,7 @@ import BigNumber from 'bignumber.js';
 
 import { createAddInstructionResolver } from '~/api/procedures/addInstruction';
 import { getAssetHolderDid } from '~/api/procedures/utils';
-import {
-  Account,
-  Context,
-  DefaultPortfolio,
-  Instruction,
-  Nft,
-  NumberedPortfolio,
-  PolymeshError,
-  Procedure,
-} from '~/internal';
+import { Account, Context, Instruction, Nft, PolymeshError, Procedure } from '~/internal';
 import { AssetHolder, ErrorCode, InstructionNftLeg, TransferFundsParams, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import {
@@ -21,13 +12,16 @@ import {
   assetHolderLikeToAssetHolderId,
   fungibleMovementToPortfolioFund,
   nftMovementToPortfolioFund,
+  stringToAssetId,
 } from '~/utils/conversion';
-import { asAssetId, asNftId, filterEventRecords } from '~/utils/internal';
-import { isFungibleLegBuilder } from '~/utils/typeguards';
+import { asAssetId, asFungibleAsset, asNftId, filterEventRecords } from '~/utils/internal';
+import { isFungibleLegBuilder, isPortfolioAssetHolder } from '~/utils/typeguards';
 
 export interface Storage {
   fromHolder: AssetHolder;
   toHolder: AssetHolder;
+  fromDid: string | undefined;
+  toDid: string | undefined;
   signingDid: string;
   signingAccount: string;
 }
@@ -59,7 +53,14 @@ export async function getFund(
     // isn't the source Account itself — even when both keys belong to the same DID. Portfolio
     // sources are always authorized via custody on-chain, regardless of the owning DID
     if (fromHolder instanceof Account && fromHolder.address !== signingAccount) {
-      const allowance = await asset.getAllowance({ owner: fromHolder, spender: signingAccount });
+      // `isFungibleLegBuilder` narrows the leg to a `FungibleLeg`, whose `asset` is a
+      // `FungibleAsset` — but the parameter accepts `string | FungibleAsset`, so an Asset ID may
+      // still be there at runtime and has to be resolved before any of its methods can be used
+      const fungibleAsset = await asFungibleAsset(asset, context);
+      const allowance = await fungibleAsset.getAllowance({
+        owner: fromHolder,
+        spender: signingAccount,
+      });
 
       if (allowance.lt(amount)) {
         throw new PolymeshError({
@@ -154,7 +155,7 @@ export async function prepareTransferFunds(
       },
     },
     context,
-    storage: { fromHolder, toHolder },
+    storage: { fromHolder, toHolder, fromDid, toDid },
     storage,
   } = this;
 
@@ -164,11 +165,6 @@ export async function prepareTransferFunds(
       message: 'from and to asset holders cannot be the same',
     });
   }
-
-  const [fromDid, toDid] = await Promise.all([
-    getAssetHolderDid(fromHolder, context),
-    getAssetHolderDid(toHolder, context),
-  ]);
 
   if (!fromDid || !toDid) {
     throw new PolymeshError({
@@ -218,29 +214,52 @@ export async function prepareTransferFunds(
  * @hidden
  */
 export async function getAuthorization(
-  this: Procedure<TransferFundsParams, Instruction | undefined, Storage>
+  this: Procedure<TransferFundsParams, Instruction | undefined, Storage>,
+  { asset }: TransferFundsParams
 ): Promise<ProcedureAuthorization> {
   const {
     context,
-    storage: { fromHolder, toHolder, signingDid },
+    storage: { fromHolder, toHolder, fromDid, toDid, signingDid },
   } = this;
 
-  const toDid = await getAssetHolderDid(toHolder, context);
+  // the source is authorized on every path
+  const holders: AssetHolder[] = [fromHolder];
 
-  // the signer always authorizes/affirms the source; the destination is only auto-affirmed
-  // (and thus requires permission) when the signer's own identity also owns it
-  const holders = [fromHolder, ...(toDid === signingDid ? [toHolder] : [])];
+  // the destination is only checked cross-identity, and only when the chain affirms on the
+  // receiver's behalf: that needs the caller's own Identity to own it, and the receiver to not
+  // auto-affirm (the receiver's own setting, never the signer's). Same-identity transfers move
+  // the funds directly and never look at the destination
+  if (fromDid !== toDid && toDid === signingDid) {
+    const assetId = await asAssetId(asset, context);
 
-  const portfolios = holders.filter(holder => !(holder instanceof Account)) as unknown as (
-    | DefaultPortfolio
-    | NumberedPortfolio
-  )[];
+    const { isAutomatic } =
+      await context.polymeshApi.call.settlementApi.getReceiverAffirmationRequirement(
+        assetHolderIdToMeshAssetHolder(assetHolderLikeToAssetHolderId(toHolder), context),
+        stringToAssetId(assetId, context)
+      );
+
+    if (!isAutomatic) {
+      holders.push(toHolder);
+    }
+  }
+
+  let roles: ProcedureAuthorization['roles'];
+
+  if (isPortfolioAssetHolder(fromHolder)) {
+    // a Portfolio source is custody checked on every path. Compared against the acting Identity
+    // (the MultiSig's own when signing through one); a `PortfolioCustodian` role would use the
+    // signing key's Identity instead
+    const isCustodian = await fromHolder.isCustodiedBy({ identity: signingDid });
+
+    roles = isCustodian || 'The signing Identity must be the custodian of the origin Portfolio';
+  }
 
   return {
+    roles,
     permissions: {
       transactions: [TxTags.settlement.TransferFunds],
       assets: [],
-      portfolios,
+      portfolios: holders.filter(isPortfolioAssetHolder),
     },
   };
 }
@@ -254,19 +273,36 @@ export async function prepareStorage(
 ): Promise<Storage> {
   const { context } = this;
 
-  const [identity, { address }] = await Promise.all([
-    context.getSigningIdentity(),
-    context.getActingAccount(),
-  ]);
-
   const fromHolder = assetHolderLikeToAssetHolder(from, context);
   const toHolder = assetHolderLikeToAssetHolder(to, context);
+
+  // the extrinsic is dispatched with the acting Account as its origin — a MultiSig proposal
+  // executes as the MultiSig itself — so both the allowance/ownership checks and the chain's
+  // permission checks key off that Account and the Identity it belongs to, not off the key that
+  // signs the proposal
+  const actingAccount = await context.getActingAccount();
+
+  const [identity, fromDid, toDid] = await Promise.all([
+    actingAccount.getIdentity(),
+    getAssetHolderDid(fromHolder, context),
+    getAssetHolderDid(toHolder, context),
+  ]);
+
+  if (!identity) {
+    throw new PolymeshError({
+      code: ErrorCode.DataUnavailable,
+      message: 'The acting Account does not have an associated Identity',
+      data: { actingAddress: actingAccount.address },
+    });
+  }
 
   return {
     fromHolder,
     toHolder,
+    fromDid,
+    toDid,
     signingDid: identity.did,
-    signingAccount: address,
+    signingAccount: actingAccount.address,
   };
 }
 

--- a/src/api/procedures/transferFunds.ts
+++ b/src/api/procedures/transferFunds.ts
@@ -1,4 +1,5 @@
 import { PolymeshPrimitivesPortfolioFund } from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
 
 import { createAddInstructionResolver } from '~/api/procedures/addInstruction';
 import { getAssetHolderDid } from '~/api/procedures/utils';
@@ -7,19 +8,12 @@ import {
   Context,
   DefaultPortfolio,
   Instruction,
+  Nft,
   NumberedPortfolio,
   PolymeshError,
   Procedure,
 } from '~/internal';
-import {
-  AssetHolder,
-  ErrorCode,
-  FungiblePortfolioMovement,
-  InstructionNftLeg,
-  NonFungiblePortfolioMovement,
-  TransferFundsParams,
-  TxTags,
-} from '~/types';
+import { AssetHolder, ErrorCode, InstructionNftLeg, TransferFundsParams, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import {
   assetHolderIdToMeshAssetHolder,
@@ -28,6 +22,7 @@ import {
   fungibleMovementToPortfolioFund,
   nftMovementToPortfolioFund,
 } from '~/utils/conversion';
+import { asAssetId, asNftId } from '~/utils/internal';
 import { isFungibleLegBuilder } from '~/utils/typeguards';
 
 export interface Storage {
@@ -43,11 +38,10 @@ export interface Storage {
 export async function getFund(
   context: Context,
   args: TransferFundsParams,
-  fromDid: string,
   storage: Storage
 ): Promise<PolymeshPrimitivesPortfolioFund> {
   const { memo, ...leg } = args;
-  const { fromHolder, signingDid, signingAccount } = storage;
+  const { fromHolder, signingAccount } = storage;
   const isFungible = await isFungibleLegBuilder(leg, context);
 
   let rawFund: PolymeshPrimitivesPortfolioFund;
@@ -61,9 +55,10 @@ export async function getFund(
       });
     }
 
-    // spender mode only applies to Account sources where the signer isn't the owner; Portfolio
+    // allowances are granted key to key, so spender mode applies whenever the submitting Account
+    // isn't the source Account itself — even when both keys belong to the same DID. Portfolio
     // sources are always authorized via custody on-chain, regardless of the owning DID
-    if (fromHolder instanceof Account && fromDid !== signingDid) {
+    if (fromHolder instanceof Account && fromHolder.address !== signingAccount) {
       const allowance = await asset.getAllowance({ owner: fromHolder, spender: signingAccount });
 
       if (allowance.lt(amount)) {
@@ -75,27 +70,67 @@ export async function getFund(
           },
         });
       }
-    } else {
-      const [balance] = await fromHolder.getAssetBalances({ assets: [asset] });
-      if (!balance || balance.free.lt(amount)) {
-        throw new PolymeshError({
-          code: ErrorCode.UnmetPrerequisite,
-          message: 'Sender has insufficient balance to cover the transfer',
-          data: {
-            balance,
-          },
-        });
-      }
+    }
+
+    const [balance] = await fromHolder.getAssetBalances({ assets: [asset] });
+    if (!balance || balance.free.lt(amount)) {
+      throw new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'Sender has insufficient balance to cover the transfer',
+        data: {
+          balance,
+        },
+      });
     }
 
     rawFund = await fungibleMovementToPortfolioFund(
-      { asset, amount, memo } as FungiblePortfolioMovement,
+      { asset, amount, ...(memo !== undefined && { memo }) },
       context
     );
   } else {
     const { asset, nfts } = leg as InstructionNftLeg;
+
+    // NFTs have no allowance mechanism, so only the owning key (or the owning identity's
+    // custodied Portfolio) can authorize their transfer
+    if (fromHolder instanceof Account && fromHolder.address !== signingAccount) {
+      throw new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message:
+          'Only the owning key can transfer NFTs from an Account. Allowances do not apply to NFTs',
+      });
+    }
+
+    const assetId = await asAssetId(asset, context);
+
+    const unavailableNfts: BigNumber[] = [];
+    await Promise.all(
+      nfts.map(async nftId => {
+        const id = asNftId(nftId);
+        const nft = new Nft({ id, assetId }, context);
+
+        const owner = await nft.getOwner();
+        if (!owner || !owner.isEqual(fromHolder)) {
+          unavailableNfts.push(id);
+          return;
+        }
+
+        const isLocked = await nft.isLocked();
+        if (isLocked) {
+          unavailableNfts.push(id);
+        }
+      })
+    );
+
+    if (unavailableNfts.length) {
+      throw new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'Some of the NFTs are not owned by the sender, are locked, or do not exist',
+        data: { unavailableNfts },
+      });
+    }
+
     rawFund = await nftMovementToPortfolioFund(
-      { asset, nfts, memo } as NonFungiblePortfolioMovement,
+      { asset, nfts, ...(memo !== undefined && { memo }) },
       context
     );
   }
@@ -151,7 +186,7 @@ export async function prepareTransferFunds(
     context
   );
   const rawTo = assetHolderIdToMeshAssetHolder(assetHolderLikeToAssetHolderId(toHolder), context);
-  const rawFund = await getFund(context, args, fromDid, storage);
+  const rawFund = await getFund(context, args, storage);
 
   return {
     transaction: settlement.transferFunds,

--- a/src/api/procedures/transferFunds.ts
+++ b/src/api/procedures/transferFunds.ts
@@ -4,7 +4,14 @@ import BigNumber from 'bignumber.js';
 import { createAddInstructionResolver } from '~/api/procedures/addInstruction';
 import { getAssetHolderDid } from '~/api/procedures/utils';
 import { Account, Context, Instruction, Nft, PolymeshError, Procedure } from '~/internal';
-import { AssetHolder, ErrorCode, InstructionNftLeg, TransferFundsParams, TxTags } from '~/types';
+import {
+  AssetHolder,
+  ErrorCode,
+  FungibleLeg,
+  InstructionNftLeg,
+  TransferFundsParams,
+  TxTags,
+} from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import {
   assetHolderIdToMeshAssetHolder,
@@ -29,114 +36,133 @@ export interface Storage {
 /**
  * @hidden
  */
+async function getFungibleFund(
+  context: Context,
+  storage: Storage,
+  leg: FungibleLeg,
+  memo?: string
+): Promise<PolymeshPrimitivesPortfolioFund> {
+  const { fromHolder, signingAccount } = storage;
+  const { asset, amount } = leg;
+
+  if (amount.lte(0)) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Amount should be greater than 0',
+    });
+  }
+
+  // allowances are granted key to key, so spender mode applies whenever the submitting Account
+  // isn't the source Account itself — even when both keys belong to the same DID. Portfolio
+  // sources are always authorized via custody on-chain, regardless of the owning DID
+  if (fromHolder instanceof Account && fromHolder.address !== signingAccount) {
+    // `isFungibleLegBuilder` narrows the leg to a `FungibleLeg`, whose `asset` is a
+    // `FungibleAsset` — but the parameter accepts `string | FungibleAsset`, so an Asset ID may
+    // still be there at runtime and has to be resolved before any of its methods can be used
+    const fungibleAsset = await asFungibleAsset(asset, context);
+    const allowance = await fungibleAsset.getAllowance({
+      owner: fromHolder,
+      spender: signingAccount,
+    });
+
+    if (allowance.lt(amount)) {
+      throw new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'Spender has insufficient allowance to cover the transfer',
+        data: {
+          allowance,
+        },
+      });
+    }
+  }
+
+  const [balance] = await fromHolder.getAssetBalances({ assets: [asset] });
+  if (!balance || balance.free.lt(amount)) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Sender has insufficient balance to cover the transfer',
+      data: {
+        balance,
+      },
+    });
+  }
+
+  return fungibleMovementToPortfolioFund(
+    { asset, amount, ...(memo !== undefined && { memo }) },
+    context
+  );
+}
+
+/**
+ * @hidden
+ */
+async function getNftFund(
+  context: Context,
+  storage: Storage,
+  leg: InstructionNftLeg,
+  memo?: string
+): Promise<PolymeshPrimitivesPortfolioFund> {
+  const { fromHolder, signingAccount } = storage;
+  const { asset, nfts } = leg;
+
+  // NFTs have no allowance mechanism, so only the owning key (or the owning identity's
+  // custodied Portfolio) can authorize their transfer
+  if (fromHolder instanceof Account && fromHolder.address !== signingAccount) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message:
+        'Only the owning key can transfer NFTs from an Account. Allowances do not apply to NFTs',
+    });
+  }
+
+  const assetId = await asAssetId(asset, context);
+
+  const unavailableNfts: BigNumber[] = [];
+  await Promise.all(
+    nfts.map(async nftId => {
+      const id = asNftId(nftId);
+      const nft = new Nft({ id, assetId }, context);
+
+      const owner = await nft.getOwner();
+      if (!owner?.isEqual(fromHolder)) {
+        unavailableNfts.push(id);
+        return;
+      }
+
+      const isLocked = await nft.isLocked();
+      if (isLocked) {
+        unavailableNfts.push(id);
+      }
+    })
+  );
+
+  if (unavailableNfts.length) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Some of the NFTs are not owned by the sender, are locked, or do not exist',
+      data: { unavailableNfts },
+    });
+  }
+
+  return nftMovementToPortfolioFund({ asset, nfts, ...(memo !== undefined && { memo }) }, context);
+}
+
+/**
+ * @hidden
+ */
 export async function getFund(
   context: Context,
   args: TransferFundsParams,
   storage: Storage
 ): Promise<PolymeshPrimitivesPortfolioFund> {
   const { memo, ...leg } = args;
-  const { fromHolder, signingAccount } = storage;
   const isFungible = await isFungibleLegBuilder(leg, context);
 
-  let rawFund: PolymeshPrimitivesPortfolioFund;
   if (isFungible(leg)) {
-    const { asset, amount } = leg;
-
-    if (amount.lte(0)) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: 'Amount should be greater than 0',
-      });
-    }
-
-    // allowances are granted key to key, so spender mode applies whenever the submitting Account
-    // isn't the source Account itself — even when both keys belong to the same DID. Portfolio
-    // sources are always authorized via custody on-chain, regardless of the owning DID
-    if (fromHolder instanceof Account && fromHolder.address !== signingAccount) {
-      // `isFungibleLegBuilder` narrows the leg to a `FungibleLeg`, whose `asset` is a
-      // `FungibleAsset` — but the parameter accepts `string | FungibleAsset`, so an Asset ID may
-      // still be there at runtime and has to be resolved before any of its methods can be used
-      const fungibleAsset = await asFungibleAsset(asset, context);
-      const allowance = await fungibleAsset.getAllowance({
-        owner: fromHolder,
-        spender: signingAccount,
-      });
-
-      if (allowance.lt(amount)) {
-        throw new PolymeshError({
-          code: ErrorCode.UnmetPrerequisite,
-          message: 'Spender has insufficient allowance to cover the transfer',
-          data: {
-            allowance,
-          },
-        });
-      }
-    }
-
-    const [balance] = await fromHolder.getAssetBalances({ assets: [asset] });
-    if (!balance || balance.free.lt(amount)) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: 'Sender has insufficient balance to cover the transfer',
-        data: {
-          balance,
-        },
-      });
-    }
-
-    rawFund = await fungibleMovementToPortfolioFund(
-      { asset, amount, ...(memo !== undefined && { memo }) },
-      context
-    );
-  } else {
-    const { asset, nfts } = leg as InstructionNftLeg;
-
-    // NFTs have no allowance mechanism, so only the owning key (or the owning identity's
-    // custodied Portfolio) can authorize their transfer
-    if (fromHolder instanceof Account && fromHolder.address !== signingAccount) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message:
-          'Only the owning key can transfer NFTs from an Account. Allowances do not apply to NFTs',
-      });
-    }
-
-    const assetId = await asAssetId(asset, context);
-
-    const unavailableNfts: BigNumber[] = [];
-    await Promise.all(
-      nfts.map(async nftId => {
-        const id = asNftId(nftId);
-        const nft = new Nft({ id, assetId }, context);
-
-        const owner = await nft.getOwner();
-        if (!owner || !owner.isEqual(fromHolder)) {
-          unavailableNfts.push(id);
-          return;
-        }
-
-        const isLocked = await nft.isLocked();
-        if (isLocked) {
-          unavailableNfts.push(id);
-        }
-      })
-    );
-
-    if (unavailableNfts.length) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: 'Some of the NFTs are not owned by the sender, are locked, or do not exist',
-        data: { unavailableNfts },
-      });
-    }
-
-    rawFund = await nftMovementToPortfolioFund(
-      { asset, nfts, ...(memo !== undefined && { memo }) },
-      context
-    );
+    return getFungibleFund(context, storage, leg, memo);
   }
 
-  return rawFund;
+  return getNftFund(context, storage, leg as InstructionNftLeg, memo);
 }
 
 /**

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -248,6 +248,7 @@ interface AccountOptions extends EntityOptions {
   stakingGetLedger?: EntityGetter<StakingLedger | null>;
   getMultiSig?: EntityGetter<MultiSig | null>;
   getNextAssetId?: EntityGetter<string>;
+  getAssetBalances?: EntityGetter<PortfolioBalance[]>;
 }
 
 interface SubsidyOptions extends EntityOptions {
@@ -720,6 +721,7 @@ const MockAccountClass = createMockEntityClass<AccountOptions>(
     checkPermissions!: jest.Mock;
     getMultiSig!: jest.Mock;
     getNextAssetId!: jest.Mock;
+    getAssetBalances!: jest.Mock;
     authorizations = {} as {
       getReceived: jest.Mock;
       getOne: jest.Mock;
@@ -763,11 +765,13 @@ const MockAccountClass = createMockEntityClass<AccountOptions>(
       this.staking.getNomination = createEntityGetterMock(opts.stakingGetNomination);
       this.getMultiSig = createEntityGetterMock(opts.getMultiSig);
       this.getNextAssetId = createEntityGetterMock(opts.getNextAssetId);
+      this.getAssetBalances = createEntityGetterMock(opts.getAssetBalances);
     }
   },
   () => ({
     address: 'someAddress',
     key: 'someKey',
+    getAssetBalances: [],
     getBalance: {
       free: new BigNumber(100),
       locked: new BigNumber(10),
@@ -2095,6 +2099,7 @@ const MockMultiSigClass = createMockEntityClass<MultiSigOptions>(
     stakingGetNomination: null,
     getMultiSig: null,
     getNextAssetId: '12341234-1234-1234-1234-123412341234',
+    getAssetBalances: [],
   }),
   ['MultiSig', 'Account']
 );


### PR DESCRIPTION
## Summary
- Removes the SDK-side block that rejected `assets.transferFunds` whenever `from` and `to` resolved to different identities. The chain (`settlement.transferFunds`) already supports this: it authorizes the source (allowance for `Account`, custody for `Portfolio`), creates a settlement instruction, auto-affirms the sender, and either executes immediately (if the receiver has automatic affirmation — the default) or leaves the instruction pending until the receiver affirms it.
- Fixed two spots that implicitly assumed same-DID:
  - The client-side balance/allowance pre-check now keys off whether the signer *owns* the source `Account` (spender/allowance mode) rather than DID equality, so cross-DID custody transfers (moving funds from a Portfolio owned by a different identity) get checked too.
  - `getAuthorization` now only requires portfolio permission on `toHolder` when the signer's own identity also owns it (mirroring the chain's auto-affirm condition) — previously it always required it, which would make cross-DID transfers fail permission checks since a signer's secondary-key permissions can never cover another identity's portfolio.
- `addInstruction`'s `createAddInstructionResolver` gained an optional `skipError` param, reused by `transferFunds` since the same-DID path legitimately emits no `InstructionCreated` event.

## Breaking change
`Assets.transferFunds` return type changed from `void` to `Instruction | undefined`. It resolves to the pending `Instruction` when a cross-DID transfer is left awaiting the receiver's affirmation, and `undefined` when the transfer settles immediately (same-DID, or the receiver auto-affirmed).

## Test plan
- [x] Unit tests updated/added in `transferFunds.ts` and `addInstruction.ts` test suites
- [x] Full suite passes (135 suites / 1158 tests) and `tsc` is clean
- [x] Verified end-to-end against a live chain (`polymesh-arm64:8705aca53b-develop-debian`) with two distinct identities:
  - Cross-DID Portfolio → Portfolio: returns pending `Instruction`, balance moves only after receiver affirms
  - Cross-DID Account → Account: same behavior
  - Same-DID Portfolio → Portfolio: still resolves `undefined`, settles immediately (no regression)