### PR TITLE
fix: getNextCheckpoint null after schedule removal and STO receipt expiry

### DIFF
--- a/changelogs/v30.2.0-v31.0.0.md
+++ b/changelogs/v30.2.0-v31.0.0.md
@@ -310,7 +310,7 @@ Returns the closest upcoming Checkpoint across all of an Asset's active Schedule
 ```typescript
 const next = await asset.checkpoints.schedules.getNextCheckpoint();
 // { nextAt: Date, totalPending: BigNumber, schedules: [{ id: BigNumber, nextAt: Date }, ...] }
-// or null if the Asset has no active Schedules
+// or null if the Asset has no active Schedules (including after every Schedule has been removed)
 ```
 
 This complements the existing `CheckpointSchedule.details()`, which resolves the next date for one specific Schedule — `getNextCheckpoint` gives an asset-wide summary in a single query.
@@ -458,6 +458,14 @@ The mapping is now explicit and mirrors the runtime. `identity.registerDid` is a
 `createAsset` also stopped adding a manual fee for `asset.registerCustomAssetType`. There is no `ProtocolOp` variant for it — the runtime charges nothing for the registration — so the addition was always exactly 0.
 
 > **`nft.createNftCollection` and `nft.issueNft` are unaffected.** Both map to `ProtocolOp` variants (`NFTCreateCollection`, `NFTMint`) that exist on chain but that the runtime has no `charge_fee` call site for, so both quoted 0 before this change and quote 0 after. The mappings are still correct: `nft.createNftCollection` only reaches a fee on the branch where it creates the asset itself, which the SDK never takes — it always passes an `assetId` and submits `asset.createAsset` separately when a new asset is needed.
+
+### `getNextCheckpoint` returns null after every Schedule has been removed
+
+`Asset.checkpoints.schedules.getNextCheckpoint` is documented to return `null` when the Asset has no active Schedules. That held while `checkpoint.cachedNextCheckpoints` was unset, but **removing** a Schedule does not clear the storage entry — `base_remove_schedule` only drops the Schedule from the map and recalculates `nextAt`. The entry is removed later, when `advance_schedules` observes an empty map.
+
+Until then the chain keeps a sentinel `{ nextAt: u64::MAX, totalPending: 0, schedules: {} }`. `momentToDate` called `u64.toNumber()` on that `nextAt` and threw `Number can only safely store up to 53 bits`.
+
+The getter now treats an empty `schedules` map as "no active Schedules" and returns `null`, matching `NextCheckpoints::is_empty` on chain.
 
 ### `transferFunds` rejected NFTs owned by a MultiSig's own Account
 

