### PR TITLE
fix: 🐛 authorise ballot voting as a holder action

### DIFF
--- a/src/api/procedures/__tests__/castBallotVote.ts
+++ b/src/api/procedures/__tests__/castBallotVote.ts
@@ -239,16 +239,11 @@ describe('castBallotVote procedure', () => {
   describe('getAuthorization', () => {
     it('should return the appropriate roles and permissions', () => {
       const boundFunc = getAuthorization.bind(proc);
-      const args = {
-        asset,
-        ballot,
-        votes: [[{ fallback: new BigNumber(0), power: new BigNumber(1) }]],
-      } as Params;
 
-      expect(boundFunc(args)).toEqual({
+      expect(boundFunc()).toEqual({
         permissions: {
           transactions: [TxTags.corporateBallot.Vote],
-          assets: [asset],
+          assets: [],
           portfolios: [],
         },
       });

--- a/src/api/procedures/castBallotVote.ts
+++ b/src/api/procedures/castBallotVote.ts
@@ -191,14 +191,11 @@ export async function prepareCastBallotVote(
 /**
  * @hidden
  */
-export function getAuthorization(
-  this: Procedure<Params, void>,
-  { asset }: Params
-): ProcedureAuthorization {
+export function getAuthorization(this: Procedure<Params, void>): ProcedureAuthorization {
   return {
     permissions: {
       transactions: [TxTags.corporateBallot.Vote],
-      assets: [asset],
+      assets: [],
       portfolios: [],
     },
   };


### PR DESCRIPTION
### Description

Re-lands #1644 from a maintainer branch so the commit passes `Authenticate Commits`, which requires every commit in the PR range to be signed by a key in the org's allowed-signers list. Original bug report, diagnosis and fix by @savelkouls, credited as co-author on the commit.

**Casting a vote on a corporate ballot failed for every ordinary token holder.** `castBallotVote` declared its transaction permission scoped to the Asset:

```ts
permissions: {
  transactions: [TxTags.corporateBallot.Vote],
  assets: [asset],
  portfolios: [],
}
```

`Procedure.checkRolesAndAgentPermissions` runs the External Agent check whenever both `assets` and `transactions` are non-empty, so scoping the transaction to the Asset also asserted that the signer is an Agent of it. A holder is not an Agent of the Asset they hold, so every vote failed with:

```
The signing Identity doesn't have the required permissions to execute this procedure

{ message: 'The Identity is not an Agent for the Asset',
  missingPermissions: ['corporateBallot.vote'] }
```

The practical effect: an issuer, who *is* an Agent, could vote on its own ballot; the holders the ballot was opened for could not. The chain never required this — the same vote, signed by the same holder key, succeeds with `skipChecks: { agentPermissions: true }` and the tally is recorded correctly. The requirement was only ever asserted client-side.

#### The change

Asset permissions apply exclusively to agent actions, so the fix is to drop the Asset from `assets`, which in turn skips the Agent check:

```diff
-export function getAuthorization(
-  this: Procedure<Params, void>,
-  { asset }: Params
-): ProcedureAuthorization {
+export function getAuthorization(this: Procedure<Params, void>): ProcedureAuthorization {
   return {
     permissions: {
       transactions: [TxTags.corporateBallot.Vote],
-      assets: [asset],
+      assets: [],
       portfolios: [],
     },
   };
 }
```

This matches `claimDividends` and the other holder-side procedures.

Note this differs from the approach originally proposed in #1644, which split the declaration into `signerPermissions` plus `agentPermissions: true` on the assumption that a non-empty `assets` list also scoped a secondary Account's permissions. Per review, it does not — asset permissions are agent-scoped only, so the empty list is both correct and consistent with the rest of the codebase. See the [secondary key permissions docs](https://developers.polymesh.network/identity/advanced/secondary-keys/#secondary-key-permissions).

#### Verification

- Originally observed and fixed against Polymesh **Development** chain, runtime `8000020`, SDK **v30.2.0**.
- `src/api/procedures/__tests__/castBallotVote.ts` — 9 passing. Reverting the fix fails the `getAuthorization` case.
- ESLint clean on both changed files.
- `prepareCastBallotVote` is untouched — the extrinsic and its arguments are unchanged, so there is no on-chain behaviour change.

### Breaking Changes

**None.** No public API signature changes, and nothing submitted to the chain changes. The change only relaxes a client-side assertion, so no caller who previously succeeded can now fail.

One observable behaviour change, which is the fix itself: for a holder who is not an Agent, `ballot.vote.checkAuthorization(...)` now returns `agentPermissions: { result: true }` instead of `{ result: false, message: 'The Identity is not an Agent for the Asset' }`. Anything asserting that failure — a test, or UI text telling holders they must be an Agent — will change accordingly.

### JIRA Link

N/A — community-reported, tracked in #1643.

### Checklist

- [x] Updated the Readme.md (if required) ?

  Not required — `README.md` does not document ballot voting or Procedure permissions, and no public API surface changed.