### PR TITLE
feat: 🎸 add `CorporateActionBase.getDocuments` getter

### DIFF
--- a/changelogs/v30.2.0-next.md
+++ b/changelogs/v30.2.0-next.md
@@ -274,6 +274,17 @@ const next = await asset.checkpoints.schedules.getNextCheckpoint();
 
 This complements the existing `CheckpointSchedule.details()`, which resolves the next date for one specific Schedule — `getNextCheckpoint` gives an asset-wide summary in a single query.
 
+### `CorporateActionBase.getDocuments` getter
+
+Returns the documents linked to a Corporate Action, read from the chain's `corporateAction.caDocLink` storage and resolved against the Asset's document list:
+
+```typescript
+const documents = await corporateAction.getDocuments();
+// AssetDocumentWithId[]
+```
+
+This is the missing read-side counterpart to the existing `linkDocuments` method, which writes to the same storage via `corporateAction.linkCaDoc`. Any linked document ID that no longer exists on the Asset (since removed) is omitted from the result.
+
 ---
 
 ## Bug fixes

--- a/src/api/entities/CorporateActionBase/__tests__/index.ts
+++ b/src/api/entities/CorporateActionBase/__tests__/index.ts
@@ -12,6 +12,7 @@ import {
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { createMockBtreeSet, createMockU64 } from '~/testUtils/mocks/dataSources';
 import {
+  AssetDocumentWithId,
   CorporateActionKind,
   CorporateActionTargets,
   TargetTreatment,
@@ -297,6 +298,64 @@ describe('CorporateAction class', () => {
       schedulePointsQueryMock.mockResolvedValue([]);
 
       return expect(corporateAction.checkpoint()).rejects.toThrow('No checkpoint found');
+    });
+  });
+
+  describe('method: getDocuments', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return an empty array if the CA has no linked documents', async () => {
+      dsMockUtils.createQueryMock('corporateAction', 'caDocLink', {
+        returnValue: [],
+      });
+      dsMockUtils.createQueryMock('asset', 'assetDocuments', {
+        multi: [],
+      });
+
+      const result = await corporateAction.getDocuments();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return the documents linked to the CA, omitting any that no longer exist on the Asset', async () => {
+      const firstDocId = new BigNumber(1);
+      const secondDocId = new BigNumber(2);
+
+      dsMockUtils.createQueryMock('corporateAction', 'caDocLink', {
+        returnValue: [
+          dsMockUtils.createMockU32(firstDocId),
+          dsMockUtils.createMockU32(secondDocId),
+        ],
+      });
+
+      dsMockUtils.createQueryMock('asset', 'assetDocuments', {
+        multi: [
+          dsMockUtils.createMockOption(
+            dsMockUtils.createMockDocument({
+              uri: dsMockUtils.createMockBytes('someUri'),
+              name: dsMockUtils.createMockBytes('someName'),
+              contentHash: dsMockUtils.createMockDocumentHash('None'),
+              docType: dsMockUtils.createMockOption(),
+              filingDate: dsMockUtils.createMockOption(),
+            })
+          ),
+          dsMockUtils.createMockOption(),
+        ],
+      });
+
+      const result = await corporateAction.getDocuments();
+
+      const expected: AssetDocumentWithId[] = [
+        {
+          id: firstDocId,
+          name: 'someName',
+          uri: 'someUri',
+        },
+      ];
+
+      expect(result).toEqual(expected);
     });
   });
 

--- a/src/api/entities/CorporateActionBase/index.ts
+++ b/src/api/entities/CorporateActionBase/index.ts
@@ -17,16 +17,19 @@ import {
   PolymeshError,
 } from '~/internal';
 import {
+  AssetDocumentWithId,
   ErrorCode,
   InputCaCheckpoint,
   LinkCaDocsParams,
   ModifyCaCheckpointParams,
   ProcedureMethod,
 } from '~/types';
-import { HumanReadableType, Modify } from '~/types/utils';
+import { HumanReadableType, Modify, tuple } from '~/types/utils';
 import {
   assetToMeshAssetId,
   bigNumberToU32,
+  corporateActionIdentifierToCaId,
+  documentToAssetDocumentWithId,
   momentToDate,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -157,6 +160,44 @@ export abstract class CorporateActionBase extends Entity<UniqueIdentifiers, unkn
    * @note any previous links are removed in favor of the new list
    */
   public linkDocuments: ProcedureMethod<LinkCaDocsParams, void>;
+
+  /**
+   * Retrieve the documents linked to this Corporate Action
+   */
+  public async getDocuments(): Promise<AssetDocumentWithId[]> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { corporateAction, asset },
+        },
+      },
+      context,
+      id,
+      asset: caAsset,
+    } = this;
+
+    const rawCaId = corporateActionIdentifierToCaId({ asset: caAsset, localId: id }, context);
+    const rawAssetId = assetToMeshAssetId(caAsset, context);
+
+    const rawDocIds = await corporateAction.caDocLink(rawCaId);
+
+    const rawDocuments = await asset.assetDocuments.multi(
+      rawDocIds.map(docId => tuple(rawAssetId, docId))
+    );
+
+    return rawDocuments.reduce<AssetDocumentWithId[]>((result, rawDocumentOpt, index) => {
+      if (rawDocumentOpt.isSome) {
+        result.push(
+          documentToAssetDocumentWithId({
+            document: rawDocumentOpt.unwrap(),
+            id: rawDocIds[index]!,
+          })
+        );
+      }
+
+      return result;
+    }, []);
+  }
 
   /**
    * Modify the Corporate Action's Checkpoint


### PR DESCRIPTION
## Summary
- Adds `CorporateActionBase.getDocuments()`, the missing read-side counterpart to the existing `linkDocuments` procedure (`corporateAction.linkCaDoc`)
- Reads `corporateAction.caDocLink` for the CA's linked document IDs, then batch-resolves them via `asset.assetDocuments.multi(...)`, filtering out any documents that were since removed from the Asset
- Returns `AssetDocumentWithId[]`, matching the shape already used by `Asset.documents.get()`

## Test plan
- [x] Unit tests covering no linked documents and multiple linked documents (one of which no longer exists on the Asset), 100% coverage on the changed file
- [x] Verified against a live local dev chain: added a document to an Asset, initiated a Corporate Action, linked the document via `linkDocuments`, and confirmed `getDocuments()` returns it correctly
- [x] `yarn tsc --noEmit -p tsconfig.lib.json` and `yarn eslint` pass with no errors