--- a/changelogs/v30.2.0-v31.0.0.md
+++ b/changelogs/v30.2.0-v31.0.0.md
@@ -73,6 +73,7 @@ Use this checklist when upgrading from v30.2.0.
 10. Remove usage of `ScopeClaimProof`, `AddInvestorUniquenessClaimParams`, `ModifyPrimaryIssuanceAgentParams` and `ModifyCorporateActionsAgentParams` (see [Removed types describing extrinsics that no longer exist](#8-removed-types-describing-extrinsics-that-no-longer-exist))
 11. Update any code that types `Assets.transferFunds`'s result as `void` (see [`Assets.transferFunds` return type changed](#9-assetstransferfunds-return-type-changed))
 12. Remove usage of `MiddlewareMetadata.paddedIds` (see [`MiddlewareMetadata.paddedIds` removed](#10-middlewaremetadatapaddedids-removed))
+13. Pass `expiresAt` to `Instruction.generateOffChainAffirmationReceipt` and `Offering.generateOffChainFundingReceipt` (see [`expiresAt` is required on off-chain receipts](#11-expiresat-is-required-on-off-chain-receipts))
 
 ---
 
@@ -251,6 +252,33 @@ Code that reads `paddedIds` off the metadata should drop it. No query results ch
 
 ---
 
+### 11. `expiresAt` is required on off-chain receipts
+
+Chain v8 signs off-chain receipts as a `ChainScopedMessage`, which always includes an expiry. `expiresAt` is therefore a required argument of:
+
+- `Instruction.generateOffChainAffirmationReceipt`
+- `Offering.generateOffChainFundingReceipt`
+
+and a required field on `OffChainAffirmationReceipt` and `OffChainFundingReceipt`.
+
+```typescript
+await instruction.generateOffChainAffirmationReceipt({
+  legId,
+  uid,
+  expiresAt: new Date('2030-01-01'),
+});
+
+await offering.generateOffChainFundingReceipt({
+  uid,
+  offChainTicker,
+  amount,
+  sender,
+  expiresAt: new Date('2030-01-01'),
+});
+```
+
+---
+
 ## Deprecated APIs
 
 ### `registerIdentity`'s `createCdd` / `expiry` params
@@ -275,7 +303,7 @@ These paths previously branched on `context.isV7` and are now unconditional:
 
 - `Context.getAccountBalance` uses only the v8 `FrameSystemAccountInfo` shape — the legacy `AccountInfo` assembly path is removed.
 - `transferPolyx` always uses `balances.transferWithMemo` with an optional memo — v7's memo-less `balances.transfer` path is removed.
-- `Instruction.generateOffChainAffirmationTransactionRaw` always requires `expiresAt`, and the payload always uses the v8 receipt format.
+- `Instruction.generateOffChainAffirmationReceipt` and `Instruction.generateOffChainAffirmationTransactionRaw` always require `expiresAt`, and the payload always uses the v8 receipt format.
 - `Identity.checkRoleForDid` and `Identity.isDidRegistrar` always query `didRegistrars.activeMembers` — the v7 `cddServiceProviders.activeMembers` fallback is gone. (`Identity.isGcMember` is unrelated and unchanged; it queries `committeeMembership.activeMembers`.)
 - `registerDid` and `selfRegisterDid` no longer guard against v7 chains.
 
@@ -466,6 +494,24 @@ The mapping is now explicit and mirrors the runtime. `identity.registerDid` is a
 Until then the chain keeps a sentinel `{ nextAt: u64::MAX, totalPending: 0, schedules: {} }`. `momentToDate` called `u64.toNumber()` on that `nextAt` and threw `Number can only safely store up to 53 bits`.
 
 The getter now treats an empty `schedules` map as "no active Schedules" and returns `null`, matching `NextCheckpoints::is_empty` on chain.
+
+### STO off-chain funding receipts now encode `expiresAt`
+
+`PolymeshPrimitivesStoFundraiserReceiptDetails` includes `expiresAt`. `offChainFundingReceiptDetailsToMeshReceiptDetails` never set it, so it encoded as `0` and the chain rejected every off-chain funded investment with `sto.ReceiptExpired`. `Offering.generateOffChainFundingReceipt` also had no way to supply an expiry, and did not include genesis hash, receipt label or expiry in the signed payload — unlike settlement receipts, which were fixed in 30.1.1-beta.3.
+
+Pass `expiresAt` when generating a funding receipt (same contract as `Instruction.generateOffChainAffirmationReceipt`):
+
+```typescript
+const receipt = await offering.generateOffChainFundingReceipt({
+  uid,
+  offChainTicker,
+  amount,
+  sender,
+  expiresAt: new Date('2030-01-01'),
+});
+```
+
+The signed payload now matches the chain's `ChainScopedMessage`: `<Bytes>` + genesis hash + uid + SCALE-encoded `"Polymesh STO Fundraiser Receipt"` label + expiry + fundraiser receipt + `</Bytes>`.
 
 ### `transferFunds` rejected NFTs owned by a MultiSig's own Account
 

--- a/src/api/entities/Asset/Fungible/Checkpoints/Schedules.ts
+++ b/src/api/entities/Asset/Fungible/Checkpoints/Schedules.ts
@@ -159,6 +159,17 @@ export class Schedules extends Namespace<FungibleAsset> {
 
     const { nextAt, totalPending, schedules } = rawNextCheckpointsOpt.unwrap();
 
+    /*
+     * removing a Schedule does not clear the cached entry, it just drops the Schedule from the map and
+     * resets `nextAt` to the `u64::MAX` sentinel (the entry is only removed once the Schedules run their
+     * course). The chain's `NextCheckpoints::is_empty` is defined as an empty `schedules` map, so that is
+     * the authoritative signal for "no active Schedules". Reading `nextAt` in that state would also
+     * overflow, since `u64::MAX` cannot be represented as a JS number
+     */
+    if (schedules.size === 0) {
+      return null;
+    }
+
     return {
       nextAt: momentToDate(nextAt),
       totalPending: u64ToBigNumber(totalPending),

--- a/src/api/entities/Asset/Fungible/Checkpoints/__tests__/Schedules.ts
+++ b/src/api/entities/Asset/Fungible/Checkpoints/__tests__/Schedules.ts
@@ -229,6 +229,32 @@ describe('Schedules class', () => {
       expect(result).toBeNull();
     });
 
+    it('should return null if every Schedule has been removed', async () => {
+      const rawAssetId = dsMockUtils.createMockAssetId(assetId);
+
+      when(assetToMeshAssetIdSpy)
+        .calledWith(expect.objectContaining({ id: assetId }), context)
+        .mockReturnValue(rawAssetId);
+
+      /*
+       * removing every Schedule leaves the cached entry in place, with no Schedules and `nextAt` set to
+       * the `u64::MAX` sentinel
+       */
+      dsMockUtils.createQueryMock('checkpoint', 'cachedNextCheckpoints', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockNextCheckpoints({
+            nextAt: dsMockUtils.createMockMoment(new BigNumber('18446744073709551615')),
+            totalPending: dsMockUtils.createMockU64(new BigNumber(0)),
+            schedules: dsMockUtils.createMockBtreeMap(new Map()),
+          })
+        ),
+      });
+
+      const result = await schedules.getNextCheckpoint();
+
+      expect(result).toBeNull();
+    });
+
     it('should return the cached next Checkpoint information from the chain', async () => {
       const rawAssetId = dsMockUtils.createMockAssetId(assetId);
       const nextAt = new Date('10/14/2030');

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -2869,13 +2869,5 @@ describe('Instruction class', () => {
         signer,
       });
     });
-    it('should throw an error if expiresAt is not provided', () => {
-      return expect(
-        instruction.generateOffChainAffirmationReceipt({
-          legId,
-          uid,
-        })
-      ).rejects.toThrow('`expiresAt` is required');
-    });
   });
 });

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -1343,6 +1343,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
    * @param args.metadata (optional) metadata to be associated with the receipt
    * @param args.signer (optional) Signer to be used to generate receipt signature. Defaults to signing Account associated with the SDK
    * @param args.signerKeyRingType (optional) keyring type of the signer. Defaults to 'Sr25519'
+   * @param args.expiresAt timestamp at which the receipt expires and can no longer be used to affirm
    */
   public async generateOffChainAffirmationReceipt(args: {
     legId: BigNumber;
@@ -1350,7 +1351,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
     metadata?: string;
     signer?: string | Account;
     signerKeyRingType?: SignerKeyRingType;
-    expiresAt?: Date;
+    expiresAt: Date;
   }): Promise<OffChainAffirmationReceipt> {
     const {
       id,
@@ -1370,13 +1371,6 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
       signerKeyRingType = SignerKeyRingType.Sr25519,
       expiresAt,
     } = args;
-
-    if (!expiresAt) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: '`expiresAt` is required',
-      });
-    }
 
     const rawId = bigNumberToU64(id, context);
     const rawLegId = bigNumberToU64(legId, context);

