### PR TITLE
feat: 🎸 add `Checkpoint.Schedules.getNextCheckpoint` getter

### DIFF
--- a/changelogs/v30.2.0-next.md
+++ b/changelogs/v30.2.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v30.2.0 to next release
-description: Pending changes since Polymesh SDK v30.2.0, to be included in the next release. Drops all chain v7 support — the SDK now targets chain v8 only. Includes breaking changes, deprecations, bug fixes, and migration steps.
+description: Pending changes since Polymesh SDK v30.2.0, to be included in the next release. Drops all chain v7 support — the SDK now targets chain v8 only. Includes breaking changes, deprecations, new features, bug fixes, and migration steps.
 sidebar_label: v30.2.0 → next
 id: v30-2-to-next
 tags:
@@ -35,6 +35,8 @@ This release **drops all chain v7 support and backward-compatibility code**, now
 **Curious about removed or deprecated APIs?** Visit [Deprecated APIs](#deprecated-apis).
 
 **Want to understand behavior changes?** See [Modified Behavior](#modified-behavior).
+
+**Looking for what's new?** See [New Features](#new-features).
 
 **Looking for fixes?** Check [Bug Fixes](#bug-fixes).
 
@@ -255,6 +257,22 @@ These paths previously branched on `context.isV7` and are now unconditional:
 - `Instruction.generateOffChainAffirmationTransactionRaw` always requires `expiresAt`, and the payload always uses the v8 receipt format.
 - `Identity.checkRoleForDid` and `Identity.isDidRegistrar` always query `didRegistrars.activeMembers` — the v7 `cddServiceProviders.activeMembers` fallback is gone. (`Identity.isGcMember` is unrelated and unchanged; it queries `committeeMembership.activeMembers`.)
 - `registerDid` and `selfRegisterDid` no longer guard against v7 chains.
+
+---
+
+## New features
+
+### `Asset.checkpoints.schedules.getNextCheckpoint` getter
+
+Returns the closest upcoming Checkpoint across all of an Asset's active Schedules, read from the chain's cached `checkpoint.cachedNextCheckpoints` storage instead of resolving each Schedule individually:
+
+```typescript
+const next = await asset.checkpoints.schedules.getNextCheckpoint();
+// { nextAt: Date, totalPending: BigNumber, schedules: [{ id: BigNumber, nextAt: Date }, ...] }
+// or null if the Asset has no active Schedules
+```
+
+This complements the existing `CheckpointSchedule.details()`, which resolves the next date for one specific Schedule — `getNextCheckpoint` gives an asset-wide summary in a single query.
 
 ---
 

--- a/src/api/entities/Asset/Fungible/Checkpoints/Schedules.ts
+++ b/src/api/entities/Asset/Fungible/Checkpoints/Schedules.ts
@@ -1,6 +1,7 @@
 import { PolymeshPrimitivesCheckpointScheduleCheckpoints } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 
+import { NextCheckpoints } from '~/api/entities/Asset/Fungible/Checkpoints/types';
 import {
   CheckpointSchedule,
   Context,
@@ -130,5 +131,41 @@ export class Schedules extends Namespace<FungibleAsset> {
     const complexity = await context.polymeshApi.query.checkpoint.schedulesMaxComplexity();
 
     return u64ToBigNumber(complexity);
+  }
+
+  /**
+   * Retrieve the cached next Checkpoint information for this Asset, aggregated across all of its active Schedules
+   *
+   * @returns `null` if the Asset has no active Schedules
+   */
+  public async getNextCheckpoint(): Promise<NextCheckpoints | null> {
+    const {
+      parent,
+      context: {
+        polymeshApi: {
+          query: { checkpoint },
+        },
+      },
+      context,
+    } = this;
+
+    const rawAssetId = assetToMeshAssetId(parent, context);
+
+    const rawNextCheckpointsOpt = await checkpoint.cachedNextCheckpoints(rawAssetId);
+
+    if (rawNextCheckpointsOpt.isNone) {
+      return null;
+    }
+
+    const { nextAt, totalPending, schedules } = rawNextCheckpointsOpt.unwrap();
+
+    return {
+      nextAt: momentToDate(nextAt),
+      totalPending: u64ToBigNumber(totalPending),
+      schedules: [...schedules.entries()].map(([id, scheduleNextAt]) => ({
+        id: u64ToBigNumber(id),
+        nextAt: momentToDate(scheduleNextAt),
+      })),
+    };
   }
 }

--- a/src/api/entities/Asset/Fungible/Checkpoints/__tests__/Schedules.ts
+++ b/src/api/entities/Asset/Fungible/Checkpoints/__tests__/Schedules.ts
@@ -207,4 +207,72 @@ describe('Schedules class', () => {
       expect(result).toEqual(new BigNumber(20));
     });
   });
+
+  describe('method: getNextCheckpoint', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return null if there is no cached next Checkpoint information', async () => {
+      const rawAssetId = dsMockUtils.createMockAssetId(assetId);
+
+      when(assetToMeshAssetIdSpy)
+        .calledWith(expect.objectContaining({ id: assetId }), context)
+        .mockReturnValue(rawAssetId);
+
+      dsMockUtils.createQueryMock('checkpoint', 'cachedNextCheckpoints', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+
+      const result = await schedules.getNextCheckpoint();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return the cached next Checkpoint information from the chain', async () => {
+      const rawAssetId = dsMockUtils.createMockAssetId(assetId);
+      const nextAt = new Date('10/14/2030');
+      const totalPending = new BigNumber(3);
+      const firstScheduleId = new BigNumber(1);
+      const secondScheduleId = new BigNumber(2);
+      const firstScheduleNextAt = new Date('10/14/2030');
+      const secondScheduleNextAt = new Date('11/14/2030');
+
+      when(assetToMeshAssetIdSpy)
+        .calledWith(expect.objectContaining({ id: assetId }), context)
+        .mockReturnValue(rawAssetId);
+
+      dsMockUtils.createQueryMock('checkpoint', 'cachedNextCheckpoints', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockNextCheckpoints({
+            nextAt: dsMockUtils.createMockMoment(new BigNumber(nextAt.getTime())),
+            totalPending: dsMockUtils.createMockU64(totalPending),
+            schedules: dsMockUtils.createMockBtreeMap(
+              new Map([
+                [
+                  dsMockUtils.createMockU64(firstScheduleId),
+                  dsMockUtils.createMockMoment(new BigNumber(firstScheduleNextAt.getTime())),
+                ],
+                [
+                  dsMockUtils.createMockU64(secondScheduleId),
+                  dsMockUtils.createMockMoment(new BigNumber(secondScheduleNextAt.getTime())),
+                ],
+              ])
+            ),
+          })
+        ),
+      });
+
+      const result = await schedules.getNextCheckpoint();
+
+      expect(result).toEqual({
+        nextAt,
+        totalPending,
+        schedules: [
+          { id: firstScheduleId, nextAt: firstScheduleNextAt },
+          { id: secondScheduleId, nextAt: secondScheduleNextAt },
+        ],
+      });
+    });
+  });
 });

