### PR TITLE
chore: 🤖 drop receiving Portfolio permission from transferFunds

### DIFF
--- a/src/api/procedures/__tests__/transferFunds.ts
+++ b/src/api/procedures/__tests__/transferFunds.ts
@@ -63,7 +63,6 @@ describe('transferFunds procedure', () => {
   let createAddInstructionResolverSpy: jest.SpyInstance;
   let asAssetIdSpy: jest.SpyInstance;
   let asFungibleAssetSpy: jest.SpyInstance;
-  let stringToAssetIdSpy: jest.SpyInstance;
   let getOwnerSpy: jest.SpyInstance;
   let isLockedSpy: jest.SpyInstance;
   let filterEventRecordsSpy: jest.SpyInstance;
@@ -97,7 +96,6 @@ describe('transferFunds procedure', () => {
     );
     asAssetIdSpy = jest.spyOn(utilsInternalModule, 'asAssetId');
     asFungibleAssetSpy = jest.spyOn(utilsInternalModule, 'asFungibleAsset');
-    stringToAssetIdSpy = jest.spyOn(utilsConversionModule, 'stringToAssetId');
     getOwnerSpy = jest.spyOn(Nft.prototype, 'getOwner');
     isLockedSpy = jest.spyOn(Nft.prototype, 'isLocked');
     filterEventRecordsSpy = jest.spyOn(utilsInternalModule, 'filterEventRecords');
@@ -977,13 +975,6 @@ describe('transferFunds procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    const args: TransferFundsParams = {
-      from: 'someAccount',
-      to: 'someOtherAccount',
-      asset: 'SOME_ASSET',
-      amount: new BigNumber(100),
-    };
-
     let fromPortfolioHolder: Mocked<NumberedPortfolio>;
     let toPortfolioHolder: Mocked<NumberedPortfolio>;
 
@@ -1001,10 +992,9 @@ describe('transferFunds procedure', () => {
 
       asAssetIdSpy.mockClear();
       asAssetIdSpy.mockResolvedValue('12341234-1234-1234-1234-123412341234');
-      stringToAssetIdSpy.mockReturnValue('rawAssetId');
     });
 
-    it('should require the source Portfolio permission and custody, without the destination, for a same-DID transfer', async () => {
+    it('should require the source Portfolio permission and custody, without the destination', async () => {
       const proc = procedureMockUtils.getInstance<
         TransferFundsParams,
         Instruction | undefined,
@@ -1020,7 +1010,7 @@ describe('transferFunds procedure', () => {
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc(args)).resolves.toEqual({
+      await expect(boundFunc()).resolves.toEqual({
         roles: true,
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
@@ -1029,8 +1019,8 @@ describe('transferFunds procedure', () => {
         },
       });
 
-      // the destination is never checked on the same-DID path, so its affirmation requirement
-      // doesn't need to be fetched
+      // the destination is never a hard requirement, so its affirmation requirement doesn't
+      // need to be fetched
       expect(asAssetIdSpy).not.toHaveBeenCalled();
     });
 
@@ -1052,7 +1042,7 @@ describe('transferFunds procedure', () => {
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc(args)).resolves.toEqual({
+      await expect(boundFunc()).resolves.toEqual({
         roles: 'The signing Identity must be the custodian of the origin Portfolio',
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
@@ -1082,7 +1072,7 @@ describe('transferFunds procedure', () => {
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc(args)).resolves.toEqual({
+      await expect(boundFunc()).resolves.toEqual({
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
           portfolios: [],
@@ -1112,7 +1102,7 @@ describe('transferFunds procedure', () => {
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc(args)).resolves.toEqual({
+      await expect(boundFunc()).resolves.toEqual({
         roles: true,
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
@@ -1122,19 +1112,16 @@ describe('transferFunds procedure', () => {
       });
     });
 
-    it("should include a cross-DID destination owned by the signer's Identity when the receiver has to affirm", async () => {
+    it("should exclude a cross-DID destination owned by the signer's Identity, even when the receiver has to affirm", async () => {
       const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
         did: 'otherDid',
         id: new BigNumber(1),
         isCustodiedBy: true,
       });
 
-      // the receiver has opted into mandatory affirmation, so the chain affirms on their behalf
-      // and runs the destination's custody/permission checks
-      dsMockUtils.createCallMock('settlementApi', 'getReceiverAffirmationRequirement', {
-        returnValue: { isAutomatic: false },
-      });
-
+      // the chain affirms the destination opportunistically on this path — it skips that
+      // affirmation and leaves the Instruction pending rather than rejecting the transfer, so
+      // the destination must not be demanded here
       const proc = procedureMockUtils.getInstance<
         TransferFundsParams,
         Instruction | undefined,
@@ -1150,45 +1137,7 @@ describe('transferFunds procedure', () => {
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc(args)).resolves.toEqual({
-        roles: true,
-        permissions: {
-          transactions: [TxTags.settlement.TransferFunds],
-          portfolios: [fromHolder, toPortfolioHolder],
-          assets: [],
-        },
-      });
-    });
-
-    it("should exclude a cross-DID destination owned by the signer's Identity when it is auto-affirmed", async () => {
-      const fromHolder = entityMockUtils.getNumberedPortfolioInstance({
-        did: 'otherDid',
-        id: new BigNumber(1),
-        isCustodiedBy: true,
-      });
-
-      // auto-affirmation is decided by the receiver alone, so the chain never affirms the
-      // destination and never checks it
-      dsMockUtils.createCallMock('settlementApi', 'getReceiverAffirmationRequirement', {
-        returnValue: { isAutomatic: true },
-      });
-
-      const proc = procedureMockUtils.getInstance<
-        TransferFundsParams,
-        Instruction | undefined,
-        Storage
-      >(mockContext, {
-        fromHolder,
-        toHolder: toPortfolioHolder,
-        fromDid: 'otherDid',
-        toDid: 'someDid',
-        signingDid: 'someDid',
-        signingAccount: 'someAccount',
-      });
-
-      const boundFunc = getAuthorization.bind(proc);
-
-      await expect(boundFunc(args)).resolves.toEqual({
+      await expect(boundFunc()).resolves.toEqual({
         roles: true,
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],
@@ -1206,10 +1155,6 @@ describe('transferFunds procedure', () => {
       });
       const toHolder = entityMockUtils.getAccountInstance({ address: 'someAccount' });
 
-      dsMockUtils.createCallMock('settlementApi', 'getReceiverAffirmationRequirement', {
-        returnValue: { isAutomatic: false },
-      });
-
       const proc = procedureMockUtils.getInstance<
         TransferFundsParams,
         Instruction | undefined,
@@ -1225,7 +1170,7 @@ describe('transferFunds procedure', () => {
 
       const boundFunc = getAuthorization.bind(proc);
 
-      await expect(boundFunc(args)).resolves.toEqual({
+      await expect(boundFunc()).resolves.toEqual({
         roles: true,
         permissions: {
           transactions: [TxTags.settlement.TransferFunds],

--- a/src/api/procedures/transferFunds.ts
+++ b/src/api/procedures/transferFunds.ts
@@ -19,7 +19,6 @@ import {
   assetHolderLikeToAssetHolderId,
   fungibleMovementToPortfolioFund,
   nftMovementToPortfolioFund,
-  stringToAssetId,
 } from '~/utils/conversion';
 import { asAssetId, asFungibleAsset, asNftId, filterEventRecords } from '~/utils/internal';
 import { isFungibleLegBuilder, isPortfolioAssetHolder } from '~/utils/typeguards';
@@ -247,34 +246,11 @@ export async function prepareTransferFunds(
  * @hidden
  */
 export async function getAuthorization(
-  this: Procedure<TransferFundsParams, Instruction | undefined, Storage>,
-  { asset }: TransferFundsParams
+  this: Procedure<TransferFundsParams, Instruction | undefined, Storage>
 ): Promise<ProcedureAuthorization> {
   const {
-    context,
-    storage: { fromHolder, toHolder, fromDid, toDid, signingDid },
+    storage: { fromHolder, signingDid },
   } = this;
-
-  // the source is authorized on every path
-  const holders: AssetHolder[] = [fromHolder];
-
-  // the destination is only checked cross-identity, and only when the chain affirms on the
-  // receiver's behalf: that needs the caller's own Identity to own it, and the receiver to not
-  // auto-affirm (the receiver's own setting, never the signer's). Same-identity transfers move
-  // the funds directly and never look at the destination
-  if (fromDid !== toDid && toDid === signingDid) {
-    const assetId = await asAssetId(asset, context);
-
-    const { isAutomatic } =
-      await context.polymeshApi.call.settlementApi.getReceiverAffirmationRequirement(
-        assetHolderIdToMeshAssetHolder(assetHolderLikeToAssetHolderId(toHolder), context),
-        stringToAssetId(assetId, context)
-      );
-
-    if (!isAutomatic) {
-      holders.push(toHolder);
-    }
-  }
 
   let roles: ProcedureAuthorization['roles'];
 
@@ -292,7 +268,9 @@ export async function getAuthorization(
     permissions: {
       transactions: [TxTags.settlement.TransferFunds],
       assets: [],
-      portfolios: holders.filter(isPortfolioAssetHolder),
+      // the destination is never required - the chain affirms it opportunistically, leaving the
+      // Instruction pending rather than failing when the caller can't affirm it
+      portfolios: [fromHolder].filter(isPortfolioAssetHolder),
     },
   };
 }


### PR DESCRIPTION
### Description

`transferFunds` declared the receiving Portfolio in `permissions.portfolios` on the
cross-identity path where the signer is also the receiver. That mirrored the chain,
which affirmed the destination via `unsafe_affirm_instruction` and reverted the whole
extrinsic when the signer lacked custody of, or key permission over, that Portfolio.

[Polymesh#1991](https://github.com/PolymeshAssociation/Polymesh/pull/1991) makes that
affirmation opportunistic — the chain now skips it and leaves the Instruction
`Pending` instead of rejecting the transfer. The destination is no longer a hard
requirement, so it is dropped from the declared authorization, along with the
`settlementApi.getReceiverAffirmationRequirement` call that gated it.

Source side unchanged: origin Portfolio permission and the custodian `roles` check
both remain.

**Ordering:** the chain PR isn't merged yet. Until it ships, an affected signer gets
an on-chain revert rather than a pre-flight rejection — the transfer fails either way. This is a new feature so is not currently in use and deemed acceptable.

### Breaking Changes

None — cross-identity `transferFunds` is itself new in v31.0.0, so no released
behavior changes.

### JIRA Link

<!-- add ticket -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