--- a/src/api/entities/Offering/__tests__/index.ts
+++ b/src/api/entities/Offering/__tests__/index.ts
@@ -4,6 +4,14 @@ import {
   PolymeshPrimitivesTicker,
 } from '@polkadot/types/lookup';
 import { Bytes, Option, U64, U128 } from '@polkadot/types-codec';
+import {
+  hexAddPrefix,
+  hexStripPrefix,
+  stringToHex,
+  stringToU8a,
+  u8aConcat,
+  u8aToHex,
+} from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -506,7 +514,7 @@ describe('Offering class', () => {
     });
   });
 
-  describe('method: generateOffChainAffirmationReceipt', () => {
+  describe('method: generateOffChainFundingReceipt', () => {
     let uid: BigNumber;
     let id: BigNumber;
     let rawId: U64;
@@ -526,6 +534,8 @@ describe('Offering class', () => {
     let offering: Offering;
     let rawFundraiser: Option<PalletStoFundraiser>;
     let rawFundraiserName: Option<Bytes>;
+    let rawExpiresAt: ReturnType<typeof dsMockUtils.createMockMoment>;
+    let label: Uint8Array;
 
     beforeAll(() => {
       bigNumberToU64Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU64');
@@ -538,6 +548,7 @@ describe('Offering class', () => {
       senderIdentity = '0x12'.padStart(66, '1');
       receiverIdentity = '0x01'.padStart(66, '0');
       offChainTicker = 'OFFCHAIN';
+      label = stringToU8a('Polymesh STO Fundraiser Receipt');
     });
 
     beforeEach(() => {
@@ -586,15 +597,28 @@ describe('Offering class', () => {
       dsMockUtils.createQueryMock('sto', 'fundraiserNames', {
         returnValue: rawFundraiserName,
       });
+
+      rawExpiresAt = dsMockUtils.createMockMoment(new BigNumber(1000));
+      jest.spyOn(utilsConversionModule, 'dateToMoment').mockReturnValue(rawExpiresAt);
+
+      when(context.createType)
+        .calledWith('Bytes', 'Polymesh STO Fundraiser Receipt')
+        .mockReturnValue({
+          toU8a: () => u8aConcat(new Uint8Array([label.length << 2]), label),
+        } as unknown as Bytes);
+
       offering = new Offering({ assetId: '12341234-1234-1234-1234-123412341234', id }, context);
     });
 
     it('should return the funding receipt for offchain ticker', async () => {
+      const expiresAt = new Date('2030/01/01');
+
       const result = await offering.generateOffChainFundingReceipt({
         uid,
         offChainTicker,
         amount,
         sender: senderIdentity,
+        expiresAt,
       });
 
       expect(result).toEqual({
@@ -607,12 +631,14 @@ describe('Offering class', () => {
           value: '0xsignature',
         },
         metadata: undefined,
+        expiresAt,
       });
     });
 
     it('should return the funding receipt for offchain ticker with signer', async () => {
       const signer = 'someSigner';
       const metadata = 'some metadata';
+      const expiresAt = new Date('2030/01/01');
 
       const result = await offering.generateOffChainFundingReceipt({
         uid,
@@ -622,6 +648,7 @@ describe('Offering class', () => {
         signerKeyRingType: SignerKeyRingType.Ed25519,
         signer,
         metadata,
+        expiresAt,
       });
 
       expect(result).toEqual({
@@ -632,10 +659,29 @@ describe('Offering class', () => {
           value: '0xsignature',
         },
         metadata,
+        expiresAt,
       });
 
+      /*
+       * the chain rebuilds the signed payload as `<Bytes>` + genesis hash + uid + the SCALE encoded
+       * receipt label + the receipt expiry + the receipt itself + `</Bytes>`
+       */
+      const expectedPayload = [
+        stringToHex('<Bytes>'),
+        context.polymeshApi.genesisHash.toHex(),
+        rawUid.toHex(true),
+        u8aToHex(u8aConcat(new Uint8Array([label.length << 2]), label)),
+        rawExpiresAt.toHex(true),
+        rawId.toHex(true),
+        rawSenderIdentity.toHex(),
+        rawReceiverIdentity.toHex(),
+        rawTicker.toHex(),
+        rawAmount.toHex(true),
+        stringToHex('</Bytes>'),
+      ];
+
       expect(context.getSignature).toHaveBeenCalledWith({
-        rawPayload: expect.stringMatching(/0x3c42797465733e(.*)3c2f42797465733e/),
+        rawPayload: hexAddPrefix(expectedPayload.map(e => hexStripPrefix(e)).join('')),
         signer,
       });
     });

--- a/src/api/entities/Offering/index.ts
+++ b/src/api/entities/Offering/index.ts
@@ -1,6 +1,6 @@
 import { Bytes, Option } from '@polkadot/types';
 import { PalletStoFundraiser } from '@polkadot/types/lookup';
-import { hexAddPrefix, hexStripPrefix, stringToHex } from '@polkadot/util';
+import { hexAddPrefix, hexStripPrefix, stringToHex, u8aToHex } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 
 import { Investment, OfferingDetails } from '~/api/entities/Offering/types';
@@ -36,7 +36,9 @@ import {
   assetToMeshAssetId,
   bigNumberToU64,
   bigNumberToU128,
+  dateToMoment,
   fundraiserToOfferingDetails,
+  stringToBytes,
   stringToIdentityId,
   stringToTicker,
   tickerToString,
@@ -360,9 +362,13 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
    * @param args.metadata - (optional) additional metadata to be associated with the receipt
    * @param args.signer - (optional) authorized venue receipt signer to generate the cryptographic signature. Defaults to signing Account associated with the SDK
    * @param args.signerKeyRingType - (optional) keyring type for signature generation. Defaults to 'Sr25519'. Supported types: SR25519, ED25519, ECDSA
+   * @param args.expiresAt - timestamp at which the receipt expires and can no longer be used to invest
    *
    * @note The generated receipt contains SCALE-encoded data wrapped with `<Bytes>` tags, including:
+   * - Chain genesis hash
    * - Receipt UID
+   * - Receipt label
+   * - Receipt expiry
    * - Fundraiser ID
    * - Sender's DID (investor)
    * - Receiver's DID (raising portfolio owner)
@@ -379,6 +385,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
     metadata?: string;
     signer?: string | Account;
     signerKeyRingType?: SignerKeyRingType;
+    expiresAt: Date;
   }): Promise<OffChainFundingReceipt> {
     const { id, context } = this;
 
@@ -390,6 +397,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
       sender,
       offChainTicker,
       amount,
+      expiresAt,
     } = args;
 
     const rawFundraiserId = bigNumberToU64(id, context);
@@ -409,7 +417,13 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
 
     const payloadStrings = [
       stringToHex('<Bytes>'),
+      context.polymeshApi.genesisHash.toHex(),
       rawUid.toHex(true),
+      // the chain encodes the label as a SCALE `&[u8]`, which is length
+      // prefixed - `Bytes.toHex()` strips that prefix, so `toU8a()` (the
+      // full wire encoding) has to be used instead
+      u8aToHex(stringToBytes('Polymesh STO Fundraiser Receipt', context).toU8a()),
+      dateToMoment(expiresAt, context).toHex(true),
       rawFundraiserId.toHex(true),
       rawSender.toHex(),
       rawReceiver.toHex(),
@@ -430,6 +444,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
         value: signatureValue,
       },
       metadata,
+      expiresAt,
     };
   }
 }

--- a/src/api/entities/Offering/types.ts
+++ b/src/api/entities/Offering/types.ts
@@ -117,4 +117,8 @@ export interface OffChainFundingReceipt {
    * (optional) Metadata value that can be used to attach messages to the receipt
    */
   metadata: string | undefined;
+  /**
+   * Timestamp at which the receipt expires
+   */
+  expiresAt: Date;
 }

--- a/src/api/procedures/__tests__/investInOffering.ts
+++ b/src/api/procedures/__tests__/investInOffering.ts
@@ -137,6 +137,7 @@ describe('investInOffering procedure', () => {
         value: '0xSomevalue',
       },
       metadata: 'Some metadata',
+      expiresAt: new Date('2030/01/01'),
     };
   });
 

--- a/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
+++ b/src/api/procedures/__tests__/modifyInstructionAffirmation.ts
@@ -397,6 +397,7 @@ describe('modifyInstructionAffirmation procedure', () => {
           value: '0xsignature',
         },
         metadata: 'Optional metadata',
+        expiresAt: new Date('2030/01/01'),
       };
 
       offChainAffirmationsQueryMock.mockResolvedValue(

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1178,7 +1178,7 @@ export interface OffChainAffirmationReceipt {
   /**
    * Timestamp at which the receipt expires
    */
-  expiresAt?: Date | undefined;
+  expiresAt: Date;
 }
 
 export type AffirmInstructionParams = {

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -11551,25 +11551,6 @@ describe('receiptDetailsToMeshReceiptDetails', () => {
 
     expect(result).toEqual(fakeResult);
   });
-
-  it('should throw an error if expiresAt is missing', () => {
-    const context = dsMockUtils.getContextInstance();
-    const instructionId = new BigNumber(1);
-    const receipt: OffChainAffirmationReceipt = {
-      uid: new BigNumber(1),
-      legId: new BigNumber(0),
-      signer: '5EYCAe5ijAx5xEfZdpCna3grUpY1M9M5vLUH5vpmwV1EnaYR',
-      signature: {
-        type: SignerKeyRingType.Sr25519,
-        value: '0xsomevalue',
-      },
-      metadata: 'Random metadata',
-    };
-
-    expect(() => receiptDetailsToMeshReceiptDetails([receipt], instructionId, context)).toThrow(
-      '`expiresAt` is required'
-    );
-  });
 });
 
 describe('portfolioIdStringToPortfolio', () => {
@@ -12779,11 +12760,8 @@ describe('offChainFundingReceiptDetailsToMeshReceiptDetails', () => {
     const context = dsMockUtils.getContextInstance();
     jest.spyOn(utilsInternalModule, 'assertAddressValid').mockImplementation();
 
+    const expiresAt = new Date('2030/01/01');
     const fakeResult = 'fakeResult' as unknown as PolymeshPrimitivesStoFundraiserReceiptDetails;
-
-    when(context.createType)
-      .calledWith('PolymeshPrimitivesStoFundraiserReceiptDetails', expect.any(Object))
-      .mockReturnValue(fakeResult);
 
     const mockReceiptDetails: OffChainFundingReceipt = {
       uid: new BigNumber(1),
@@ -12793,7 +12771,25 @@ describe('offChainFundingReceiptDetailsToMeshReceiptDetails', () => {
         value: '0xsignature',
       },
       metadata: 'testMetadata',
+      expiresAt,
     };
+
+    when(context.createType)
+      .calledWith('PolymeshPrimitivesStoFundraiserReceiptDetails', {
+        uid: bigNumberToU64(mockReceiptDetails.uid, context),
+        signer: stringToAccountId(mockReceiptDetails.signer as string, context),
+        signature: signatureToMeshRuntimeMultiSignature(
+          mockReceiptDetails.signature.type,
+          mockReceiptDetails.signature.value,
+          context
+        ),
+        expiresAt: dateToMoment(expiresAt, context),
+        metadata: offChainMetadataToMeshReceiptMetadata(
+          mockReceiptDetails.metadata as string,
+          context
+        ),
+      })
+      .mockReturnValue(fakeResult);
 
     const result = offChainFundingReceiptDetailsToMeshReceiptDetails(mockReceiptDetails, context);
 

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -5596,13 +5596,6 @@ export function receiptDetailsToMeshReceiptDetails(
     ({ legId, uid, signer, signature, metadata, expiresAt }) => {
       const { address: signerAddress } = asAccount(signer, context);
 
-      if (!expiresAt) {
-        throw new PolymeshError({
-          code: ErrorCode.UnmetPrerequisite,
-          message: '`expiresAt` is required',
-        });
-      }
-
       return context.createType('PolymeshPrimitivesSettlementReceiptDetails', {
         uid: bigNumberToU64(uid, context),
         instructionId: rawInstructionId,
@@ -6176,13 +6169,14 @@ export function offChainFundingReceiptDetailsToMeshReceiptDetails(
   receiptDetails: OffChainFundingReceipt,
   context: Context
 ): PolymeshPrimitivesStoFundraiserReceiptDetails {
-  const { uid, signer, signature, metadata } = receiptDetails;
+  const { uid, signer, signature, metadata, expiresAt } = receiptDetails;
   const { address: signerAddress } = asAccount(signer, context);
 
   return context.createType('PolymeshPrimitivesStoFundraiserReceiptDetails', {
     uid: bigNumberToU64(uid, context),
     signer: stringToAccountId(signerAddress, context),
     signature: signatureToMeshRuntimeMultiSignature(signature.type, signature.value, context),
+    expiresAt: dateToMoment(expiresAt, context),
     metadata: optionize(offChainMetadataToMeshReceiptMetadata)(metadata, context),
   });
 }


### PR DESCRIPTION
## Summary

- `Asset.checkpoints.schedules.getNextCheckpoint()` now returns `null` when every Schedule has been removed. Removing a Schedule does not clear `checkpoint.cachedNextCheckpoints`; the chain leaves `{ nextAt: u64::MAX, totalPending: 0, schedules: {} }`. The getter used to call `momentToDate` on that sentinel and throw `Number can only safely store up to 53 bits`. An empty `schedules` map is treated as no active Schedules, matching `NextCheckpoints::is_empty`.
- STO off-chain funding receipts now carry `expiresAt`, matching settlement receipts. `generateOffChainFundingReceipt` accepts `expiresAt`, includes genesis hash / receipt label / expiry in the signed `ChainScopedMessage` payload, and `offChainFundingReceiptDetailsToMeshReceiptDetails` encodes it. Missing `expiresAt` throws `` `expiresAt` is required ``. Previously `expiresAt` encoded as `0` and every off-chain invest failed with `sto.ReceiptExpired`.

## Test plan

- [x] Unit tests for `getNextCheckpoint` with the empty-schedules sentinel
- [x] Unit tests for `generateOffChainFundingReceipt` / `offChainFundingReceiptDetailsToMeshReceiptDetails` (`expiresAt` required, payload, encoding)
- [x] Live v8 node (spec 8.1.0): create + remove a Schedule → `getNextCheckpoint()` is `null`
- [x] Live v8 node: launch Offering, `enableOffChainFunding`, `generateOffChainFundingReceipt({ expiresAt })`, `offering.invest(...)` succeeds