### PR TITLE
fix: 🐛 authorise ballot voting as a holder action (issue #1643)

### DIFF
--- a/src/api/procedures/__tests__/castBallotVote.ts
+++ b/src/api/procedures/__tests__/castBallotVote.ts
@@ -246,11 +246,46 @@ describe('castBallotVote procedure', () => {
       } as Params;
 
       expect(boundFunc(args)).toEqual({
-        permissions: {
+        signerPermissions: {
           transactions: [TxTags.corporateBallot.Vote],
           assets: [asset],
           portfolios: [],
         },
+        agentPermissions: true,
+      });
+    });
+
+    it('should not require External Agent permissions, since voting is a holder action', () => {
+      // A holder is not an Agent of the Asset they hold. Declaring `permissions`
+      // with a non-empty `assets` applies to Agents as well, which made this
+      // Procedure unreachable for its intended callers.
+      const boundFunc = getAuthorization.bind(proc);
+      const args = {
+        asset,
+        ballot,
+        votes: [[{ fallback: new BigNumber(0), power: new BigNumber(1) }]],
+      } as Params;
+
+      const result = boundFunc(args);
+
+      expect(result.agentPermissions).toBe(true);
+      expect(result.permissions).toBeUndefined();
+    });
+
+    it('should still scope a secondary Account permission to the Asset', () => {
+      // The Agent check is what has to go, not the Asset scoping: a secondary
+      // key permissioned for one Asset should not be able to vote on another.
+      const boundFunc = getAuthorization.bind(proc);
+      const args = {
+        asset,
+        ballot,
+        votes: [[{ fallback: new BigNumber(0), power: new BigNumber(1) }]],
+      } as Params;
+
+      expect(boundFunc(args).signerPermissions).toEqual({
+        transactions: [TxTags.corporateBallot.Vote],
+        assets: [asset],
+        portfolios: [],
       });
     });
   });

--- a/src/api/procedures/castBallotVote.ts
+++ b/src/api/procedures/castBallotVote.ts
@@ -195,12 +195,30 @@ export function getAuthorization(
   this: Procedure<Params, void>,
   { asset }: Params
 ): ProcedureAuthorization {
+  /*
+   * Voting is a holder action, so no External Agent permissions are required.
+   *
+   * `permissions` applies to both secondary Accounts and External Agent
+   * Identities, so naming the Asset there in order to scope the transaction
+   * permission also asserts that the signer is an Agent of that Asset — see
+   * `Procedure.checkRolesAndAgentPermissions`, which runs the Agent check
+   * whenever both `assets` and `transactions` are non-empty. A holder is not an
+   * Agent of the Asset they hold, so that made this Procedure unreachable for
+   * its intended callers, failing with "The Identity is not an Agent for the
+   * Asset".
+   *
+   * These are declared separately rather than by emptying `assets` (as
+   * `claimDividends` does) so that the Asset scoping of a secondary Account's
+   * permissions is preserved: a secondary key permissioned for one Asset should
+   * not be able to vote on another.
+   */
   return {
-    permissions: {
+    signerPermissions: {
       transactions: [TxTags.corporateBallot.Vote],
       assets: [asset],
       portfolios: [],
     },
+    agentPermissions: true,
   };
 }
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

**Casting a vote on a corporate ballot fails for every ordinary token holder.**
The Procedure is authorised as if voting were an External Agent action, so it is
unreachable for the callers it exists for.

`castBallotVote` declares a single `permissions` block naming the Asset:

```ts
permissions: {
  transactions: [TxTags.corporateBallot.Vote],
  assets: [asset],
  portfolios: [],
}
```

`permissions` applies to **both** secondary Accounts and External Agent
Identities, so scoping the transaction permission to the Asset also asserts that
the signer is an Agent of that Asset — `Procedure.checkRolesAndAgentPermissions`
runs the Agent check whenever both `assets` and `transactions` are non-empty.

A holder is not an Agent of the Asset they hold, so every vote fails with:

```
The signing Identity doesn't have the required permissions to execute this procedure

{ message: 'The Identity is not an Agent for the Asset',
  missingPermissions: ['corporateBallot.vote'] }
```

Note the practical effect: an issuer, who *is* an Agent, can vote on its own
ballot; the holders the ballot was opened for cannot.

**The chain does not require this.** The same vote, signed by the same holder
key, succeeds with `skipChecks: { agentPermissions: true }` and the tally is
recorded correctly. The requirement was only ever asserted client-side.

#### The change

fixing issue #1643

Declare the two separately: keep the Asset in `signerPermissions`, and set
`agentPermissions: true`.

```diff
-  return {
-    permissions: {
-      transactions: [TxTags.corporateBallot.Vote],
-      assets: [asset],
-      portfolios: [],
-    },
-  };
+  return {
+    signerPermissions: {
+      transactions: [TxTags.corporateBallot.Vote],
+      assets: [asset],
+      portfolios: [],
+    },
+    agentPermissions: true,
+  };
```

`ProcedureAuthorization` already documents both fields as taking precedence over
`permissions` for their respective signer types, and a boolean `agentPermissions`
short-circuits the Agent check.

#### Why not `assets: []`

`claimDividends` — the other holder-side corporate action — avoids the same trap
by passing an empty `assets` array, which works because the Agent check only runs
when `assets` is non-empty.

That shape was not copied here deliberately. `signerPermissions` is passed whole
to `Account.checkPermissions`, and `getMissingAssetPermissions` skips the Asset
comparison entirely when the required list is empty — so `assets: []` would also
drop the Asset scoping of a secondary Account's permissions, letting a secondary
key permissioned for one Asset vote on another. Splitting the declaration removes
the incorrect Agent assertion while keeping that scoping intact.

Out of scope, but worth flagging for maintainers: `claimDividends` carries that
same latent gap today.

#### Verification

- Observed and fixed against Polymesh **Development** chain, runtime `8000020`,
  SDK **v30.2.0**.
- `src/api/procedures/__tests__/castBallotVote.ts` — 11 passing, including two
  added cases: that no Agent permissions are required, and that the secondary
  Account's Asset scoping is retained. Reverting the fix fails three of them.
- Full suite green: **210 suites, 2533 tests**.
- ESLint clean on both changed files. `tsc` reports the same four pre-existing
  `rootDir`/`scripts` errors before and after.
- `prepareCastBallotVote` is untouched — the extrinsic and its arguments are
  unchanged, so there is no on-chain behaviour change.

### Breaking Changes

<!-- List all the breaking changes here -->

**None.** No public API signature changes, and nothing submitted to the chain
changes. The change only relaxes a client-side assertion, so no caller who
previously succeeded can now fail.

One observable behaviour change, which is the fix itself: for a holder who is not
an Agent, `ballot.vote.checkAuthorization(...)` now returns
`agentPermissions: { result: true }` instead of `{ result: false, message: 'The
Identity is not an Agent for the Asset' }`. Anything asserting that failure — a
test, or UI text telling holders they must be an Agent — will change accordingly.

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

N/A — external contribution, no JIRA access. Happy to open a GitHub issue first
if you would prefer this tracked before review.

### Checklist

- [x] Updated the Readme.md (if required) ?

  Not required — `README.md` does not document ballot voting or Procedure
  permissions, and no public API surface changed.