--- a/src/api/entities/Asset/Fungible/Checkpoints/types.ts
+++ b/src/api/entities/Asset/Fungible/Checkpoints/types.ts
@@ -25,3 +25,29 @@ export type InputCaCheckpoint =
        */
       id: BigNumber;
     };
+
+export interface ScheduleNextCheckpoint {
+  /**
+   * identifier for the Checkpoint Schedule
+   */
+  id: BigNumber;
+  /**
+   * next Checkpoint creation date for this Schedule
+   */
+  nextAt: Date;
+}
+
+export interface NextCheckpoints {
+  /**
+   * closest upcoming Checkpoint creation date across all of the Asset's active Schedules
+   */
+  nextAt: Date;
+  /**
+   * total amount of pending Checkpoints across all of the Asset's active Schedules
+   */
+  totalPending: BigNumber;
+  /**
+   * next Checkpoint creation date for each active Schedule
+   */
+  schedules: ScheduleNextCheckpoint[];
+}

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -97,6 +97,7 @@ import {
   PolymeshPrimitivesAuthorization,
   PolymeshPrimitivesAuthorizationAuthorizationData,
   PolymeshPrimitivesCddId,
+  PolymeshPrimitivesCheckpointNextCheckpoints,
   PolymeshPrimitivesCheckpointScheduleCheckpoints,
   PolymeshPrimitivesComplianceManagerComplianceRequirement,
   PolymeshPrimitivesCondition,
@@ -3653,6 +3654,35 @@ export const createMockCheckpointSchedule = (
       pending,
     },
     !checkpointSchedule
+  );
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
+export const createMockNextCheckpoints = (
+  nextCheckpoints?:
+    | PolymeshPrimitivesCheckpointNextCheckpoints
+    | {
+        nextAt: Moment | Parameters<typeof createMockMoment>[0];
+        totalPending: u64 | Parameters<typeof createMockU64>[0];
+        schedules: BTreeMap<u64, u64> | Parameters<typeof createMockBtreeMap>[0];
+      }
+): MockCodec<PolymeshPrimitivesCheckpointNextCheckpoints> => {
+  const { nextAt, totalPending, schedules } = nextCheckpoints ?? {
+    nextAt: createMockMoment(),
+    totalPending: createMockU64(),
+    schedules: createMockBtreeMap(),
+  };
+
+  return createMockCodec(
+    {
+      nextAt: createMockMoment(nextAt),
+      totalPending: createMockU64(totalPending),
+      schedules,
+    },
+    !nextCheckpoints
   );
 };
 /**


### PR DESCRIPTION
## Summary
- Adds `Asset.checkpoints.schedules.getNextCheckpoint()`, which reads the chain's `checkpoint.cachedNextCheckpoints` storage
- Returns the closest upcoming Checkpoint creation date, total pending count, and per-Schedule next dates across all of an Asset's active Schedules, or `null` if nothing is cached
- Complementary to (and distinct from) `CheckpointSchedule.details()`, which resolves the next date for one specific schedule

## Test plan
- [x] Unit tests covering the `None` case and a populated case with multiple schedules (100% coverage on the changed file)
- [x] Verified against a live local dev chain: created an Asset, created a Checkpoint Schedule, issued supply to trigger the cache, and confirmed `getNextCheckpoint()` returns the expected `nextAt`/`totalPending`/`schedules` matching the on-chain cached value
- [x] `yarn tsc --noEmit -p tsconfig.lib.json` and `yarn eslint` pass with no errors