### PR TITLE
fix: 🐛 compare NFT ownership by address for MultiSig Account holders in transferFunds

### DIFF
--- a/changelogs/v30.2.0-v31.0.0.md
+++ b/changelogs/v30.2.0-v31.0.0.md
@@ -459,6 +459,10 @@ The mapping is now explicit and mirrors the runtime. `identity.registerDid` is a
 
 > **`nft.createNftCollection` and `nft.issueNft` are unaffected.** Both map to `ProtocolOp` variants (`NFTCreateCollection`, `NFTMint`) that exist on chain but that the runtime has no `charge_fee` call site for, so both quoted 0 before this change and quote 0 after. The mappings are still correct: `nft.createNftCollection` only reaches a fee on the branch where it creates the asset itself, which the SDK never takes — it always passes an `assetId` and submits `asset.createAsset` separately when a new asset is needed.
 
+### `transferFunds` rejected NFTs owned by a MultiSig's own Account
+
+`transferFunds`'s NFT-ownership check compared the Account or Portfolio returned by `Nft.getOwner()` against the source holder using `Entity.isEqual`, whose uuid is keyed by the entity's constructor name. `getOwner()` always resolves an Account-type holder to a plain `Account`, so when the source was a `MultiSig`'s own Account — a `MultiSig` subclass instance — the comparison failed even though the address matched, and the transfer was rejected with `Some of the NFTs are not owned by the sender, are locked, or do not exist`. The check now compares by address whenever both sides are Account-like, falling back to `isEqual` for Portfolio holders.
+
 ---
 
 ## Version compatibility matrix

--- a/src/api/procedures/__tests__/transferFunds.ts
+++ b/src/api/procedures/__tests__/transferFunds.ts
@@ -485,6 +485,52 @@ describe('transferFunds procedure', () => {
       );
     });
 
+    it('should recognize a MultiSig as the NFT owner by address, even though `getOwner` always resolves Account holders to a plain Account', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const asset = entityMockUtils.getNftCollectionInstance({ assetId });
+      const multiSigHolder = entityMockUtils.getMultiSigInstance({ address: 'multiSigAddress' });
+      multiSigHolder.isEqual.mockReturnValue(false);
+      // `Nft.getOwner` always resolves Account-type holders to a plain `Account`, never the
+      // `MultiSig` subclass, so its `isEqual` would (correctly, matching real behavior) report
+      // no match against the MultiSig instance -- the ownership check must fall back to
+      // comparing addresses instead of relying on `isEqual` for this pairing
+      const plainAccountOwner = entityMockUtils.getAccountInstance({ address: 'multiSigAddress' });
+      plainAccountOwner.isEqual.mockReturnValue(false);
+
+      asAssetIdSpy.mockResolvedValue(assetId);
+      getOwnerSpy.mockResolvedValue(plainAccountOwner as unknown as AssetHolder);
+      isLockedSpy.mockResolvedValue(false);
+
+      nftMovementToPortfolioFundSpy.mockResolvedValue('rawNftFund');
+      assetHolderLikeToAssetHolderIdSpy.mockReturnValue('someHolderId');
+      assetHolderIdToMeshAssetHolderSpy.mockReturnValue('rawHolder');
+      createAddInstructionResolverSpy.mockReturnValue(() => []);
+
+      const proc = procedureMockUtils.getInstance<
+        TransferFundsParams,
+        Instruction | undefined,
+        Storage
+      >(mockContext, {
+        fromHolder: multiSigHolder,
+        toHolder: toPortfolioHolder,
+        fromDid: 'someDid',
+        toDid: 'someDid',
+        signingDid: 'someDid',
+        signingAccount: multiSigHolder.address,
+      });
+
+      const transaction = dsMockUtils.createTxMock('settlement', 'transferFunds');
+
+      const result = await prepareTransferFunds.call(proc, {
+        from: multiSigHolder,
+        to: toPortfolioHolder,
+        asset,
+        nfts: [new BigNumber(1)],
+      });
+
+      expect(result.transaction).toBe(transaction);
+    });
+
     it('should return a transfer funds transaction spec when fromHolder is an Account with sufficient allowance', async () => {
       const asset = entityMockUtils.getFungibleAssetInstance({ ticker: 'TICKER' });
       asset.getAllowance.mockResolvedValue(new BigNumber(150));

--- a/src/api/procedures/transferFunds.ts
+++ b/src/api/procedures/transferFunds.ts
@@ -124,7 +124,14 @@ async function getNftFund(
       const nft = new Nft({ id, assetId }, context);
 
       const owner = await nft.getOwner();
-      if (!owner?.isEqual(fromHolder)) {
+      // `getOwner` always resolves Account holders to a plain `Account`, so comparing a MultiSig
+      // `fromHolder` via `isEqual` would incorrectly fail (its uuid is keyed by class name) even
+      // when the address matches -- compare by address for any Account/MultiSig pairing instead
+      const isOwner =
+        owner instanceof Account && fromHolder instanceof Account
+          ? owner.address === fromHolder.address
+          : !!owner?.isEqual(fromHolder);
+      if (!isOwner) {
         unavailableNfts.push(id);
         return;
       }


### PR DESCRIPTION
## Summary
- `transferFunds`'s NFT-ownership check compared `nft.getOwner()`'s result against `fromHolder` via `Entity.isEqual`, whose uuid is keyed by the constructor's class name (`Account` vs `MultiSig`)
- `getOwner` always resolves Account-type holders to a plain `Account`, so a `MultiSig`-owned NFT could never match, even at the identical address — every NFT transfer sourced from a MultiSig's own Account holder was rejected with "Some of the NFTs are not owned by the sender, are locked, or do not exist"
- Found via live-chain verification of the (now-merged) cross-identity `transferFunds` feature (#1641), covering the full matrix: multisig/non-multisig × Account/Portfolio holder × fungible/NFT asset
- Fix compares by address for any Account/MultiSig pairing, falling back to `isEqual` for Portfolio holders

## Test plan
- [x] Added a regression test that fails without the fix and passes with it
- [x] Full `transferFunds` unit suite (31 tests) passes
- [x] Verified live against a local dev chain: MultiSig → Account NFT transfer now succeeds end-to-end (pending instruction → affirm → execute)