### PR TITLE
feat: sign Polymesh transactions with an Ethereum wallet

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -52,7 +52,7 @@ Routing is automatic and per-Account: the SDK detects an Ethereum-derived addres
 - `Account.ethAddress` — the checksummed Ethereum address controlling the Account, or `null` if it is not Ethereum-derived.
 - `AccountKeyType.Ethereum` — returned by `Account.getTypeInfo()`. If the Account is also a MultiSig signer, `MultiSig` still takes priority, since that is the flag that determines whether to use `run` or `runAsProposal`.
 - `PolymeshTransactionBase.ethTxHash` — the Ethereum transaction hash, set when the wallet broadcast the transaction itself.
-- `PolymeshTransactionBase.toEthSignablePayload()` and `Network.submitEthTransaction()` — detached/custody signing, for Fireblocks, KMS/HSM and air-gapped flows.
+- `PolymeshTransactionBase.toEthSignablePayload()` and `Network.submitEthTransaction()` — detached/custody signing, for Fireblocks, KMS/HSM and air-gapped flows. No signing manager is required to build the payload; pass `{ eip1559: false }` for a signer that can only encode legacy transactions.
 - `Network.decodeCall(hex)` — decodes a SCALE-encoded call into its `TxTag`, argument metadata and a human-readable form, so a dapp can display what is being signed alongside the wallet prompt.
 
 **Fees.** `getTotalFees()` remains the single entry point and is correct on both paths. On the Ethereum path the `gas` component is derived from the dry run (`ethGas × gasPrice ÷ nativeToEthRatio`) rather than from `payment_queryInfo`, so it may differ slightly from the equivalent native call — measured at 1.008–1.011× the fee the chain actually charges, erring on the safe side. Protocol fees are charged separately and are still summed into the total, so balance checks continue to protect against a transaction that would be included, fail, and charge anyway.

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,0 +1,180 @@
+---
+title: SDK Changelog - v31.0.0 to next release
+description: Pending changes since Polymesh SDK v31.0.0, to be included in the next release. Adds support for signing Polymesh transactions with an Ethereum wallet, mapping an Account to its Ethereum address, broadcasting a transaction without waiting for it, and reports on-chain failure reasons that previously surfaced as Unknown error.
+sidebar_label: v31.0.0 → next
+id: v31-0-to-next
+tags:
+  - changelog
+  - sdk
+---
+
+This guide describes **unreleased** changes since **v31.0.0** of `@polymeshassociation/polymesh-sdk`. These will be included in the next release.
+
+---
+
+## Overview
+
+This release adds support for **signing Polymesh transactions with an Ethereum wallet** such as MetaMask, on chains running the `revive` pallet, adds **Ethereum address mapping** so an Account can safely receive funds at its Ethereum address, and reports on-chain failure reasons that previously surfaced as `Unknown error`. These changes are additive — note the new `AccountKeyType.Ethereum` variant described below.
+
+---
+
+## New features
+
+### Sign Polymesh transactions with an Ethereum wallet
+
+An Ethereum key can now be used to sign any Polymesh transaction. The chain's `revive` pallet dispatches on behalf of the Account `AccountId32 = <20-byte H160> ++ [0xEE; 12]`, so each Ethereum address controls exactly one Polymesh Account.
+
+Attach an Ethereum signing manager and set the signing Account — every existing procedure works unchanged:
+
+```typescript
+const sdk = await Polymesh.connect({
+  nodeUrl: 'wss://...',
+  signingManager: await EthSigningManager.create({ provider: window.ethereum }),
+});
+
+sdk.setSigningAccount(ethDerivedSs58Address);
+
+// unchanged call, unchanged result
+await sdk.assets.createAsset({ ... });
+```
+
+Routing is automatic and per-Account: the SDK detects an Ethereum-derived address and switches transports for that transaction only. A signing manager holding both native and Ethereum keys is supported without extra configuration, and no procedure, argument or `ProcedureOpts` changes are required.
+
+**Two submission modes**, chosen from the signer's advertised capabilities:
+
+- **Signers that can return raw signed bytes** (viem/ethers local accounts, Ledger, Fireblocks, KMS/HSM) — the SDK broadcasts and tracks the transaction itself, so the nonce is SDK-controlled and the transaction lifecycle is identical to the native path.
+- **Wallets that sign and broadcast themselves** (MetaMask and other injected EIP-1193 providers) — the wallet owns the nonce, and the SDK correlates the result back to the Substrate extrinsic by matching `keccak256` of the `revive.ethTransact` payload against the Ethereum transaction hash.
+
+**Before the wallet is opened**, the SDK performs a dry run over the Substrate connection. Failures such as a missing Identity are reported as structured errors up front rather than as a wallet-level revert.
+
+**New API surface** (all additive):
+
+- `Account.ethAddress` — the checksummed Ethereum address controlling the Account, or `null` if it is not Ethereum-derived.
+- `AccountKeyType.Ethereum` — returned by `Account.getTypeInfo()`. If the Account is also a MultiSig signer, `MultiSig` still takes priority, since that is the flag that determines whether to use `run` or `runAsProposal`.
+- `PolymeshTransactionBase.ethTxHash` — the Ethereum transaction hash, set when the wallet broadcast the transaction itself.
+- `PolymeshTransactionBase.toEthSignablePayload()` and `Network.submitEthTransaction()` — detached/custody signing, for Fireblocks, KMS/HSM and air-gapped flows.
+- `Network.decodeCall(hex)` — decodes a SCALE-encoded call into its `TxTag`, argument metadata and a human-readable form, so a dapp can display what is being signed alongside the wallet prompt.
+
+**Fees.** `getTotalFees()` remains the single entry point and is correct on both paths. On the Ethereum path the `gas` component is derived from the dry run (`ethGas × gasPrice ÷ nativeToEthRatio`) rather than from `payment_queryInfo`, so it may differ slightly from the equivalent native call — measured at 1.008–1.011× the fee the chain actually charges, erring on the safe side. Protocol fees are charged separately and are still summed into the total, so balance checks continue to protect against a transaction that would be included, fail, and charge anyway.
+
+Note that an Ethereum-signed transaction costs somewhat more than the same call signed natively, because the outer extrinsic carries the entire signed Ethereum transaction as its payload.
+
+**Limitations.** These throw rather than failing silently:
+
+- **Off-chain signatures are not supported.** The chain's `verify_any_signature` accepts only sr25519 and ed25519, so an Ethereum key cannot produce one. This affects bulk secondary-key addition (`addSecondaryAccountsWithAuth`) and off-chain settlement/investment receipts. Onboarding an Ethereum key into an existing Identity is unaffected — that flow uses two ordinary signed dispatches (`inviteAccount`, then accepting the authorization).
+- **MultiSig signing with an Ethereum key is out of scope** for this release and throws `NotSupported`.
+- **Transaction history is not yet available** for Ethereum-derived Accounts. The middleware cannot currently attribute a `revive` extrinsic to the Ethereum Account, so `getTransactionHistory()` throws `NotSupported` rather than returning a misleadingly empty list. Balance activity driven by chain events (e.g. `getPolyxTransactions`) is unaffected.
+- **`toSignablePayload()` throws** for an Ethereum-derived Account; use `toEthSignablePayload()` instead.
+- **`mortality` and `paidForBy` are rejected**, as is an explicit `nonce` when the wallet owns nonce management. Ethereum transactions have no era — replay protection comes from the nonce and chain ID — and there is no third-party fee payer on this transport.
+
+**Subsidies are ignored on the Ethereum path**, and this one does not throw. Whether a subsidy applies to a dispatch made through `revive.ethTransact` is not established, so `getTotalFees()` attributes the fee to the signing Account rather than to a subsidizer. If a subsidy does in fact apply, the fee is over-reported rather than under-reported, so balance checks stay conservative.
+
+### Map an Account to its Ethereum address
+
+Polymesh Accounts are 32 bytes (`AccountId32`); Ethereum addresses are 20 (`H160`). The `revive` pallet bridges the two, and the direction matters:
+
+- **Ethereum key → Account.** The key is padded, `AccountId32 = <20-byte H160> ++ [0xEE; 12]`. The chain inverts this by stripping the padding, so it always works and needs no setup. This is the Account an Ethereum wallet signs for.
+- **Account → Ethereum address.** The address is `keccak256(<32-byte AccountId32>)[12..]`. Hashing is lossy, so **the chain cannot invert it**. Until the Account calls `revive.mapAccount`, the chain resolves that address to its `0xEE`-padded fallback Account instead — and anything sent there is credited to the fallback Account, not to yours.
+
+The practical consequence: **map the Account before advertising its Ethereum address or receiving funds at it.** Funds already sent to an unmapped address are not lost — the chain's `revive.dispatchAsFallbackAccount` can dispatch on the fallback Account's behalf — but recovering them is manual and is not wrapped by the SDK in this release.
+
+```ts
+const account = await sdk.accountManagement.getSigningAccount();
+
+const { address, type, isMapped, fallbackAccount } = await account.getEvmAddressDetails();
+
+if (!isMapped) {
+  // funds sent to `address` right now would be credited to `fallbackAccount`
+  const tx = await sdk.accountManagement.mapEvmAccount();
+  await tx.run();
+}
+
+// `fallbackAccount` is still reported after mapping, because mapping does not move
+// funds that arrived earlier. Check it to find a balance stranded before the mapping
+const { free } = await fallbackAccount.getBalance();
+```
+
+**New API surface** (all additive):
+
+- `Account.evmAddress` — the Ethereum address the chain associates with the Account, mirroring revive's address mapper. Synchronous, and defined for every Account: the padded Ethereum key for an Ethereum-derived Account, the `keccak256` derivation otherwise. It reports what the address _would_ be, not whether the chain can resolve it.
+- `Account.getEvmAddressDetails()` — the address together with its `EvmAddressType` (`Native` for an Ethereum-derived Account, `Derived` otherwise), whether it `isMapped`, and the `fallbackAccount` credited whenever the chain cannot resolve the address. For a `Derived` address the fallback Account is reported **even once the Account is mapped**, because mapping does not move funds that arrived beforehand — so it stays the pointer to anything stranded there. `Native` has no fallback Account, since that Account already _is_ the one the Ethereum key controls.
+- `AccountManagement.mapEvmAccount()` / `unmapEvmAccount()` — register or unregister the signing Account against its derived address. Mapping takes a deposit, released by unmapping. Mapping throws for an Ethereum-derived Account (the chain rejects an `Address20` origin — there is nothing to map) and for an Account that is already mapped; unmapping throws for one that is not.
+- `AccountManagement.getAccountByEvmAddress({ evmAddress })` — the reverse direction, mirroring the chain: the Account that mapped the address, or the `0xEE`-padded fallback Account if none has. It always resolves to an Account, so use `getEvmAddressDetails()` on the Account you expect if you need to know whether a mapping actually exists.
+
+### Transaction inclusion is reported before finalization
+
+Transactions tracked by scanning blocks — offline-signed submissions, HTTP connections, and Ethereum transactions broadcast by a wallet — previously stayed in `Running` until the block containing them was finalized, with no intermediate feedback for roughly 15–25 seconds.
+
+The scan now reports inclusion as soon as the transaction appears in a block, emitting `TransactionStatus.InBlock` after roughly one block. The resolved result still comes from a finalized block, so this is a progress signal only and cannot report a transaction that is later reorganised away as complete.
+
+Where the node connection supports subscriptions, blocks are now followed by subscription rather than polled, which removes a repeating poll cycle per in-flight transaction.
+
+### Broadcast without waiting, and bound how long waiting lasts
+
+Transactions tracked by scanning blocks previously had no upper bound on how long they would wait, and no way to stop waiting. A wallet prompt the user never answers — MetaMask dismissed, the extension backgrounded — left `run()` pending indefinitely, and there was no path anywhere that submitted a transaction without also tracking it to finalization.
+
+`transaction.broadcast()` splits `run()` at its natural seam. It returns once the transaction has been accepted for broadcast, handing back the hash and a `watch` that performs the second half:
+
+```ts
+const tx = await sdk.assets.createAsset({ ... });
+
+const { txHash, startingBlock, watch } = await tx.broadcast();
+// the transaction is on its way; whether to wait is now your decision
+
+const asset = await watch({ timeout: 60000 }); // same value `run()` would have returned
+```
+
+`watch()` runs the same resolver `run()` does, so nothing is lost by broadcasting first. It can be retried if it times out — nothing is resubmitted, the block scan simply starts again.
+
+To bound `run()` itself, pass `submission` in the Procedure options:
+
+```ts
+const tx = await sdk.assets.createAsset(
+  { ... },
+  { submission: { broadcastTimeout: 120000, watchTimeout: 60000 } }
+);
+```
+
+`broadcastTimeout` covers the wallet confirmation prompt; `watchTimeout` covers the wait for a finalized block. Both default to waiting indefinitely, so existing behavior is unchanged. The same options are accepted by `Network.submitTransaction()` and `Network.submitEthTransaction()`.
+
+**A timeout never cancels a transaction** — it only stops the SDK waiting. Both raise the new `ErrorCode.TransactionTimeout`, distinct from `TransactionAborted` and `TransactionReverted` precisely because the transaction may still be included afterwards. For the same reason a `watchTimeout` leaves the transaction's status at `Running` or `InBlock` rather than moving it to `Failed`. Nothing is automatically resubmitted or gas-bumped: on the wallet-broadcast path the SDK does not own the nonce, so an automatic retry risks submitting the same transaction twice.
+
+`Network.watchTransaction()` picks tracking back up from a hash alone, for a transaction that was broadcast but never watched, or whose watch timed out:
+
+```ts
+const details = await sdk.network.watchTransaction({
+  startingBlock, // returned by `broadcast()` — persist it alongside the hash
+  txHash,
+  isEthTxHash: true, // when an Ethereum wallet broadcast it
+});
+```
+
+Because it needs nothing but a hash and a block height, tracking can resume in a later session — after a page reload, where the original `watch` no longer exists.
+
+**New API surface** (all additive):
+
+- `PolymeshTransactionBase.broadcast()` — returns a `TransactionBroadcastHandle` carrying `txHash`, `ethTxHash`, `startingBlock` and `watch`. Throws `NotSupported` for a MultiSig signer, whose resulting proposal can only be read from the finalized transaction — use `runAsProposal`.
+- `SubmissionOpts` (`broadcastTimeout`, `watchTimeout`) — accepted as `ProcedureOpts.submission`, and by `Network.submitTransaction()` / `Network.submitEthTransaction()`.
+- `Network.watchTransaction()` — resume tracking a broadcast transaction by hash.
+- `ErrorCode.TransactionTimeout`.
+
+Note that `broadcast()` always submits without an extrinsic status subscription, since that channel cannot report a hash without also waiting for the result. The trade-off is that `Future` status reporting and in-pool `Aborted` detection are unavailable on that path — those come from the node's status stream, which only `run()` attaches to.
+
+---
+
+## Bug fixes
+
+### Report the actual reason an on-chain transaction failed
+
+A failed transaction whose dispatch error was not a module error was reported as `Unknown error`, discarding the reason. `SpRuntimeDispatchError` has fifteen variants, of which only three were handled.
+
+`Token`, `Arithmetic` and `Transactional` errors are now reported by name — an Account that cannot cover a transfer produces `Token error: FundsUnavailable` instead of `Unknown error` — and any other variant falls back to its own name rather than being discarded. This affects all transactions, not only those signed with an Ethereum key.
+
+---
+
+## Version compatibility matrix
+
+| SDK version | Chain v7 | Chain v8.x | Middleware V2     | Polkadot.js |
+| ----------- | -------- | ---------- | ----------------- | ----------- |
+| v31.0.0     | ❌       | ✅         | ≥ v19.6.0-alpha.2 | 16.5.2      |
+| next        | ❌       | ✅         | ≥ v19.6.0-alpha.2 | 16.5.2      |

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -61,13 +61,15 @@ Note that an Ethereum-signed transaction costs somewhat more than the same call 
 
 **Limitations.** These throw rather than failing silently:
 
-- **Off-chain signatures are not supported.** The chain's `verify_any_signature` accepts only sr25519 and ed25519, so an Ethereum key cannot produce one. This affects bulk secondary-key addition (`addSecondaryAccountsWithAuth`) and off-chain settlement/investment receipts. Onboarding an Ethereum key into an existing Identity is unaffected — that flow uses two ordinary signed dispatches (`inviteAccount`, then accepting the authorization).
+- **Off-chain signatures are not supported.** The chain's `verify_any_signature` accepts only sr25519 and ed25519, so an Ethereum key cannot produce one. This affects bulk secondary-key addition (`addSecondaryAccountsWithAuth`) and off-chain settlement/investment receipts. Onboarding an Ethereum key into an existing Identity still works — that flow uses two ordinary signed dispatches (`inviteAccount`, then accepting the authorization) — but the joining key must hold POLYX to pay its own fee, as described above.
 - **MultiSig signing with an Ethereum key is out of scope** for this release and throws `NotSupported`.
 - **Transaction history is not yet available** for Ethereum-derived Accounts. The middleware cannot currently attribute a `revive` extrinsic to the Ethereum Account, so `getTransactionHistory()` throws `NotSupported` rather than returning a misleadingly empty list. Balance activity driven by chain events (e.g. `getPolyxTransactions`) is unaffected.
 - **`toSignablePayload()` throws** for an Ethereum-derived Account; use `toEthSignablePayload()` instead.
-- **`mortality` and `paidForBy` are rejected**, as is an explicit `nonce` when the wallet owns nonce management. Ethereum transactions have no era — replay protection comes from the nonce and chain ID — and there is no third-party fee payer on this transport.
+- **`mortality` is rejected**, as is an explicit `nonce` when the wallet owns nonce management. Ethereum transactions have no era — replay protection comes from the nonce and chain ID. `paidForBy` is accepted but has no effect, since the signing Account pays regardless.
 
-**Subsidies are ignored on the Ethereum path**, and this one does not throw. Whether a subsidy applies to a dispatch made through `revive.ethTransact` is not established, so `getTotalFees()` attributes the fee to the signing Account rather than to a subsidizer. If a subsidy does in fact apply, the fee is over-reported rather than under-reported, so balance checks stay conservative.
+**An Ethereum-derived Account always pays its own fees.** `revive.ethTransact` is a bare extrinsic, so neither a subsidy nor a third-party payer reaches the chain's fee pipeline — gas is charged to the signing Account. `getTotalFees()` reports this accurately, attributing the fee to the caller in both cases.
+
+The practical consequence is that **an Ethereum key must hold POLYX before it can join an Identity**, where a native key does not: accepting a `JoinIdentity` authorization is normally paid for by the inviting Identity, and that does not apply here. Fund the Account first, or the transaction fails on chain for insufficient balance.
 
 ### Map an Account to its Ethereum address
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -42,7 +42,7 @@ Routing is automatic and per-Account: the SDK detects an Ethereum-derived addres
 
 **Two submission modes**, chosen from the signer's advertised capabilities:
 
-- **Signers that can return raw signed bytes** (viem/ethers local accounts, Ledger, Fireblocks, KMS/HSM) — the SDK broadcasts and tracks the transaction itself, so the nonce is SDK-controlled and the transaction lifecycle is identical to the native path.
+- **Signers that can return raw signed bytes** (viem/ethers local accounts, Ledger, Fireblocks, KMS/HSM) — the SDK broadcasts and tracks the transaction itself, so the nonce is SDK-controlled and the transaction lifecycle is identical to the native path. The request is hex encoded throughout (EIP-1193 wire format), so a viem or ethers account needs it converted first — `EthSigningManager`'s `fromViemAccount` / `fromEthersWallet` do that.
 - **Wallets that sign and broadcast themselves** (MetaMask and other injected EIP-1193 providers) — the wallet owns the nonce, and the SDK correlates the result back to the Substrate extrinsic by matching `keccak256` of the `revive.ethTransact` payload against the Ethereum transaction hash.
 
 **Before the wallet is opened**, the SDK performs a dry run over the Substrate connection. Failures such as a missing Identity are reported as structured errors up front rather than as a wallet-level revert.
@@ -52,7 +52,7 @@ Routing is automatic and per-Account: the SDK detects an Ethereum-derived addres
 - `Account.ethAddress` — the checksummed Ethereum address controlling the Account, or `null` if it is not Ethereum-derived.
 - `AccountKeyType.Ethereum` — returned by `Account.getTypeInfo()`. If the Account is also a MultiSig signer, `MultiSig` still takes priority, since that is the flag that determines whether to use `run` or `runAsProposal`.
 - `PolymeshTransactionBase.ethTxHash` — the Ethereum transaction hash, set when the wallet broadcast the transaction itself.
-- `PolymeshTransactionBase.toEthSignablePayload()` and `Network.submitEthTransaction()` — detached/custody signing, for Fireblocks, KMS/HSM and air-gapped flows. No signing manager is required to build the payload; pass `{ eip1559: false }` for a signer that can only encode legacy transactions.
+- `PolymeshTransactionBase.toEthSignablePayload()` and `Network.submitEthTransaction()` — detached/custody signing, for Fireblocks, KMS/HSM and air-gapped flows. No signing manager is required to build the payload; pass `{ eip1559: false }` for a signer that can only encode legacy transactions. The returned `transaction` is hex encoded the same way — `EthSigningManager` exports `toEthersTransaction` / `toViemTransaction` to convert it, without requiring the manager itself.
 - `Network.decodeCall(hex)` — decodes a SCALE-encoded call into its `TxTag`, argument metadata and a human-readable form, so a dapp can display what is being signed alongside the wallet prompt.
 
 **Fees.** `getTotalFees()` remains the single entry point and is correct on both paths. On the Ethereum path the `gas` component is derived from the dry run (`ethGas × gasPrice ÷ nativeToEthRatio`) rather than from `payment_queryInfo`, so it may differ slightly from the equivalent native call — measured at 1.008–1.011× the fee the chain actually charges, erring on the safe side. Protocol fees are charged separately and are still summed into the total, so balance checks continue to protect against a transaction that would be included, fail, and charge anyway.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@polkadot/dev-ts": "^0.83.3",
     "@polkadot/typegen": "16.5.2",
     "@polymeshassociation/local-signing-manager": "^4.1.1",
-    "@polymeshassociation/signing-manager-types": "^3.7.1",
+    "@polymeshassociation/signing-manager-types": "3.8.0-beta.1",
     "@semantic-release/changelog": "^6.0.3",
     "@types/jest": "^29.5.14",
     "@types/jest-when": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@polkadot/dev-ts": "^0.83.3",
     "@polkadot/typegen": "16.5.2",
     "@polymeshassociation/local-signing-manager": "^4.1.1",
-    "@polymeshassociation/signing-manager-types": "3.8.0-beta.1",
+    "@polymeshassociation/signing-manager-types": "3.8.0",
     "@semantic-release/changelog": "^6.0.3",
     "@types/jest": "^29.5.14",
     "@types/jest-when": "^3.5.2",

--- a/scripts/compareApiSnapshot.ts
+++ b/scripts/compareApiSnapshot.ts
@@ -56,9 +56,21 @@ function compareOverloads(
       return;
     }
 
-    if (baseSig.parameters.length !== currSig.parameters.length) {
+    if (currSig.parameters.length < baseSig.parameters.length) {
+      logBreak(`${filePath} > ${parentName}.${methodName}: Params removed in overload #${i + 1}`);
+      return;
+    }
+
+    // adding trailing optional params is backwards compatible, adding required ones is not
+    const addedRequired = currSig.parameters
+      .slice(baseSig.parameters.length)
+      .filter(p => !p.optional);
+
+    if (addedRequired.length) {
       logBreak(
-        `${filePath} > ${parentName}.${methodName}: Param count mismatch in overload #${i + 1}`
+        `${filePath} > ${parentName}.${methodName}: Required param(s) added in overload #${
+          i + 1
+        }: ${addedRequired.map(p => p.name).join(', ')}`
       );
       return;
     }

--- a/src/api/client/AccountManagement.ts
+++ b/src/api/client/AccountManagement.ts
@@ -17,6 +17,7 @@ import {
   revokeSubsidy,
   subsidizeAccount,
   Subsidy,
+  toggleEvmAccountMapping,
   toggleFreezeSecondaryAccounts,
 } from '~/internal';
 import {
@@ -37,7 +38,13 @@ import {
   SubsidizeAccountParams,
   UnsubCallback,
 } from '~/types';
-import { bigNumberToU64, dateToMoment, stringToIdentityId } from '~/utils/conversion';
+import {
+  accountIdToString,
+  bigNumberToU64,
+  dateToMoment,
+  stringToIdentityId,
+} from '~/utils/conversion';
+import { ss58FromEthAddress } from '~/utils/eth';
 import {
   asAccount,
   asIdentity,
@@ -121,6 +128,20 @@ export class AccountManagement {
       },
       context
     );
+    this.mapEvmAccount = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [toggleEvmAccountMapping, { map: true }],
+        voidArgs: true,
+      },
+      context
+    );
+    this.unmapEvmAccount = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [toggleEvmAccountMapping, { map: false }],
+        voidArgs: true,
+      },
+      context
+    );
     this.acceptSubsidy = createProcedureMethod(
       { getProcedureAndArgs: args => [acceptSubsidy, args] },
       context
@@ -192,6 +213,37 @@ export class AccountManagement {
    * Unfreeze all of the secondary Accounts in the signing Identity. This will restore their permissions as they were before being frozen
    */
   public unfreezeSecondaryAccounts: NoArgsProcedureMethod<void>;
+
+  /**
+   * Register the signing Account against its derived Ethereum address, so that the chain can
+   *   resolve that address back to the Account
+   *
+   * The derived address (see {@link api/entities/Account!Account.evmAddress | Account.evmAddress})
+   *   is `keccak256` of the Account, which the chain cannot invert on its own. Until it is mapped,
+   *   anything sent to the address is credited to the fallback Account reported by
+   *   {@link api/entities/Account!Account.getEvmAddressDetails | Account.getEvmAddressDetails}
+   *   instead, and recovering it needs the chain's `revive.dispatchAsFallbackAccount`. Map the
+   *   Account *before* advertising the address or receiving funds at it
+   *
+   * @note this takes a deposit from the signing Account, released by {@link unmapEvmAccount}
+   *
+   * @throws if the signing Account is Ethereum-derived — the chain resolves its address by
+   *   stripping the padding, so there is nothing to map
+   * @throws if the signing Account is already mapped
+   */
+  public mapEvmAccount: NoArgsProcedureMethod<void>;
+
+  /**
+   * Unregister the signing Account from its derived Ethereum address, releasing the deposit taken
+   *   by {@link mapEvmAccount}
+   *
+   * @note after this, the chain can no longer resolve the derived address back to the Account, so
+   *   anything sent to it is credited to the fallback Account instead. Only do this for an Account
+   *   that will no longer be used
+   *
+   * @throws if the signing Account is not mapped
+   */
+  public unmapEvmAccount: NoArgsProcedureMethod<void>;
 
   /**
    * Approves a subsidy request
@@ -301,6 +353,38 @@ export class AccountManagement {
    */
   public getAccount(args: { address: string }): Promise<Account | MultiSig> {
     return getAccount(args, this.context);
+  }
+
+  /**
+   * Return the Account the chain credits for an Ethereum (H160) address, mirroring the `revive`
+   *   pallet's address mapper
+   *
+   * - if the address has been mapped via {@link mapEvmAccount}, this is the Account that mapped it
+   * - otherwise it is the fallback Account `ss58(<address> ++ [0xEE; 12])`, which is also the
+   *   Account controlled by the Ethereum key itself when `address` is a native Ethereum address
+   *
+   * @param args.evmAddress - 20 byte hex encoded Ethereum address. Checksummed or not
+   *
+   * @note this always resolves to an Account, so the result alone does not say whether a mapping
+   *   exists. Use {@link api/entities/Account!Account.getEvmAddressDetails |
+   *   Account.getEvmAddressDetails} on the Account you expect for that
+   *
+   * @throws if `evmAddress` is not a 20 byte hex encoded address
+   */
+  public async getAccountByEvmAddress(args: { evmAddress: string }): Promise<Account | MultiSig> {
+    const { context } = this;
+    const { evmAddress } = args;
+
+    // validates `evmAddress`, so the storage query below is never handed a malformed key
+    const fallbackAddress = ss58FromEthAddress(evmAddress, context.ss58Format);
+
+    const rawOriginalAccount = await context.polymeshApi.query.revive.originalAccount(evmAddress);
+
+    const address = rawOriginalAccount.isSome
+      ? accountIdToString(rawOriginalAccount.unwrap())
+      : fallbackAddress;
+
+    return getAccount({ address }, context);
   }
 
   /**

--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -4,10 +4,13 @@ import { compactToU8a, isHex, u8aConcat } from '@polkadot/util';
 import { HexString } from '@polkadot/util/types';
 import BigNumber from 'bignumber.js';
 
+import { ethTransactKeccakMatcher } from '~/base/ethTransaction';
 import {
   extrinsicHashMatcher,
+  ExtrinsicMatcher,
   getExtrinsicFailure,
   pollForTransactionFinalization,
+  subscribeForTransactionFinalization,
 } from '~/base/utils';
 import { Account, Context, PolymeshError, transferPolyx } from '~/internal';
 import { eventsByArgs } from '~/middleware/queries/events';
@@ -23,6 +26,7 @@ import {
   ProtocolFees,
   SubCallback,
   SubmissionDetails,
+  SubmissionOpts,
   TransactionArgument,
   TransactionPayloadInput,
   TransferPolyxParams,
@@ -43,7 +47,7 @@ import {
   transactionHexToTxTag,
   u32ToBigNumber,
 } from '~/utils/conversion';
-import { createProcedureMethod, optionize } from '~/utils/internal';
+import { createProcedureMethod, optionize, withTimeout } from '~/utils/internal';
 
 /**
  * Handles all Network related functionality, including querying for historical events from middleware
@@ -216,11 +220,17 @@ export class Network {
   /**
    * Submits a transaction payload with its signature to the chain. `signature` should be hex encoded
    *
+   * @param opts - bounds on how long to wait while broadcasting and tracking the transaction.
+   *   Defaults to waiting indefinitely
+   *
    * @throws if the signature is not hex encoded
+   * @throws `TransactionTimeout` if a bound in `opts` is exceeded. The transaction is not cancelled
+   *   by this, and can be tracked afterwards with {@link watchTransaction}
    */
   public async submitTransaction(
     txPayload: TransactionPayloadInput,
-    signature: string
+    signature: string,
+    opts: SubmissionOpts = {}
   ): Promise<SubmissionDetails> {
     const { context } = this;
 
@@ -265,7 +275,7 @@ export class Network {
 
     const transaction = context.polymeshApi.tx(extrinsic);
 
-    return await this.broadcastExtrinsic(transaction);
+    return await this.broadcastExtrinsic(transaction, opts);
   }
 
   /**
@@ -277,13 +287,88 @@ export class Network {
    *   sign it externally, and submit the raw signed bytes here
    *
    * @param rawSignedTx - the raw signed Ethereum transaction, as returned by an `EthSigner`'s `signTransaction`
+   * @param opts - bounds on how long to wait while broadcasting and tracking the transaction.
+   *   Defaults to waiting indefinitely
+   *
+   * @throws `TransactionTimeout` if a bound in `opts` is exceeded. The transaction is not cancelled
+   *   by this, and can be tracked afterwards with {@link watchTransaction}
    */
-  public async submitEthTransaction(rawSignedTx: HexString): Promise<SubmissionDetails> {
+  public async submitEthTransaction(
+    rawSignedTx: HexString,
+    opts: SubmissionOpts = {}
+  ): Promise<SubmissionDetails> {
     const { context } = this;
 
     const transaction = context.polymeshApi.tx.revive.ethTransact(rawSignedTx);
 
-    return await this.broadcastExtrinsic(transaction);
+    return await this.broadcastExtrinsic(transaction, opts);
+  }
+
+  /**
+   * Track a transaction that has already been broadcast, by its hash, and wait for it to be
+   *   included in a finalized block
+   *
+   * Complements {@link base/PolymeshTransactionBase!PolymeshTransactionBase.broadcast | transaction.broadcast}
+   *   and the timeouts on {@link submitTransaction} / {@link submitEthTransaction}: each of those
+   *   can leave a transaction in flight but untracked. Since this needs nothing but a hash and a
+   *   block height, tracking can be picked back up in a later session — after a page reload, for
+   *   instance, where the original handle no longer exists
+   *
+   * @param args.startingBlock - block height to start searching from. This must be at or before the
+   *   block the transaction was submitted in, or it will not be found. `broadcast` returns the
+   *   correct value to persist
+   * @param args.txHash - hash of the transaction to look for
+   * @param args.isEthTxHash - set to `true` when `txHash` is an Ethereum transaction hash, i.e. the
+   *   transaction was broadcast by an Ethereum wallet. Those are carried on chain as an unsigned
+   *   `revive.ethTransact` extrinsic, so they are matched by their payload rather than by the
+   *   extrinsic hash
+   * @param args.timeout - milliseconds to wait before giving up. Defaults to waiting indefinitely
+   *
+   * @throws `TransactionTimeout` if the transaction is not found in time. It may still be included
+   *   afterwards — this reports only that the search stopped
+   */
+  public async watchTransaction(args: {
+    startingBlock: BigNumber;
+    txHash: string;
+    isEthTxHash?: boolean;
+    timeout?: number;
+  }): Promise<SubmissionDetails> {
+    const { context } = this;
+    const { startingBlock, txHash, isEthTxHash = false, timeout } = args;
+
+    const matcher: ExtrinsicMatcher = isEthTxHash
+      ? ethTransactKeccakMatcher(txHash)
+      : extrinsicHashMatcher(context.createType('Hash', txHash));
+
+    const scanning = context.supportsSubscription()
+      ? subscribeForTransactionFinalization(matcher, startingBlock, context)
+      : pollForTransactionFinalization(matcher, startingBlock, context);
+
+    const result = await withTimeout(
+      scanning,
+      timeout,
+      () =>
+        new PolymeshError({
+          code: ErrorCode.TransactionTimeout,
+          message:
+            'The transaction was not found in a finalized block within the allotted time. It has not been cancelled and may still be included, so this can be retried',
+          data: { txHash, startingBlock, timeout },
+        })
+    );
+
+    const failureError = getExtrinsicFailure(result);
+
+    if (failureError) {
+      throw failureError;
+    }
+
+    return {
+      blockHash: hashToString(result.status.asFinalized),
+      transactionHash: txHash,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      transactionIndex: new BigNumber(result.txIndex!),
+      result,
+    };
   }
 
   /**
@@ -292,11 +377,17 @@ export class Network {
    * Broadcast an already-built extrinsic (either the offline-signed native extrinsic, or the
    *   bare `revive.ethTransact` wrapper around a raw signed Ethereum transaction) and track it
    *   through to finalization
+   *
+   * @note the bounds in `opts` only apply to the polling path. The subscription path is driven by
+   *   the node's own status stream, which reports progress unprompted and does not risk waiting on
+   *   a signer that never responds
    */
   private async broadcastExtrinsic(
-    transaction: SubmittableExtrinsic<'promise', ISubmittableResult>
+    transaction: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    opts: SubmissionOpts
   ): Promise<SubmissionDetails> {
     const { context } = this;
+    const { broadcastTimeout, watchTimeout } = opts;
 
     const submissionDetails: SubmissionDetails = {
       blockHash: '',
@@ -370,12 +461,36 @@ export class Network {
     } else {
       const startingBlock = await context.getLatestBlock();
 
-      await transaction.send();
+      await withTimeout(
+        transaction.send(),
+        broadcastTimeout,
+        () =>
+          new PolymeshError({
+            code: ErrorCode.TransactionTimeout,
+            message:
+              'The transaction was not broadcast within the allotted time. It was not cancelled — whether it ends up being submitted is unknown, so check before submitting again, or the same transaction may be submitted twice',
+            data: { transactionHash: transaction.hash.toString(), broadcastTimeout },
+          })
+      );
 
-      const result = await pollForTransactionFinalization(
-        extrinsicHashMatcher(transaction.hash),
-        startingBlock,
-        context
+      const result = await withTimeout(
+        pollForTransactionFinalization(
+          extrinsicHashMatcher(transaction.hash),
+          startingBlock,
+          context
+        ),
+        watchTimeout,
+        () =>
+          new PolymeshError({
+            code: ErrorCode.TransactionTimeout,
+            message:
+              'The transaction was broadcast but was not found in a finalized block within the allotted time. It has not been cancelled and may still be included — it can be tracked by hash with `network.watchTransaction`',
+            data: {
+              transactionHash: transaction.hash.toString(),
+              startingBlock,
+              watchTimeout,
+            },
+          })
       );
 
       const failureError = getExtrinsicFailure(result);

--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -1,7 +1,11 @@
 import { compactToU8a, isHex, u8aConcat } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 
-import { handleExtrinsicFailure, pollForTransactionFinalization } from '~/base/utils';
+import {
+  extrinsicHashMatcher,
+  handleExtrinsicFailure,
+  pollForTransactionFinalization,
+} from '~/base/utils';
 import { Account, Context, PolymeshError, transferPolyx } from '~/internal';
 import { eventsByArgs } from '~/middleware/queries/events';
 import { extrinsicByHash } from '~/middleware/queries/extrinsics';
@@ -332,7 +336,11 @@ export class Network {
 
       await transaction.send();
 
-      const result = await pollForTransactionFinalization(transaction.hash, startingBlock, context);
+      const result = await pollForTransactionFinalization(
+        extrinsicHashMatcher(transaction.hash),
+        startingBlock,
+        context
+      );
 
       return {
         blockHash: hashToString(result.status.asFinalized),

--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -1,9 +1,12 @@
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { AnyJson, ISubmittableResult } from '@polkadot/types/types';
 import { compactToU8a, isHex, u8aConcat } from '@polkadot/util';
+import { HexString } from '@polkadot/util/types';
 import BigNumber from 'bignumber.js';
 
 import {
   extrinsicHashMatcher,
-  handleExtrinsicFailure,
+  getExtrinsicFailure,
   pollForTransactionFinalization,
 } from '~/base/utils';
 import { Account, Context, PolymeshError, transferPolyx } from '~/internal';
@@ -20,6 +23,7 @@ import {
   ProtocolFees,
   SubCallback,
   SubmissionDetails,
+  TransactionArgument,
   TransactionPayloadInput,
   TransferPolyxParams,
   TxTag,
@@ -36,9 +40,10 @@ import {
   moduleAddressToString,
   stringToBlockHash,
   textToString,
+  transactionHexToTxTag,
   u32ToBigNumber,
 } from '~/utils/conversion';
-import { createProcedureMethod, filterEventRecords, optionize } from '~/utils/internal';
+import { createProcedureMethod, optionize } from '~/utils/internal';
 
 /**
  * Handles all Network related functionality, including querying for historical events from middleware
@@ -260,9 +265,42 @@ export class Network {
 
     const transaction = context.polymeshApi.tx(extrinsic);
 
+    return await this.broadcastExtrinsic(transaction);
+  }
+
+  /**
+   * Submits a raw, signed Ethereum transaction that carries a Polymesh runtime call through the
+   *   `revive` pallet's sentinel address. This is the SDK-broadcast submission step, reused
+   *   here to unlock Fireblocks / KMS / HSM / air-gapped custody flows for Ethereum-derived
+   *   Accounts: build the payload via
+   *   {@link base/PolymeshTransactionBase!PolymeshTransactionBase.toEthSignablePayload | transaction.toEthSignablePayload},
+   *   sign it externally, and submit the raw signed bytes here
+   *
+   * @param rawSignedTx - the raw signed Ethereum transaction, as returned by an `EthSigner`'s `signTransaction`
+   */
+  public async submitEthTransaction(rawSignedTx: HexString): Promise<SubmissionDetails> {
+    const { context } = this;
+
+    const transaction = context.polymeshApi.tx.revive.ethTransact(rawSignedTx);
+
+    return await this.broadcastExtrinsic(transaction);
+  }
+
+  /**
+   * @hidden
+   *
+   * Broadcast an already-built extrinsic (either the offline-signed native extrinsic, or the
+   *   bare `revive.ethTransact` wrapper around a raw signed Ethereum transaction) and track it
+   *   through to finalization
+   */
+  private async broadcastExtrinsic(
+    transaction: SubmittableExtrinsic<'promise', ISubmittableResult>
+  ): Promise<SubmissionDetails> {
+    const { context } = this;
+
     const submissionDetails: SubmissionDetails = {
       blockHash: '',
-      transactionHash: extrinsic.hash.toString(),
+      transactionHash: transaction.hash.toString(),
       transactionIndex: new BigNumber(-1),
     } as SubmissionDetails;
 
@@ -272,7 +310,7 @@ export class Network {
           const { status } = receipt;
           let isLastCallback = false;
           let unsubscribing = Promise.resolve();
-          let extrinsicFailedEvent;
+          let failureError: PolymeshError | undefined;
 
           // isCompleted implies status is one of: isFinalized, isInBlock or isError
           if (receipt.isCompleted) {
@@ -284,16 +322,15 @@ export class Network {
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               submissionDetails.transactionIndex = new BigNumber(receipt.txIndex!);
 
-              // if the extrinsic failed due to an on-chain error, we should handle it in a special way
-              [extrinsicFailedEvent] = filterEventRecords(
-                receipt,
-                'system',
-                'ExtrinsicFailed',
-                true
-              );
+              /*
+               * if the extrinsic failed due to an on-chain error, we should handle it in a special
+               *   way. This also catches `revive.EthExtrinsicRevert`, emitted instead of
+               *   `system.ExtrinsicFailed` when the transaction was signed by an Ethereum key
+               */
+              failureError = getExtrinsicFailure(receipt);
 
               // extrinsic failed so we can unsubscribe
-              isLastCallback = !!extrinsicFailedEvent;
+              isLastCallback = !!failureError;
             } else {
               // isFinalized || isError so we know we can unsubscribe
               isLastCallback = true;
@@ -311,11 +348,10 @@ export class Network {
              */
             let finishing = Promise.resolve();
 
-            if (extrinsicFailedEvent) {
-              const { data } = extrinsicFailedEvent;
+            if (failureError) {
+              const error = failureError;
 
               finishing = Promise.all([unsubscribing]).then(() => {
-                const error = handleExtrinsicFailure(data[0]);
                 reject(error);
               });
             } else if (receipt.isFinalized) {
@@ -342,6 +378,12 @@ export class Network {
         context
       );
 
+      const failureError = getExtrinsicFailure(result);
+
+      if (failureError) {
+        throw failureError;
+      }
+
       return {
         blockHash: hashToString(result.status.asFinalized),
         transactionHash: hashToString(transaction.hash),
@@ -349,6 +391,28 @@ export class Network {
         result,
       };
     }
+  }
+
+  /**
+   * Decode the SCALE-encoded call carried by a `revive.ethTransact` transaction (or any other
+   *   Polymesh call), so a dapp can render it next to a wallet's confirmation prompt. Does not
+   *   fix in-wallet legibility (the wallet still shows raw bytes); it removes the worst of the
+   *   opacity for a dapp that cares
+   *
+   * @param hex - SCALE-encoded call, e.g. `transaction.toEthSignablePayload()`'s `transaction.data`
+   */
+  public decodeCall(hex: HexString): {
+    tag: TxTag;
+    args: TransactionArgument[];
+    humanReadable: AnyJson;
+  } {
+    const { context } = this;
+
+    const tag = transactionHexToTxTag(hex, context);
+    const args = context.getTransactionArguments({ tag });
+    const humanReadable = context.createType('Call', hex).toHuman();
+
+    return { tag, args, humanReadable };
   }
 
   /**

--- a/src/api/client/__tests__/AccountManagement.ts
+++ b/src/api/client/__tests__/AccountManagement.ts
@@ -1,3 +1,4 @@
+import { encodeAddress } from '@polkadot/util-crypto';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
@@ -7,6 +8,7 @@ import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mo
 import { MockContext } from '~/testUtils/mocks/dataSources';
 import { AccountBalance, Identity, PermissionType, SubCallback } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
+import { ss58FromEthAddress } from '~/utils/eth';
 import * as utilsInternalModule from '~/utils/internal';
 
 jest.mock(
@@ -233,6 +235,89 @@ describe('AccountManagement class', () => {
       const tx = await accountManagement.approveSubsidy(args);
 
       expect(tx).toEqual(expectedTransaction);
+    });
+  });
+
+  describe('method: mapEvmAccount', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const args = {
+        map: true,
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, context, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await accountManagement.mapEvmAccount();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: unmapEvmAccount', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const args = {
+        map: false,
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, context, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await accountManagement.unmapEvmAccount();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: getAccountByEvmAddress', () => {
+    const ss58Format = new BigNumber(42);
+    const evmAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+    beforeEach(() => {
+      context = dsMockUtils.getContextInstance({ ss58Format });
+      accountManagement = new AccountManagement(context);
+
+      dsMockUtils.createQueryMock('multiSig', 'multiSigSigners', { returnValue: [] });
+    });
+
+    it('should return the Account that mapped the address', async () => {
+      const mappedAddress = encodeAddress(new Uint8Array(32).fill(1), ss58Format.toNumber());
+
+      const originalAccountMock = dsMockUtils.createQueryMock('revive', 'originalAccount', {
+        returnValue: dsMockUtils.createMockOption(dsMockUtils.createMockAccountId(mappedAddress)),
+      });
+
+      const result = await accountManagement.getAccountByEvmAddress({ evmAddress });
+
+      expect(originalAccountMock).toHaveBeenCalledWith(evmAddress);
+      expect(result).toBeInstanceOf(Account);
+      expect(result.address).toBe(mappedAddress);
+    });
+
+    it('should return the 0xEE padded fallback Account when the address is not mapped', async () => {
+      dsMockUtils.createQueryMock('revive', 'originalAccount', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+
+      const result = await accountManagement.getAccountByEvmAddress({ evmAddress });
+
+      expect(result).toBeInstanceOf(Account);
+      expect(result.address).toBe(ss58FromEthAddress(evmAddress, ss58Format));
+    });
+
+    it('should throw an error if the Ethereum address is not 20 bytes', () => {
+      dsMockUtils.createQueryMock('revive', 'originalAccount', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+
+      return expect(
+        accountManagement.getAccountByEvmAddress({ evmAddress: '0x1234' })
+      ).rejects.toThrow('The supplied Ethereum address must be 20 bytes long');
     });
   });
 

--- a/src/api/client/__tests__/Network.ts
+++ b/src/api/client/__tests__/Network.ts
@@ -12,7 +12,14 @@ import { CallIdEnum, EventIdEnum, ModuleIdEnum } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { createMockCall, MockTxStatus } from '~/testUtils/mocks/dataSources';
 import { Mocked } from '~/testUtils/types';
-import { AccountBalance, ErrorCode, MiddlewareMetadata, TransactionPayload, TxTags } from '~/types';
+import {
+  AccountBalance,
+  ErrorCode,
+  MiddlewareMetadata,
+  TransactionArgument,
+  TransactionPayload,
+  TxTags,
+} from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(
@@ -718,6 +725,73 @@ describe('Network Class', () => {
         transactionIndex: new BigNumber(1),
         result: fakeReceipt,
       });
+    });
+  });
+
+  describe('offline submission failure handling', () => {
+    it('should throw when the receipt carries a revive.EthExtrinsicRevert event', async () => {
+      /*
+       * on the Ethereum path the outer extrinsic still reports `ExtrinsicSuccess`, so the revert
+       *   event is the only signal that the inner dispatch failed. Without this check a failed
+       *   transaction would be reported as a success
+       */
+      context.supportsSubscription.mockReturnValue(false);
+
+      dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
+
+      const revertError = new PolymeshError({
+        code: ErrorCode.TransactionReverted,
+        message: 'identity.AlreadyLinked: One secondary or primary key can only belong to one DID',
+      });
+
+      const fakeReceipt = new SubmittableResult({
+        blockNumber: dsMockUtils.createMockU32(new BigNumber(101)),
+        status: dsMockUtils.createMockExtrinsicStatus({
+          Finalized: dsMockUtils.createMockHash('blockHash'),
+        }),
+        txHash: dsMockUtils.createMockHash('txHash'),
+        txIndex: 1,
+      });
+
+      jest.spyOn(baseUtils, 'pollForTransactionFinalization').mockResolvedValue(fakeReceipt);
+      jest.spyOn(baseUtils, 'getExtrinsicFailure').mockReturnValue(revertError);
+
+      await expect(network.submitEthTransaction('0xrawsigned')).rejects.toThrowError(revertError);
+    });
+  });
+
+  describe('method: submitEthTransaction', () => {
+    it('should submit the raw signed transaction as a bare revive.ethTransact extrinsic', async () => {
+      const transaction = dsMockUtils.createTxMock('revive', 'ethTransact', {
+        autoResolve: MockTxStatus.Succeeded,
+      });
+
+      const result = await network.submitEthTransaction('0xrawsigned');
+
+      expect(transaction).toHaveBeenCalledWith('0xrawsigned');
+      expect(result).toEqual(
+        expect.objectContaining({
+          result: expect.any(Object),
+        })
+      );
+    });
+  });
+
+  describe('method: decodeCall', () => {
+    it('should decode a SCALE-encoded call into its tag, arguments and human readable form', () => {
+      const tag = TxTags.identity.SelfRegisterDid;
+      const args = [{ name: 'foo', type: 'Text' }] as unknown as TransactionArgument[];
+      const humanReadable = { method: 'selfRegisterDid', section: 'identity' };
+
+      jest.spyOn(utilsConversionModule, 'transactionHexToTxTag').mockReturnValue(tag);
+      context.getTransactionArguments.mockReturnValue(args);
+      when(context.createType)
+        .calledWith('Call', '0x0719')
+        .mockReturnValue({ toHuman: () => humanReadable } as unknown as GenericExtrinsic);
+
+      const result = network.decodeCall('0x0719');
+
+      expect(result).toEqual({ tag, args, humanReadable });
     });
   });
 

--- a/src/api/client/__tests__/Network.ts
+++ b/src/api/client/__tests__/Network.ts
@@ -2,8 +2,10 @@ import { SubmittableResult } from '@polkadot/api';
 import { GenericExtrinsic } from '@polkadot/types/extrinsic';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
+import { noop } from 'lodash';
 
 import { Network } from '~/api/client/Network';
+import * as ethTransactionUtils from '~/base/ethTransaction';
 import * as baseUtils from '~/base/utils';
 import { Context, PolymeshError, PolymeshTransaction } from '~/internal';
 import { eventsByArgs } from '~/middleware/queries/events';
@@ -774,6 +776,154 @@ describe('Network Class', () => {
           result: expect.any(Object),
         })
       );
+    });
+  });
+
+  describe('submission timeouts', () => {
+    beforeEach(() => {
+      context.supportsSubscription.mockReturnValue(false);
+      /*
+       * an earlier test in this file stubs this to report a revert and never restores it, which
+       *   would otherwise fail every transaction reached from here
+       */
+      jest.spyOn(baseUtils, 'getExtrinsicFailure').mockReturnValue(undefined);
+    });
+
+    it('should throw a TransactionTimeout if the transaction is not broadcast in time', async () => {
+      const transaction = dsMockUtils.createTxMock('revive', 'ethTransact', {
+        autoResolve: false,
+      });
+      /*
+       * the mock returns the same extrinsic object on every call, so overriding `send` here is
+       *   what `broadcastExtrinsic` will reach. Stands in for a node that accepts the connection
+       *   but never acknowledges the submission
+       */
+      const extrinsic = transaction('0xrawsigned') as unknown as { send: jest.Mock };
+      extrinsic.send = jest.fn().mockReturnValue(new Promise(noop));
+
+      await expect(
+        network.submitEthTransaction('0xrawsigned', { broadcastTimeout: 5 })
+      ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.TransactionTimeout }));
+    });
+
+    it('should throw a TransactionTimeout if the transaction is not finalized in time', async () => {
+      dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
+
+      // broadcast fine, but never turns up in a block
+      jest
+        .spyOn(baseUtils, 'pollForTransactionFinalization')
+        .mockReturnValue(new Promise(noop) as never);
+
+      await expect(
+        network.submitEthTransaction('0xrawsigned', { watchTimeout: 5 })
+      ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.TransactionTimeout }));
+    });
+  });
+
+  describe('method: watchTransaction', () => {
+    const fakeReceipt = new SubmittableResult({
+      blockNumber: dsMockUtils.createMockU32(new BigNumber(101)),
+      status: dsMockUtils.createMockExtrinsicStatus({
+        Finalized: dsMockUtils.createMockHash('blockHash'),
+      }),
+      txHash: dsMockUtils.createMockHash('txHash'),
+      txIndex: 1,
+    });
+
+    beforeEach(() => {
+      context.supportsSubscription.mockReturnValue(false);
+      jest.spyOn(baseUtils, 'getExtrinsicFailure').mockReturnValue(undefined);
+    });
+
+    it('should locate a native transaction by its extrinsic hash', async () => {
+      const matcher = jest.fn();
+      const hashMatcherSpy = jest.spyOn(baseUtils, 'extrinsicHashMatcher').mockReturnValue(matcher);
+      const pollSpy = jest
+        .spyOn(baseUtils, 'pollForTransactionFinalization')
+        .mockResolvedValue(fakeReceipt);
+
+      const result = await network.watchTransaction({
+        startingBlock: new BigNumber(100),
+        txHash: '0xtxhash',
+      });
+
+      expect(hashMatcherSpy).toHaveBeenCalled();
+      expect(pollSpy).toHaveBeenCalledWith(matcher, new BigNumber(100), context);
+      expect(result).toEqual({
+        blockHash: 'blockHash',
+        transactionHash: '0xtxhash',
+        transactionIndex: new BigNumber(1),
+        result: fakeReceipt,
+      });
+    });
+
+    it('should match an Ethereum transaction by its payload rather than its extrinsic hash', async () => {
+      /*
+       * a wallet-broadcast transaction rides on chain as an unsigned `revive.ethTransact`, whose
+       *   extrinsic hash the wallet never saw — only the keccak of the payload correlates it
+       */
+      const matcher = jest.fn();
+      const keccakMatcherSpy = jest
+        .spyOn(ethTransactionUtils, 'ethTransactKeccakMatcher')
+        .mockReturnValue(matcher);
+      // spies persist across tests in this file, so only calls made from here on count
+      const hashMatcherSpy = jest.spyOn(baseUtils, 'extrinsicHashMatcher').mockClear();
+      const pollSpy = jest
+        .spyOn(baseUtils, 'pollForTransactionFinalization')
+        .mockResolvedValue(fakeReceipt);
+
+      await network.watchTransaction({
+        startingBlock: new BigNumber(100),
+        txHash: '0xethtxhash',
+        isEthTxHash: true,
+      });
+
+      expect(keccakMatcherSpy).toHaveBeenCalledWith('0xethtxhash');
+      expect(hashMatcherSpy).not.toHaveBeenCalled();
+      expect(pollSpy).toHaveBeenCalledWith(matcher, new BigNumber(100), context);
+    });
+
+    it('should subscribe rather than poll when the connection supports it', async () => {
+      context.supportsSubscription.mockReturnValue(true);
+
+      const subscribeSpy = jest
+        .spyOn(baseUtils, 'subscribeForTransactionFinalization')
+        .mockResolvedValue(fakeReceipt);
+
+      await network.watchTransaction({
+        startingBlock: new BigNumber(100),
+        txHash: '0xtxhash',
+      });
+
+      expect(subscribeSpy).toHaveBeenCalled();
+    });
+
+    it('should throw a TransactionTimeout if the transaction is not found in time', async () => {
+      jest
+        .spyOn(baseUtils, 'pollForTransactionFinalization')
+        .mockReturnValue(new Promise(noop) as never);
+
+      await expect(
+        network.watchTransaction({
+          startingBlock: new BigNumber(100),
+          txHash: '0xtxhash',
+          timeout: 5,
+        })
+      ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.TransactionTimeout }));
+    });
+
+    it('should throw if the located transaction failed on chain', async () => {
+      const revertError = new PolymeshError({
+        code: ErrorCode.TransactionReverted,
+        message: 'identity.AlreadyLinked: One secondary or primary key can only belong to one DID',
+      });
+
+      jest.spyOn(baseUtils, 'pollForTransactionFinalization').mockResolvedValue(fakeReceipt);
+      jest.spyOn(baseUtils, 'getExtrinsicFailure').mockReturnValue(revertError);
+
+      await expect(
+        network.watchTransaction({ startingBlock: new BigNumber(100), txHash: '0xtxhash' })
+      ).rejects.toThrowError(revertError);
     });
   });
 

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -75,6 +75,12 @@ export enum ErrorCode {
    */
   TransactionReverted = 'TransactionReverted',
   /**
+   * the SDK stopped waiting for the transaction before it reached a conclusion. This is **not**
+   *   a failure: the transaction may well have been broadcast, and may still be included in a
+   *   block. Nothing about it was cancelled — only the waiting stopped
+   */
+  TransactionTimeout = 'TransactionTimeout',
+  /**
    * error that should cause termination of the calling application
    */
   FatalError = 'FatalError',

--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -1,9 +1,12 @@
+import { hexToU8a } from '@polkadot/util';
+import { encodeAddress, ethereumEncode, keccakAsU8a } from '@polkadot/util-crypto';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
 import {
   AccountIdentityRelation,
   AccountKeyType,
+  EvmAddressType,
   HistoricPolyxTransaction,
 } from '~/api/entities/Account/types';
 import { Account, Context, Entity, PolymeshError } from '~/internal';
@@ -32,6 +35,7 @@ import {
 } from '~/types';
 import { tuple } from '~/types/utils';
 import * as utilsConversionModule from '~/utils/conversion';
+import { ss58FromEthAddress } from '~/utils/eth';
 import * as utilsInternalModule from '~/utils/internal';
 
 jest.mock(
@@ -1236,6 +1240,107 @@ describe('Account class', () => {
       result = await account.getCollections({ collections: [assetId1] });
       expect(result).toHaveLength(1);
       expect(result[0]!.collection.id).toEqual(assetId1);
+    });
+  });
+
+  describe('EVM address mapping', () => {
+    const ss58Format = new BigNumber(42);
+
+    const nativeAccountId = new Uint8Array(32).fill(1);
+    const nativeAddress = encodeAddress(nativeAccountId, ss58Format.toNumber());
+    const derivedEvmAddress = ethereumEncode(keccakAsU8a(nativeAccountId).subarray(12));
+
+    const h160 = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+    const ethAccountId = new Uint8Array(32);
+    ethAccountId.set(hexToU8a(h160), 0);
+    ethAccountId.set(new Uint8Array(12).fill(0xee), 20);
+    const ethDerivedAddress = encodeAddress(ethAccountId, ss58Format.toNumber());
+
+    beforeEach(() => {
+      context = dsMockUtils.getContextInstance({ ss58Format });
+    });
+
+    describe('getter: evmAddress', () => {
+      it('should return the hashed address for a native Account', () => {
+        const nativeAccount = new Account({ address: nativeAddress }, context);
+
+        expect(nativeAccount.evmAddress).toBe(derivedEvmAddress);
+      });
+
+      it('should return the padded Ethereum key for an Ethereum-derived Account', () => {
+        const ethAccount = new Account({ address: ethDerivedAddress }, context);
+
+        expect(ethAccount.evmAddress).toBe(ethereumEncode(hexToU8a(h160)));
+        expect(ethAccount.evmAddress).toBe(ethAccount.ethAddress);
+      });
+    });
+
+    describe('method: getEvmAddressDetails', () => {
+      it('should report a native Account as unmapped, with the fallback Account that is credited', async () => {
+        const originalAccountMock = dsMockUtils.createQueryMock('revive', 'originalAccount', {
+          returnValue: createMockOption(),
+        });
+
+        const nativeAccount = new Account({ address: nativeAddress }, context);
+
+        const result = await nativeAccount.getEvmAddressDetails();
+
+        expect(originalAccountMock).toHaveBeenCalledWith(derivedEvmAddress);
+        expect(result.address).toBe(derivedEvmAddress);
+        expect(result.type).toBe(EvmAddressType.Derived);
+        expect(result.isMapped).toBe(false);
+        expect(result.fallbackAccount?.address).toBe(
+          ss58FromEthAddress(derivedEvmAddress, ss58Format)
+        );
+      });
+
+      it('should report a native Account as mapped once it has an entry', async () => {
+        dsMockUtils.createQueryMock('revive', 'originalAccount', {
+          returnValue: createMockOption(createMockAccountId(nativeAddress)),
+        });
+
+        const nativeAccount = new Account({ address: nativeAddress }, context);
+
+        const result = await nativeAccount.getEvmAddressDetails();
+
+        expect(result.address).toBe(derivedEvmAddress);
+        expect(result.type).toBe(EvmAddressType.Derived);
+        expect(result.isMapped).toBe(true);
+      });
+
+      it('should still report the fallback Account once mapped, since mapping does not move funds sent beforehand', async () => {
+        dsMockUtils.createQueryMock('revive', 'originalAccount', {
+          returnValue: createMockOption(createMockAccountId(nativeAddress)),
+        });
+
+        const nativeAccount = new Account({ address: nativeAddress }, context);
+
+        const result = await nativeAccount.getEvmAddressDetails();
+
+        expect(result.isMapped).toBe(true);
+        expect(result.fallbackAccount?.address).toBe(
+          ss58FromEthAddress(derivedEvmAddress, ss58Format)
+        );
+      });
+
+      it('should report an Ethereum-derived Account as natively mapped without hitting the chain', async () => {
+        const originalAccountMock = dsMockUtils.createQueryMock('revive', 'originalAccount', {
+          returnValue: createMockOption(),
+        });
+
+        const ethAccount = new Account({ address: ethDerivedAddress }, context);
+
+        const result = await ethAccount.getEvmAddressDetails();
+
+        expect(result).toEqual({
+          address: ethereumEncode(hexToU8a(h160)),
+          type: EvmAddressType.Native,
+          isMapped: true,
+          fallbackAccount: null,
+        });
+        // the chain strips the padding, so there is no stored mapping to look up
+        expect(originalAccountMock).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -1275,6 +1275,53 @@ describe('Account class', () => {
       });
     });
 
+    describe('getter: ethAddress', () => {
+      it('should return null for an Account that is not Ethereum-derived', () => {
+        const nativeAccount = new Account({ address: nativeAddress }, context);
+
+        expect(nativeAccount.ethAddress).toBeNull();
+      });
+
+      it('should return the controlling Ethereum address for an Ethereum-derived Account', () => {
+        const ethAccount = new Account({ address: ethDerivedAddress }, context);
+
+        expect(ethAccount.ethAddress).toBe(ethereumEncode(hexToU8a(h160)));
+      });
+    });
+
+    describe('method: getTransactionHistory', () => {
+      it('should throw a NotSupported error for an Ethereum-derived Account', async () => {
+        const ethAccount = new Account({ address: ethDerivedAddress }, context);
+
+        await expect(ethAccount.getTransactionHistory()).rejects.toThrow(
+          expect.objectContaining({ code: ErrorCode.NotSupported })
+        );
+      });
+    });
+
+    describe('method: getTypeInfo', () => {
+      it('should report an Ethereum-derived Account as an Ethereum key', async () => {
+        dsMockUtils.createQueryMock('identity', 'keyRecords', { returnValue: createMockOption() });
+        dsMockUtils.createQueryMock('multiSig', 'multiSigSignsRequired', {
+          returnValue: createMockU64(new BigNumber(0)),
+        });
+
+        (context.polymeshApi.queryMulti as unknown as jest.Mock).mockResolvedValue([
+          createMockOption(),
+          createMockU64(new BigNumber(0)),
+        ]);
+
+        const ethAccount = new Account({ address: ethDerivedAddress }, context);
+
+        const result = await ethAccount.getTypeInfo();
+
+        expect(result).toEqual({
+          keyType: AccountKeyType.Ethereum,
+          relation: AccountIdentityRelation.Unassigned,
+        });
+      });
+    });
+
     describe('method: getEvmAddressDetails', () => {
       it('should report a native Account as unmapped, with the fallback Account that is credited', async () => {
         const originalAccountMock = dsMockUtils.createQueryMock('revive', 'originalAccount', {

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -18,6 +18,8 @@ import {
   AccountIdentityRelation,
   AccountKeyType,
   AccountTypeInfo,
+  EvmAddressDetails,
+  EvmAddressType,
   HistoricPolyxTransaction,
 } from '~/api/entities/Account/types';
 import { Subsidies } from '~/api/entities/Subsidies';
@@ -72,7 +74,12 @@ import {
   u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
-import { ethAddressFromSs58, isEthDerivedAddress } from '~/utils/eth';
+import {
+  ethAddressFromSs58,
+  evmAddressFromSs58,
+  isEthDerivedAddress,
+  ss58FromEthAddress,
+} from '~/utils/eth';
 import {
   areSameAccounts,
   asAssetId,
@@ -150,6 +157,77 @@ export class Account extends Entity<UniqueIdentifiers, string> {
     }
 
     return ethAddressFromSs58(address, context.ss58Format);
+  }
+
+  /**
+   * The Ethereum address the chain associates with this Account, mirroring the `revive` pallet's
+   *   address mapper
+   *
+   * - for an Ethereum-derived Account, this is the Ethereum key controlling it, and is the same
+   *   value as {@link ethAddress}
+   * - for any other Account, it is derived by hashing: `keccak256(<32-byte AccountId32>)[12..]`
+   *
+   * @note this is what the address *would* be. Because hashing is one way, the chain can only
+   *   resolve a derived address back to this Account once the Account has called
+   *   {@link api/client/AccountManagement!AccountManagement.mapEvmAccount | mapEvmAccount} —
+   *   until then, anything sent to it is credited elsewhere. Use {@link getEvmAddressDetails} to
+   *   check before advertising this address
+   */
+  public get evmAddress(): string {
+    const { address, context } = this;
+
+    return evmAddressFromSs58(address, context.ss58Format);
+  }
+
+  /**
+   * Retrieve the Ethereum address the chain associates with this Account, together with whether
+   *   the chain can currently resolve that address back to this Account, and the fallback Account
+   *   credited whenever it cannot
+   *
+   * @note for a derived address the fallback Account is reported even once the Account is mapped,
+   *   since mapping does not move funds that arrived beforehand
+   */
+  public async getEvmAddressDetails(): Promise<EvmAddressDetails> {
+    const { address, context } = this;
+
+    const evmAddress = evmAddressFromSs58(address, context.ss58Format);
+
+    /*
+     * An Ethereum-derived Account's address is the Ethereum key it is padded from, which the chain
+     *   inverts by stripping the padding — there is no stored mapping to look up, and none can be
+     *   created (`revive.mapAccount` rejects an `Address20` origin)
+     */
+    if (isEthDerivedAddress(address, context.ss58Format)) {
+      return {
+        address: evmAddress,
+        type: EvmAddressType.Native,
+        isMapped: true,
+        fallbackAccount: null,
+      };
+    }
+
+    const rawOriginalAccount = await context.polymeshApi.query.revive.originalAccount(evmAddress);
+
+    /*
+     * The storage key is `keccak256` of this Account, so an entry can only have been created by
+     *   this Account mapping itself — its presence alone answers the question
+     */
+    const isMapped = rawOriginalAccount.isSome;
+
+    return {
+      address: evmAddress,
+      type: EvmAddressType.Derived,
+      isMapped,
+      /*
+       * Reported whether or not the Account is mapped: mapping does not move funds that arrived
+       *   at `evmAddress` beforehand, so this stays the only pointer to a balance stranded by the
+       *   very situation mapping exists to prevent
+       */
+      fallbackAccount: new Account(
+        { address: ss58FromEthAddress(evmAddress, context.ss58Format) },
+        context
+      ),
+    };
   }
 
   /**

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -72,6 +72,7 @@ import {
   u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
+import { ethAddressFromSs58, isEthDerivedAddress } from '~/utils/eth';
 import {
   areSameAccounts,
   asAssetId,
@@ -135,6 +136,20 @@ export class Account extends Entity<UniqueIdentifiers, string> {
     this.authorizations = new Authorizations(this, context);
     this.subsidies = new Subsidies(this, context);
     this.staking = new Staking(this, context);
+  }
+
+  /**
+   * The Ethereum address controlling this Account, or `null` if it is not an Ethereum-derived
+   *   Account (i.e. the last 12 bytes of its decoded `AccountId32` are not `0xEE`)
+   */
+  public get ethAddress(): string | null {
+    const { address, context } = this;
+
+    if (!isEthDerivedAddress(address, context.ss58Format)) {
+      return null;
+    }
+
+    return ethAddressFromSs58(address, context.ss58Format);
   }
 
   /**
@@ -207,6 +222,11 @@ export class Account extends Entity<UniqueIdentifiers, string> {
    * @param filters.start - page offset
    *
    * @note uses the middleware v2
+   *
+   * @throws `NotSupported` if this Account is Ethereum-derived: the indexer records a
+   *   `revive.ethTransact` extrinsic with `address: null`, so it cannot attribute any history to
+   *   the Ethereum-derived Account. Returning an empty result set would be indistinguishable from
+   *   "no history" and read as a bug in the caller's code
    */
   public async getTransactionHistory(
     filters: {
@@ -222,6 +242,15 @@ export class Account extends Entity<UniqueIdentifiers, string> {
     const { tag, success, size, start, orderBy = ExtrinsicsOrderBy.IdAsc, blockHash } = filters;
 
     const { context, address } = this;
+
+    if (isEthDerivedAddress(address, context.ss58Format)) {
+      throw new PolymeshError({
+        code: ErrorCode.NotSupported,
+        message:
+          'Transaction history cannot be retrieved for an Ethereum-derived Account. The indexer records these transactions without attributing them to the signing Account',
+        data: { address },
+      });
+    }
 
     let moduleId;
     let callId;
@@ -531,6 +560,8 @@ export class Account extends Entity<UniqueIdentifiers, string> {
     let keyType: AccountKeyType = AccountKeyType.Normal;
     if (!multiSignsRequired.isZero()) {
       keyType = AccountKeyType.MultiSig;
+    } else if (isEthDerivedAddress(address, context.ss58Format)) {
+      keyType = AccountKeyType.Ethereum;
     }
 
     if (optKeyRecord.isNone) {

--- a/src/api/entities/Account/types.ts
+++ b/src/api/entities/Account/types.ts
@@ -72,6 +72,12 @@ export enum AccountKeyType {
    * Account represents a smart contract
    */
   SmartContract = 'SmartContract',
+  /**
+   * Account is controlled by an Ethereum key (the last 12 bytes of its decoded `AccountId32`
+   *   are `0xEE`). If the Account is also a MultiSig signer, `MultiSig` takes priority, since
+   *   that is the flag that changes control flow (`run` vs `runAsProposal`)
+   */
+  Ethereum = 'Ethereum',
 }
 
 /**

--- a/src/api/entities/Account/types.ts
+++ b/src/api/entities/Account/types.ts
@@ -103,6 +103,61 @@ export enum AccountIdentityRelation {
 }
 
 /**
+ * How an Account's Ethereum (H160) address relates to the Account itself
+ */
+export enum EvmAddressType {
+  /**
+   * The Account is padded from a native Ethereum key (`<h160> ++ [0xEE; 12]`), so its Ethereum
+   *   address is that key. The chain can always resolve this address back to the Account, and
+   *   `revive.mapAccount` neither applies nor is needed
+   */
+  Native = 'Native',
+  /**
+   * The Account is a native Polymesh Account, so its Ethereum address is derived by hashing:
+   *   `keccak256(<32-byte AccountId32>)[12..]`. Hashing is one way, so the chain can only resolve
+   *   this address back to the Account once the Account has called `revive.mapAccount`
+   */
+  Derived = 'Derived',
+}
+
+/**
+ * The Ethereum address the chain associates with an Account, and whether the chain can resolve it
+ *   back to that Account
+ */
+export interface EvmAddressDetails {
+  /**
+   * The checksummed (EIP-55) `0x`-prefixed Ethereum address
+   */
+  address: string;
+  /**
+   * Whether `address` is the Account's own Ethereum key or is derived from it by hashing
+   */
+  type: EvmAddressType;
+  /**
+   * Whether the chain can resolve `address` back to this Account. Always `true` for
+   *   {@link EvmAddressType.Native}; for {@link EvmAddressType.Derived} it reflects whether the
+   *   Account has called `revive.mapAccount`
+   *
+   * @note while this is `false`, anything sent to `address` is credited to `fallbackAccount`
+   *   instead of to this Account
+   */
+  isMapped: boolean;
+  /**
+   * The Account credited when the chain cannot resolve `address` back to this Account, i.e. the
+   *   Account `ss58(<address> ++ [0xEE; 12])`. `null` only for {@link EvmAddressType.Native},
+   *   where this Account *is* the one the Ethereum key controls, so there is no separate fallback
+   *
+   * @note always populated for {@link EvmAddressType.Derived}, including once `isMapped` is
+   *   `true`. Mapping does not move funds that arrived before it, so this remains the place to
+   *   look for anything sent to `address` while it was still unmapped
+   *
+   * @note the chain's `revive.dispatchAsFallbackAccount` can dispatch on this Account's behalf,
+   *   which is how funds sent to an unmapped address are recovered
+   */
+  fallbackAccount: Account | null;
+}
+
+/**
  * The type of account, and its relation to an Identity
  */
 export interface AccountTypeInfo {

--- a/src/api/procedures/__tests__/toggleEvmAccountMapping.ts
+++ b/src/api/procedures/__tests__/toggleEvmAccountMapping.ts
@@ -1,0 +1,136 @@
+import { hexToU8a } from '@polkadot/util';
+import { encodeAddress, ethereumEncode, keccakAsU8a } from '@polkadot/util-crypto';
+import BigNumber from 'bignumber.js';
+
+import {
+  getAuthorization,
+  prepareToggleEvmAccountMapping,
+  ToggleEvmAccountMappingParams,
+} from '~/api/procedures/toggleEvmAccountMapping';
+import { Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+
+describe('toggleEvmAccountMapping procedure', () => {
+  let mockContext: Mocked<Context>;
+
+  const ss58Format = new BigNumber(42);
+
+  const nativeAccountId = new Uint8Array(32).fill(1);
+  const nativeAddress = encodeAddress(nativeAccountId, ss58Format.toNumber());
+  const derivedEvmAddress = ethereumEncode(keccakAsU8a(nativeAccountId).subarray(12));
+
+  const h160 = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+  const ethAccountId = new Uint8Array(32);
+  ethAccountId.set(hexToU8a(h160), 0);
+  ethAccountId.set(new Uint8Array(12).fill(0xee), 20);
+  const ethDerivedAddress = encodeAddress(ethAccountId, ss58Format.toNumber());
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance({ ss58Format });
+    mockContext.getSigningAddress.mockReturnValue(nativeAddress);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  it('should return a map account transaction spec when the Account is not mapped', async () => {
+    const originalAccountMock = dsMockUtils.createQueryMock('revive', 'originalAccount', {
+      returnValue: dsMockUtils.createMockOption(),
+    });
+
+    const transaction = dsMockUtils.createTxMock('revive', 'mapAccount');
+
+    const proc = procedureMockUtils.getInstance<ToggleEvmAccountMappingParams, void>(mockContext);
+
+    const result = await prepareToggleEvmAccountMapping.call(proc, { map: true });
+
+    // the storage must be read at the address the chain derives, not at the Account itself
+    expect(originalAccountMock).toHaveBeenCalledWith(derivedEvmAddress);
+    expect(result).toEqual({ transaction, resolver: undefined });
+  });
+
+  it('should return an unmap account transaction spec when the Account is mapped', async () => {
+    dsMockUtils.createQueryMock('revive', 'originalAccount', {
+      returnValue: dsMockUtils.createMockOption(dsMockUtils.createMockAccountId(nativeAddress)),
+    });
+
+    const transaction = dsMockUtils.createTxMock('revive', 'unmapAccount');
+
+    const proc = procedureMockUtils.getInstance<ToggleEvmAccountMappingParams, void>(mockContext);
+
+    const result = await prepareToggleEvmAccountMapping.call(proc, { map: false });
+
+    expect(result).toEqual({ transaction, resolver: undefined });
+  });
+
+  it('should throw an error if the Account is already mapped', () => {
+    dsMockUtils.createQueryMock('revive', 'originalAccount', {
+      returnValue: dsMockUtils.createMockOption(dsMockUtils.createMockAccountId(nativeAddress)),
+    });
+
+    const proc = procedureMockUtils.getInstance<ToggleEvmAccountMappingParams, void>(mockContext);
+
+    return expect(prepareToggleEvmAccountMapping.call(proc, { map: true })).rejects.toThrow(
+      'The signing Account is already mapped to its Ethereum address'
+    );
+  });
+
+  it('should throw an error if the Account is not mapped', () => {
+    dsMockUtils.createQueryMock('revive', 'originalAccount', {
+      returnValue: dsMockUtils.createMockOption(),
+    });
+
+    const proc = procedureMockUtils.getInstance<ToggleEvmAccountMappingParams, void>(mockContext);
+
+    return expect(prepareToggleEvmAccountMapping.call(proc, { map: false })).rejects.toThrow(
+      'The signing Account is not mapped to its Ethereum address'
+    );
+  });
+
+  it('should throw an error if the signing Account is Ethereum-derived', async () => {
+    mockContext.getSigningAddress.mockReturnValue(ethDerivedAddress);
+
+    const originalAccountMock = dsMockUtils.createQueryMock('revive', 'originalAccount', {
+      returnValue: dsMockUtils.createMockOption(),
+    });
+
+    const proc = procedureMockUtils.getInstance<ToggleEvmAccountMappingParams, void>(mockContext);
+
+    await expect(prepareToggleEvmAccountMapping.call(proc, { map: true })).rejects.toThrow(
+      'An Ethereum-derived Account cannot be mapped'
+    );
+
+    // rejected before reaching the chain, since no mapping can exist for such an Account
+    expect(originalAccountMock).not.toHaveBeenCalled();
+  });
+
+  describe('getAuthorization', () => {
+    it('should return no required permissions, since the chain does not check them', () => {
+      const proc = procedureMockUtils.getInstance<ToggleEvmAccountMappingParams, void>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(boundFunc()).toEqual({
+        permissions: {
+          transactions: [],
+          assets: [],
+          portfolios: [],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/toggleEvmAccountMapping.ts
+++ b/src/api/procedures/toggleEvmAccountMapping.ts
@@ -1,0 +1,94 @@
+import { PolymeshError, Procedure } from '~/internal';
+import { ErrorCode } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+import { evmAddressFromSs58, isEthDerivedAddress } from '~/utils/eth';
+
+export interface ToggleEvmAccountMappingParams {
+  map: boolean;
+}
+
+/**
+ * @hidden
+ */
+export async function prepareToggleEvmAccountMapping(
+  this: Procedure<ToggleEvmAccountMappingParams, void>,
+  args: ToggleEvmAccountMappingParams
+): Promise<
+  | TransactionSpec<void, ExtrinsicParams<'revive', 'mapAccount'>>
+  | TransactionSpec<void, ExtrinsicParams<'revive', 'unmapAccount'>>
+> {
+  const { context } = this;
+  const { map } = args;
+
+  const {
+    polymeshApi: {
+      tx: { revive: reviveTx },
+      query: { revive: reviveQuery },
+    },
+  } = context;
+
+  const signingAddress = context.getSigningAddress();
+
+  /*
+   * The chain resolves an Ethereum-derived Account by stripping its `0xEE` padding, so there is
+   *   nothing to map. `revive.mapAccount` rejects an `Address20` origin outright
+   */
+  if (isEthDerivedAddress(signingAddress, context.ss58Format)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message:
+        'An Ethereum-derived Account cannot be mapped. The chain already resolves its Ethereum address by stripping the padding from the Account',
+      data: { signingAddress },
+    });
+  }
+
+  const evmAddress = evmAddressFromSs58(signingAddress, context.ss58Format);
+
+  const rawOriginalAccount = await reviveQuery.originalAccount(evmAddress);
+
+  if (map) {
+    if (rawOriginalAccount.isSome) {
+      throw new PolymeshError({
+        code: ErrorCode.NoDataChange,
+        message: 'The signing Account is already mapped to its Ethereum address',
+        data: { signingAddress, evmAddress },
+      });
+    }
+
+    return { transaction: reviveTx.mapAccount, resolver: undefined };
+  }
+
+  if (rawOriginalAccount.isNone) {
+    throw new PolymeshError({
+      code: ErrorCode.NoDataChange,
+      message: 'The signing Account is not mapped to its Ethereum address',
+      data: { signingAddress, evmAddress },
+    });
+  }
+
+  return { transaction: reviveTx.unmapAccount, resolver: undefined };
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<ToggleEvmAccountMappingParams, void>
+): ProcedureAuthorization {
+  return {
+    permissions: {
+      // `revive.{map,unmap}_account` are gated by `ensure_signed` only — confirmed against the
+      // runtime — so they never consult `ExtrinsicPermissions`. Declaring the tags would make the
+      // pre-flight check stricter than the chain and reject secondary keys the chain accepts.
+      transactions: [],
+      assets: [],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const toggleEvmAccountMapping = (): Procedure<ToggleEvmAccountMappingParams, void> =>
+  new Procedure(prepareToggleEvmAccountMapping, getAuthorization);

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -146,6 +146,41 @@ export interface ProcedureOpts {
    * @note even if the checks are skipped from being validated on the SDK, they will still be validated on the chain
    */
   skipChecks?: SkipChecksOpt;
+
+  /**
+   * Bounds on how long the SDK will wait when submitting and tracking the transaction. By default
+   *   it waits indefinitely
+   */
+  submission?: SubmissionOpts;
+}
+
+/**
+ * Bounds on how long the SDK waits while submitting a transaction and tracking it to a finalized
+ *   block. Both default to waiting indefinitely
+ *
+ * @note a timeout only stops the SDK *waiting*. It never cancels the transaction — a transaction
+ *   that was already handed to a signer or broadcast may still be included in a block afterwards.
+ *   Use {@link api/client/Network!Network.watchTransaction | network.watchTransaction} to resume
+ *   tracking one that timed out
+ *
+ * @note these apply to the paths where the SDK locates the transaction by scanning blocks: any
+ *   connection without subscription support, and transactions broadcast by an Ethereum wallet.
+ *   When the SDK submits over a subscription-capable connection, the node reports status directly
+ *   and neither bound is used
+ */
+export interface SubmissionOpts {
+  /**
+   * milliseconds to wait for the signer (or Ethereum wallet) to accept the transaction and
+   *   broadcast it. This is the window that covers a wallet confirmation prompt, so it should be
+   *   generous enough for a human to respond
+   */
+  broadcastTimeout?: number;
+
+  /**
+   * milliseconds to wait, after the transaction has been broadcast, for it to appear in a
+   *   finalized block
+   */
+  watchTimeout?: number;
 }
 
 /**

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -22,6 +22,7 @@ import BigNumber from 'bignumber.js';
 import { chunk, clone, flattenDeep } from 'lodash';
 
 import { HistoricPolyxTransaction } from '~/api/entities/Account/types';
+import { EthSigner } from '~/base/types';
 import { processType } from '~/base/utils';
 import {
   Account,
@@ -83,7 +84,9 @@ import {
   txTagToProtocolOp,
   u16ToBigNumber,
   u32ToBigNumber,
+  u64ToBigNumber,
 } from '~/utils/conversion';
+import { isEthDerivedAddress } from '~/utils/eth';
 import {
   asAccount,
   asDid,
@@ -93,6 +96,7 @@ import {
   getApiAtBlock,
   getLatestSqVersion,
 } from '~/utils/internal';
+import { isEthSigningManager } from '~/utils/typeguards';
 
 interface ConstructorParams {
   polymeshApi: ApiPromise;
@@ -127,6 +131,10 @@ export class Context {
   private nonce?: BigNumber | undefined;
 
   private _isArchiveNodeResult?: boolean;
+
+  private _ethRuntimePalletsAddress?: Promise<string>;
+
+  private _ethChainId?: BigNumber;
 
   public specVersion: number;
 
@@ -626,6 +634,58 @@ export class Context {
     const { signingManager } = this;
 
     return signingManager?.getExternalSigner();
+  }
+
+  /**
+   * @hidden
+   *
+   * Retrieve the Ethereum signer from the Signing Manager, if it has one
+   *
+   * @returns `undefined` if there is no Signing Manager attached, or it isn't capable of signing
+   *   Ethereum transactions
+   */
+  public getEthSigner(): EthSigner | undefined {
+    const { signingManager } = this;
+
+    if (!signingManager || !isEthSigningManager(signingManager)) {
+      return undefined;
+    }
+
+    return signingManager.getEthSigner();
+  }
+
+  /**
+   * @hidden
+   *
+   * Retrieve the sentinel address used to dispatch runtime calls through the `revive` pallet,
+   *   i.e. `reviveApi.runtimePalletsAddress()`
+   *
+   * @note cached for the connection's lifetime; it cannot change without a runtime upgrade, and a
+   *   reconnect rebuilds the Context anyway
+   */
+  public getEthRuntimePalletsAddress(): Promise<string> {
+    if (!this._ethRuntimePalletsAddress) {
+      this._ethRuntimePalletsAddress = this.polymeshApi.call.reviveApi
+        .runtimePalletsAddress()
+        .then(address => address.toString());
+    }
+
+    return this._ethRuntimePalletsAddress;
+  }
+
+  /**
+   * @hidden
+   *
+   * Retrieve the EIP-155 chain ID used to sign Ethereum transactions, i.e. `consts.revive.chainId`
+   *
+   * @note cached for the connection's lifetime; it cannot change without a runtime upgrade
+   */
+  public getEthChainId(): BigNumber {
+    if (!this._ethChainId) {
+      this._ethChainId = u64ToBigNumber(this.polymeshApi.consts.revive.chainId);
+    }
+
+    return this._ethChainId;
   }
 
   /**
@@ -1461,6 +1521,9 @@ export class Context {
 
   /**
    * Get signature for a raw payload string
+   *
+   * @throws if the resolved signer is an Ethereum-derived Account: `verify_any_signature` only
+   *   accepts sr25519 and ed25519, so no Ethereum key can produce a valid off-chain signature
    */
   public async getSignature(args: {
     rawPayload: `0x${string}`;
@@ -1485,8 +1548,19 @@ export class Context {
       account = this.getSigningAddress();
     }
 
+    const { address } = asAccount(account, this);
+
+    if (isEthDerivedAddress(address, this.ss58Format)) {
+      throw new PolymeshError({
+        code: ErrorCode.NotSupported,
+        message:
+          'Off-chain signatures are not supported for Ethereum-derived Accounts. The chain only accepts sr25519 and ed25519 signatures for this operation',
+        data: { address },
+      });
+    }
+
     const result = await externalSigner.signRaw({
-      address: asAccount(account, this).address,
+      address,
       data: rawPayload,
       type: 'bytes',
     });

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -10,6 +10,8 @@ import {
   getExtrinsicFailure,
   handleTransactionSubmissionError,
   pollForTransactionFinalization,
+  subscribeForTransactionFinalization,
+  TransactionInclusionInfo,
 } from '~/base/utils';
 import { Context, Identity, MultiSigProposal, PolymeshError } from '~/internal';
 import { latestBlockQuery } from '~/middleware/queries/common';
@@ -553,7 +555,26 @@ export abstract class PolymeshTransactionBase<
 
     this.setIsRunningStatus(txHash);
 
-    const finalizedReceipt = await pollForTransactionFinalization(matcher, startingBlock, context);
+    /*
+     * report inclusion as soon as the transaction lands in a block, rather than leaving the caller
+     *   with no feedback for the whole finalization window
+     */
+    const onInBlock = ({ blockHash, blockNumber, txIndex }: TransactionInclusionInfo): void => {
+      this.blockHash = blockHash;
+      this.blockNumber = blockNumber;
+      this.txIndex = new BigNumber(txIndex);
+      this.updateStatus(TransactionStatus.InBlock);
+    };
+
+    /*
+     * subscribing is strictly better where the connection allows it: blocks arrive as they are
+     *   produced instead of on a poll tick, and it removes a repeating `getHeader`/`getBlock`
+     *   cycle per in-flight transaction. Polling remains the fallback for HTTP connections, which
+     *   is what it was always intended for
+     */
+    const finalizedReceipt = context.supportsSubscription()
+      ? await subscribeForTransactionFinalization(matcher, startingBlock, context, onInBlock)
+      : await pollForTransactionFinalization(matcher, startingBlock, context, undefined, onInBlock);
 
     this.blockHash = hashToString(finalizedReceipt.status.asFinalized);
     this.blockNumber = u32ToBigNumber(finalizedReceipt.blockNumber!);

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -1578,8 +1578,8 @@ export abstract class PolymeshTransactionBase<
      *   extrinsic, so neither `paidForBy` nor a subsidy reaches the chain's fee pipeline — gas is
      *   charged to the signing Account.
      *
-     * TODO: revisit both branches below if the chain ever routes third-party payment through this
-     *   transport
+     * Both branches below would need revisiting if the chain ever routes third-party payment
+     *   through this transport
      */
     if (paidForBy && !isEthSigner) {
       const { account: primaryAccount } = await paidForBy.getPrimaryAccount();

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -15,9 +15,10 @@ import {
   getEthSubmissionMode,
   getNativeToEthRatio,
 } from '~/base/ethTransaction';
-import { EthTransactionPayload } from '~/base/types';
+import { EthSigner, EthTransactionPayload, EthTransactionRequest } from '~/base/types';
 import {
   extrinsicHashMatcher,
+  ExtrinsicMatcher,
   getExtrinsicFailure,
   handleTransactionSubmissionError,
   pollForTransactionFinalization,
@@ -36,6 +37,8 @@ import {
   PayingAccount,
   PayingAccountFees,
   PayingAccountType,
+  SubmissionOpts,
+  TransactionBroadcastHandle,
   TransactionPayload,
   TransactionStatus,
   UnsubCallback,
@@ -60,7 +63,7 @@ import {
   u64ToBigNumber,
 } from '~/utils/conversion';
 import { isEthDerivedAddress } from '~/utils/eth';
-import { defusePromise, delay, filterEventRecords, optionize } from '~/utils/internal';
+import { defusePromise, delay, filterEventRecords, optionize, withTimeout } from '~/utils/internal';
 
 /**
  * @hidden
@@ -194,6 +197,13 @@ export abstract class PolymeshTransactionBase<
   /**
    * @hidden
    *
+   * Bounds on how long to wait while broadcasting and tracking this transaction
+   */
+  protected submissionOpts: SubmissionOpts;
+
+  /**
+   * @hidden
+   *
    * object that performs the payload signing logic
    */
   protected signer?: PolkadotSigner | undefined;
@@ -231,6 +241,13 @@ export abstract class PolymeshTransactionBase<
 
   /**
    * @hidden
+   * in-flight `watch` call started by {@link broadcast}, used to reject overlapping calls. Cleared
+   *   once it settles, so a `watch` that timed out can simply be retried
+   */
+  private watching: Promise<TransformedReturnValue> | undefined;
+
+  /**
+   * @hidden
    */
   constructor(
     transactionSpec: BaseTransactionSpec<ReturnValue, TransformedReturnValue> &
@@ -246,6 +263,7 @@ export abstract class PolymeshTransactionBase<
       mortality,
       multiSig,
       multiSigOpts,
+      submission,
       preRunValidation,
     } = transactionSpec;
 
@@ -253,6 +271,7 @@ export abstract class PolymeshTransactionBase<
     this.multiSig = multiSig ?? null;
     this.mortality = mortality;
     this.multiSigOpts = multiSigOpts ?? {};
+    this.submissionOpts = submission ?? {};
     this.signer = signer;
     this.context = context;
     this.paidForBy = paidForBy;
@@ -337,31 +356,184 @@ export abstract class PolymeshTransactionBase<
 
       const receipt = await this.internalRun();
 
-      this.receipt = receipt;
-
-      const {
-        resolver,
-        transformer = (val): Promise<TransformedReturnValue> =>
-          Promise.resolve(val as unknown as TransformedReturnValue),
-      } = this;
-
-      let value: ReturnValue;
-
-      if (isResolverFunction(resolver)) {
-        value = await resolver(receipt);
-      } else {
-        value = resolver;
-      }
-
-      this._result = await transformer(value);
-      this.updateStatus(TransactionStatus.Succeeded);
-
-      return this._result;
+      return await this.resolveResult(receipt);
     } catch (err) {
       this.handleRunError(err);
     } finally {
       this.markAsRan();
     }
+  }
+
+  /**
+   * Broadcast the transaction and return as soon as it has been accepted, without waiting for it
+   *   to be included in a block. This is {@link run} split at its natural seam — the returned
+   *   handle's `watch` performs the second half and yields the exact value `run` would have — so
+   *   `await (await tx.broadcast()).watch()` is equivalent to `await tx.run()`
+   *
+   * Use it when waiting is not wanted, or not safe to depend on: an Ethereum wallet that
+   *   broadcasts on the user's behalf, a long finalization window a UI should not block on, or a
+   *   flow that persists the hash and resumes tracking later via
+   *   {@link api/client/Network!Network.watchTransaction | network.watchTransaction}
+   *
+   * @note this always submits without an extrinsic status subscription, since that channel cannot
+   *   report a hash without also waiting for the result. The trade-off is that `Future` status
+   *   reporting and in-pool `Aborted` detection are unavailable — those come from the node's
+   *   status stream, which only {@link run} attaches to
+   *
+   * @throws if the transaction has already been run or broadcast
+   * @throws `NotSupported` if the signing Account is a MultiSig signer. Use `runAsProposal`, which
+   *   needs the finalized receipt to report the resulting proposal
+   */
+  public async broadcast(): Promise<TransactionBroadcastHandle<TransformedReturnValue>> {
+    const { context } = this;
+
+    if (this.hasRun) {
+      throw new PolymeshError({
+        code: ErrorCode.General,
+        message: 'Cannot re-run a Transaction',
+      });
+    }
+
+    if (this.multiSig) {
+      throw new PolymeshError({
+        code: ErrorCode.NotSupported,
+        message:
+          '`.broadcast` cannot be used with a MultiSig signer, since the resulting proposal can only be read from the finalized transaction. `.runAsProposal` should be called instead',
+        data: { signingAddress: this.signingAddress, multiSigAddress: this.multiSig.address },
+      });
+    }
+
+    try {
+      if (this.preRunValidation) {
+        await this.preRunValidation({ asProposal: false });
+      }
+
+      await this.assertFeesCovered();
+
+      const startingBlock = await context.getLatestBlock();
+
+      const { matcher } = await this.broadcastToChain(await this.buildPollingSubmission());
+
+      return {
+        // set by `broadcastToChain`, which cannot succeed without it
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        txHash: this.txHash!,
+        ...(this.ethTxHash !== undefined ? { ethTxHash: this.ethTxHash } : {}),
+        startingBlock,
+        watch: opts => this.watchBroadcast(matcher, startingBlock, opts?.timeout),
+      };
+    } catch (err) {
+      this.handleRunError(err);
+    } finally {
+      /*
+       * marked here rather than via `markAsRan`, which would also start the middleware sync. There
+       *   is nothing for the middleware to have synced until `watch` sees a block, so that emit
+       *   waits until then
+       */
+      this.hasRun = true;
+    }
+  }
+
+  /**
+   * @hidden
+   *
+   * The second half of {@link broadcast}: wait for inclusion, then produce the same value `run`
+   *   would have. Retryable after a timeout, since nothing is resubmitted — the block scan simply
+   *   starts over from the same point
+   */
+  private async watchBroadcast(
+    matcher: ExtrinsicMatcher,
+    startingBlock: BigNumber,
+    timeout?: number | undefined
+  ): Promise<TransformedReturnValue> {
+    if (this.isSuccess) {
+      // already watched to completion; scanning again would only rediscover the same block
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return this._result!;
+    }
+
+    if (this.watching) {
+      throw new PolymeshError({
+        code: ErrorCode.General,
+        message:
+          'This transaction is already being watched. Await the promise returned by the previous `watch` call instead of starting another',
+      });
+    }
+
+    const watching = (async (): Promise<TransformedReturnValue> => {
+      try {
+        const receipt = await this.watchForInclusion(matcher, startingBlock, timeout);
+
+        const result = await this.resolveResult(receipt);
+
+        this.startMiddlewareSync();
+
+        return result;
+      } catch (err) {
+        this.handleRunError(err);
+      }
+    })();
+
+    this.watching = watching;
+
+    try {
+      return await watching;
+    } finally {
+      this.watching = undefined;
+    }
+  }
+
+  /**
+   * @hidden
+   *
+   * Route to the polling-style submission for whichever signing path this transaction uses. The
+   *   returned function is what actually touches the signer, so that {@link broadcastToChain} can
+   *   bound it
+   */
+  private async buildPollingSubmission(): Promise<() => Promise<PollingSubmission>> {
+    const { signingAddress, context } = this;
+
+    await context.assertHasSigningAddress(signingAddress);
+
+    if (isEthDerivedAddress(signingAddress, context.ss58Format)) {
+      const { ethSigner, request } = await this.buildEthRequest();
+
+      return this.buildEthPollingSubmission(ethSigner, request);
+    }
+
+    const { txWithArgs, signerOptions } = this.buildNativeSignerData();
+
+    return () => Promise.resolve(this.buildNativePollingSubmission(txWithArgs, signerOptions));
+  }
+
+  /**
+   * @hidden
+   *
+   * Turn a finalized receipt into the value the caller gets back, recording it and moving the
+   *   transaction to `Succeeded`. Shared by `run` and by the `watch` returned from
+   *   {@link broadcast}, so that both produce the same value for the same transaction
+   */
+  private async resolveResult(receipt: ISubmittableResult): Promise<TransformedReturnValue> {
+    this.receipt = receipt;
+
+    const {
+      resolver,
+      transformer = (val): Promise<TransformedReturnValue> =>
+        Promise.resolve(val as unknown as TransformedReturnValue),
+    } = this;
+
+    let value: ReturnValue;
+
+    if (isResolverFunction(resolver)) {
+      value = await resolver(receipt);
+    } else {
+      value = resolver;
+    }
+
+    this._result = await transformer(value);
+    this.updateStatus(TransactionStatus.Succeeded);
+
+    return this._result;
   }
 
   /**
@@ -381,6 +553,14 @@ export abstract class PolymeshTransactionBase<
         this.updateStatus(TransactionStatus.Rejected);
         break;
       }
+      case ErrorCode.TransactionTimeout: {
+        /*
+         * the transaction was not cancelled, the SDK merely stopped waiting for it. Moving to
+         *   `Failed` would assert something untrue — it may still be included in a block — so the
+         *   last observed status (`Running`, or `InBlock` if it was already seen) stands
+         */
+        break;
+      }
       case ErrorCode.TransactionReverted:
       case ErrorCode.FatalError:
       default: {
@@ -398,6 +578,18 @@ export abstract class PolymeshTransactionBase<
   private markAsRan(): void {
     this.hasRun = true;
 
+    this.startMiddlewareSync();
+  }
+
+  /**
+   * @hidden
+   *
+   * Kick off the middleware sync notification. Separate from {@link markAsRan} because
+   *   {@link broadcast} marks the transaction as ran without having waited for a block — there is
+   *   nothing for the middleware to have synced yet at that point, so the emit waits until `watch`
+   *   completes
+   */
+  private startMiddlewareSync(): void {
     /*
      * We do not await this promise because it is supposed to run in the background, and
      * any errors encountered are emitted. If the user isn't listening, they shouldn't
@@ -414,13 +606,39 @@ export abstract class PolymeshTransactionBase<
    *   throwing any pertinent errors
    */
   private async internalRun(): Promise<ISubmittableResult> {
-    const { signingAddress, signer, mortality, context } = this;
+    const { signingAddress, context } = this;
 
     await context.assertHasSigningAddress(signingAddress);
 
     if (isEthDerivedAddress(signingAddress, context.ss58Format)) {
       return this.internalRunEth();
     }
+
+    const { txWithArgs, signerOptions } = this.buildNativeSignerData();
+
+    if (context.supportsSubscription()) {
+      return this.runViaSubscription({
+        subscribe: callback => txWithArgs.signAndSend(signingAddress, signerOptions, callback),
+        getTxHash: () => txWithArgs.hash.toString(),
+      });
+    }
+
+    return this.runViaPolling(() =>
+      Promise.resolve(this.buildNativePollingSubmission(txWithArgs, signerOptions))
+    );
+  }
+
+  /**
+   * @hidden
+   *
+   * Compose the transaction and assemble the options the native signer is called with. Also moves
+   *   the transaction into `Unapproved`, since from here on the signer is what everything waits on
+   */
+  private buildNativeSignerData(): {
+    txWithArgs: SubmittableExtrinsic<'promise', ISubmittableResult>;
+    signerOptions: Record<string, unknown>;
+  } {
+    const { signer, mortality, context } = this;
 
     // era is how many blocks the transaction remains valid for, `undefined` for default
     const era = mortality.immortal ? 0 : mortality.lifetime?.toNumber();
@@ -446,15 +664,24 @@ export abstract class PolymeshTransactionBase<
       ...(era !== undefined ? { era } : {}),
     };
 
-    if (context.supportsSubscription()) {
-      return this.runViaSubscription({
-        subscribe: callback => txWithArgs.signAndSend(signingAddress, signerOptions, callback),
-        getTxHash: () => txWithArgs.hash.toString(),
-      });
-    }
+    return { txWithArgs, signerOptions };
+  }
 
-    return this.runViaPolling({
-      send: async () => {
+  /**
+   * @hidden
+   *
+   * The native "send once and correlate by hash" submission. Used when the connection has no
+   *   subscription support, and by {@link broadcast}, which cannot use the callback-driven
+   *   subscription at all since that never yields control back before the transaction resolves
+   */
+  private buildNativePollingSubmission(
+    txWithArgs: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    signerOptions: Record<string, unknown>
+  ): PollingSubmission {
+    const { signingAddress } = this;
+
+    return {
+      send: async (): Promise<{ txHash: string; matcher: ExtrinsicMatcher }> => {
         /*
          * the resolved hash is used instead of `txWithArgs.hash` because a signer may return a modified
          *   `signedTransaction` (e.g. Ledger devices signing via the generic app), in which case the
@@ -467,7 +694,7 @@ export abstract class PolymeshTransactionBase<
           matcher: extrinsicHashMatcher(submittedTxHash),
         };
       },
-    });
+    };
   }
 
   /**
@@ -501,6 +728,34 @@ export abstract class PolymeshTransactionBase<
    *   `revive.ethTransact` extrinsic
    */
   private async internalRunEth(): Promise<ISubmittableResult> {
+    const { context } = this;
+
+    const { ethSigner, request } = await this.buildEthRequest();
+
+    if (getEthSubmissionMode(ethSigner) === 'sdkBroadcast' && context.supportsSubscription()) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const rawSignedTx = await ethSigner.signTransaction!(request);
+
+      const { subscription } = buildSdkBroadcastSubmission(context, rawSignedTx);
+
+      return this.runViaSubscription(subscription);
+    }
+
+    return this.runViaPolling(this.buildEthPollingSubmission(ethSigner, request));
+  }
+
+  /**
+   * @hidden
+   *
+   * The eager half of the Ethereum path: validate, compose the call and perform the mandatory dry
+   *   run pre-flight. Deliberately kept out of the broadcast phase — it is chain RPC work, not a
+   *   signer interaction, so a failure here is a real error rather than something a timeout should
+   *   describe as "state unknown"
+   */
+  private async buildEthRequest(): Promise<{
+    ethSigner: EthSigner;
+    request: EthTransactionRequest;
+  }> {
     const { context, signingAddress } = this;
 
     this.assertMortalitySupportedForEth();
@@ -530,19 +785,29 @@ export abstract class PolymeshTransactionBase<
       ...(nonceOverride ? { nonce: nonceOverride } : {}),
     });
 
-    const mode = getEthSubmissionMode(ethSigner);
+    return { ethSigner, request };
+  }
 
-    if (mode === 'sdkBroadcast') {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const rawSignedTx = await ethSigner.signTransaction!(request);
+  /**
+   * @hidden
+   *
+   * The deferred half of the Ethereum path. Everything that touches the signer lives in here, so
+   *   that the broadcast timeout covers the wallet confirmation prompt in both modes: the raw
+   *   signing in `sdkBroadcast`, and the sign-and-send in `walletBroadcast`
+   */
+  private buildEthPollingSubmission(
+    ethSigner: EthSigner,
+    request: EthTransactionRequest
+  ): () => Promise<PollingSubmission> {
+    const { context } = this;
 
-      const { subscription, polling } = buildSdkBroadcastSubmission(context, rawSignedTx);
+    if (getEthSubmissionMode(ethSigner) === 'sdkBroadcast') {
+      return async () => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const rawSignedTx = await ethSigner.signTransaction!(request);
 
-      if (context.supportsSubscription()) {
-        return this.runViaSubscription(subscription);
-      }
-
-      return this.runViaPolling(polling);
+        return buildSdkBroadcastSubmission(context, rawSignedTx).polling;
+      };
     }
 
     /*
@@ -552,15 +817,16 @@ export abstract class PolymeshTransactionBase<
      */
     const walletBroadcastSubmission = buildWalletBroadcastSubmission(ethSigner, request);
 
-    return this.runViaPolling({
-      send: async () => {
-        const result = await walletBroadcastSubmission.send();
-        // set as soon as the hash is known, even if the transaction later reverts or is not found
-        this.ethTxHash = result.txHash;
+    return () =>
+      Promise.resolve({
+        send: async (): Promise<{ txHash: string; matcher: ExtrinsicMatcher }> => {
+          const result = await walletBroadcastSubmission.send();
+          // set as soon as the hash is known, even if the transaction later reverts or is not found
+          this.ethTxHash = result.txHash;
 
-        return result;
-      },
-    });
+          return result;
+        },
+      });
   }
 
   /**
@@ -664,18 +930,84 @@ export abstract class PolymeshTransactionBase<
    *   subscriptions, or because the transaction was broadcast by an Ethereum wallet rather than
    *   by the SDK
    */
-  private async runViaPolling(submission: PollingSubmission): Promise<ISubmittableResult> {
-    const { context } = this;
+  private async runViaPolling(
+    getSubmission: () => Promise<PollingSubmission>
+  ): Promise<ISubmittableResult> {
+    const startingBlock = await this.context.getLatestBlock();
 
-    const startingBlock = await context.getLatestBlock();
+    const { matcher } = await this.broadcastToChain(getSubmission);
 
-    const { txHash, matcher } = await submission.send().catch((err: Error) => {
-      const error = handleTransactionSubmissionError(err);
+    return this.watchForInclusion(matcher, startingBlock);
+  }
 
-      throw new PolymeshError(error);
+  /**
+   * @hidden
+   *
+   * Hand the transaction to its signer and get it broadcast, yielding the hash it can be looked up
+   *   by and the predicate that recognizes it in a block. This is the phase a wallet confirmation
+   *   prompt happens in, so it is what `submission.broadcastTimeout` bounds
+   *
+   * @throws `TransactionTimeout` if the signer does not broadcast in time. Note this says nothing
+   *   about whether the transaction was broadcast — only that the SDK gave up waiting to hear
+   */
+  private async broadcastToChain(
+    getSubmission: () => Promise<PollingSubmission>
+  ): Promise<{ txHash: string; matcher: ExtrinsicMatcher }> {
+    const {
+      submissionOpts: { broadcastTimeout },
+    } = this;
+
+    const sending = (async (): Promise<{ txHash: string; matcher: ExtrinsicMatcher }> => {
+      const submission = await getSubmission();
+
+      return submission.send();
+    })();
+
+    const result = await withTimeout(
+      sending,
+      broadcastTimeout,
+      () =>
+        new PolymeshError({
+          code: ErrorCode.TransactionTimeout,
+          message:
+            'The signer did not broadcast the transaction within the allotted time. It was not cancelled — whether it ends up being broadcast is unknown, so check before submitting again, or the same transaction may be submitted twice',
+          data: { broadcastTimeout },
+        })
+    ).catch((err: Error) => {
+      /*
+       * a timeout is already a well formed error describing exactly what happened. Only genuine
+       *   submission failures need translating (e.g. a signer cancellation)
+       */
+      if (err instanceof PolymeshError && err.code === ErrorCode.TransactionTimeout) {
+        throw err;
+      }
+
+      throw handleTransactionSubmissionError(err);
     });
 
-    this.setIsRunningStatus(txHash);
+    this.setIsRunningStatus(result.txHash);
+
+    return result;
+  }
+
+  /**
+   * @hidden
+   *
+   * Locate the broadcast transaction by scanning blocks, updating this transaction's block data as
+   *   it goes. Bounded by `submission.watchTimeout`, or by the `timeout` passed to the `watch`
+   *   returned from {@link broadcast}, which takes precedence
+   *
+   * @throws `TransactionTimeout` if the transaction is not found in time. The transaction is
+   *   unaffected by this and may still be included in a block afterwards
+   */
+  private async watchForInclusion(
+    matcher: ExtrinsicMatcher,
+    startingBlock: BigNumber,
+    timeout?: number | undefined
+  ): Promise<ISubmittableResult> {
+    const { context, submissionOpts } = this;
+
+    const watchTimeout = timeout ?? submissionOpts.watchTimeout;
 
     /*
      * report inclusion as soon as the transaction lands in a block, rather than leaving the caller
@@ -696,9 +1028,26 @@ export abstract class PolymeshTransactionBase<
      *   cycle per in-flight transaction. Polling remains the fallback for HTTP connections, which
      *   is what it was always intended for
      */
-    const finalizedReceipt = context.supportsSubscription()
-      ? await subscribeForTransactionFinalization(matcher, startingBlock, context, onInBlock)
-      : await pollForTransactionFinalization(matcher, startingBlock, context, undefined, onInBlock);
+    const scanning = context.supportsSubscription()
+      ? subscribeForTransactionFinalization(matcher, startingBlock, context, onInBlock)
+      : pollForTransactionFinalization(matcher, startingBlock, context, undefined, onInBlock);
+
+    const finalizedReceipt = await withTimeout(
+      scanning,
+      watchTimeout,
+      () =>
+        new PolymeshError({
+          code: ErrorCode.TransactionTimeout,
+          message:
+            'The transaction was broadcast but was not found in a finalized block within the allotted time. It has not been cancelled and may still be included — it can be tracked by hash with `network.watchTransaction`',
+          data: {
+            txHash: this.txHash,
+            ethTxHash: this.ethTxHash,
+            startingBlock,
+            watchTimeout,
+          },
+        })
+    );
 
     this.blockHash = hashToString(finalizedReceipt.status.asFinalized);
     this.blockNumber = u32ToBigNumber(finalizedReceipt.blockNumber!);

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -2,12 +2,12 @@
 import { EventEmitter } from 'events';
 
 import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { SignerOptions } from '@polkadot/api-base/types';
 import { ISubmittableResult, Signer as PolkadotSigner } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
 import {
-  handleExtrinsicFailure,
+  extrinsicHashMatcher,
+  getExtrinsicFailure,
   handleTransactionSubmissionError,
   pollForTransactionFinalization,
 } from '~/base/utils';
@@ -31,6 +31,8 @@ import {
   BaseTransactionSpec,
   isResolverFunction,
   MaybeResolverFunction,
+  PollingSubmission,
+  SubscriptionSubmission,
   TransactionConstructionData,
 } from '~/types/internal';
 import { Ensured } from '~/types/utils';
@@ -40,6 +42,7 @@ import {
   dateToMoment,
   hashToString,
   stringToAccountId,
+  transactionHexToTxTag,
   u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -415,155 +418,167 @@ export abstract class PolymeshTransactionBase<
     };
 
     if (context.supportsSubscription()) {
-      return new Promise((resolve, reject) => {
-        let settingBlockData = Promise.resolve();
-        const gettingUnsub = txWithArgs.signAndSend(signingAddress, signerOptions, receipt => {
-          const { status } = receipt;
-          let isLastCallback = false;
-          let unsubscribing = Promise.resolve();
-          let extrinsicFailedEvent;
-
-          if (status.isFuture) {
-            this.updateStatus(TransactionStatus.Future);
-          } else if (receipt.isCompleted) {
-            // isCompleted implies status is one of: isFinalized, isInBlock or isError
-            if (receipt.isInBlock) {
-              const inBlockHash = status.asInBlock;
-              /*
-               * this must be done to ensure that the block hash and number are set before the success event
-               *   is emitted, and at the same time. We do not resolve or reject the containing promise until this
-               *   one resolves
-               */
-              settingBlockData = defusePromise(
-                this.context.polymeshApi.rpc.chain.getBlock(inBlockHash).then(({ block }) => {
-                  this.blockHash = hashToString(inBlockHash);
-                  this.blockNumber = u32ToBigNumber(block.header.number.unwrap());
-
-                  // we know that the index has to be set by the time the transaction is included in a block
-                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  this.txIndex = new BigNumber(receipt.txIndex!);
-                  this.updateStatus(TransactionStatus.InBlock);
-                })
-              );
-
-              // if the extrinsic failed due to an on-chain error, we should handle it in a special way
-              [extrinsicFailedEvent] = filterEventRecords(
-                receipt,
-                'system',
-                'ExtrinsicFailed',
-                true
-              );
-              // extrinsic failed so we can unsubscribe
-              isLastCallback = !!extrinsicFailedEvent;
-            } else {
-              // isFinalized || isError so we know we can unsubscribe
-              isLastCallback = true;
-            }
-
-            if (isLastCallback) {
-              unsubscribing = gettingUnsub.then((unsub: UnsubCallback) => {
-                unsub();
-              });
-            }
-
-            /*
-             * Promise chain that handles all sub-promises in this pass through the signAndSend callback.
-             * Primarily for consistent error handling
-             */
-            let finishing = Promise.resolve();
-
-            if (extrinsicFailedEvent) {
-              const { data } = extrinsicFailedEvent;
-
-              finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
-                const error = handleExtrinsicFailure(data[0]);
-                reject(error);
-              });
-            } else if (receipt.isFinalized) {
-              finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
-                this.handleExtrinsicSuccess(resolve, reject, receipt);
-              });
-            } else if (receipt.isError) {
-              reject(new PolymeshError({ code: ErrorCode.TransactionAborted }));
-            }
-
-            finishing.catch((err: Error) => reject(err));
-          }
-        });
-
-        gettingUnsub
-          .then(() => {
-            // tx approved by signer
-            this.setIsRunningStatus(txWithArgs.hash.toString());
-          })
-          .catch((err: Error) => {
-            const error = handleTransactionSubmissionError(err);
-            reject(new PolymeshError(error));
-          });
+      return this.runViaSubscription({
+        subscribe: callback => txWithArgs.signAndSend(signingAddress, signerOptions, callback),
+        getTxHash: () => txWithArgs.hash.toString(),
       });
-    } else {
-      return this.runViaPolling(txWithArgs, signerOptions);
     }
+
+    return this.runViaPolling({
+      send: async () => {
+        /*
+         * the resolved hash is used instead of `txWithArgs.hash` because a signer may return a modified
+         *   `signedTransaction` (e.g. Ledger devices signing via the generic app), in which case the
+         *   submitted extrinsic's hash can differ from the locally composed one
+         */
+        const submittedTxHash = await txWithArgs.signAndSend(signingAddress, signerOptions);
+
+        return {
+          txHash: submittedTxHash.toString(),
+          matcher: extrinsicHashMatcher(submittedTxHash),
+        };
+      },
+    });
   }
 
   /**
    * @hidden
    *
-   * Sign and submit the transaction, then poll for its finalization. Used when the
+   * Submit the transaction and track it through a subscription, updating the transaction's
+   *   status and block data as the node reports progress. All lifecycle bookkeeping lives here,
+   *   so the only thing a submission strategy has to provide is *how* the transaction reaches
+   *   the chain
+   */
+  private runViaSubscription(submission: SubscriptionSubmission): Promise<ISubmittableResult> {
+    const { subscribe, getTxHash } = submission;
+
+    return new Promise((resolve, reject) => {
+      let settingBlockData = Promise.resolve();
+      const gettingUnsub = subscribe(receipt => {
+        const { status } = receipt;
+        let isLastCallback = false;
+        let unsubscribing = Promise.resolve();
+        let failureError: PolymeshError | undefined;
+
+        if (status.isFuture) {
+          this.updateStatus(TransactionStatus.Future);
+        } else if (receipt.isCompleted) {
+          // isCompleted implies status is one of: isFinalized, isInBlock or isError
+          if (receipt.isInBlock) {
+            const inBlockHash = status.asInBlock;
+            /*
+             * this must be done to ensure that the block hash and number are set before the success event
+             *   is emitted, and at the same time. We do not resolve or reject the containing promise until this
+             *   one resolves
+             */
+            settingBlockData = defusePromise(
+              this.context.polymeshApi.rpc.chain.getBlock(inBlockHash).then(({ block }) => {
+                this.blockHash = hashToString(inBlockHash);
+                this.blockNumber = u32ToBigNumber(block.header.number.unwrap());
+
+                // we know that the index has to be set by the time the transaction is included in a block
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.txIndex = new BigNumber(receipt.txIndex!);
+                this.updateStatus(TransactionStatus.InBlock);
+              })
+            );
+
+            // if the extrinsic failed due to an on-chain error, we should handle it in a special way
+            failureError = this.getReceiptFailure(receipt);
+            // extrinsic failed so we can unsubscribe
+            isLastCallback = !!failureError;
+          } else {
+            // isFinalized || isError so we know we can unsubscribe
+            isLastCallback = true;
+          }
+
+          if (isLastCallback) {
+            unsubscribing = gettingUnsub.then((unsub: UnsubCallback) => {
+              unsub();
+            });
+          }
+
+          /*
+           * Promise chain that handles all sub-promises in this pass through the signAndSend callback.
+           * Primarily for consistent error handling
+           */
+          let finishing = Promise.resolve();
+
+          if (failureError) {
+            const error = failureError;
+
+            finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
+              reject(error);
+            });
+          } else if (receipt.isFinalized) {
+            finishing = Promise.all([settingBlockData, unsubscribing]).then(() => {
+              this.handleExtrinsicSuccess(resolve, reject, receipt);
+            });
+          } else if (receipt.isError) {
+            reject(new PolymeshError({ code: ErrorCode.TransactionAborted }));
+          }
+
+          finishing.catch((err: Error) => reject(err));
+        }
+      });
+
+      gettingUnsub
+        .then(() => {
+          // tx approved by signer
+          this.setIsRunningStatus(getTxHash());
+        })
+        .catch((err: Error) => {
+          const error = handleTransactionSubmissionError(err);
+          reject(new PolymeshError(error));
+        });
+    });
+  }
+
+  /**
+   * @hidden
+   *
+   * Submit the transaction, then poll for its finalization. Used when the
    *   node connection does not support subscriptions
    */
-  private async runViaPolling(
-    txWithArgs: SubmittableExtrinsic<'promise', ISubmittableResult>,
-    signerOptions: Partial<SignerOptions>
-  ): Promise<ISubmittableResult> {
-    const { signingAddress, context } = this;
+  private async runViaPolling(submission: PollingSubmission): Promise<ISubmittableResult> {
+    const { context } = this;
 
     const startingBlock = await context.getLatestBlock();
 
-    /*
-     * the resolved hash is used instead of `txWithArgs.hash` because a signer may return a modified
-     *   `signedTransaction` (e.g. Ledger devices signing via the generic app), in which case the
-     *   submitted extrinsic's hash can differ from the locally composed one
-     */
-    const submittedTxHash = await txWithArgs
-      .signAndSend(signingAddress, signerOptions)
-      .then(txHash => {
-        this.setIsRunningStatus(txHash.toString());
+    const { txHash, matcher } = await submission.send().catch((err: Error) => {
+      const error = handleTransactionSubmissionError(err);
 
-        return txHash;
-      })
-      .catch((err: Error) => {
-        const error = handleTransactionSubmissionError(err);
+      throw new PolymeshError(error);
+    });
 
-        throw new PolymeshError(error);
-      });
+    this.setIsRunningStatus(txHash);
 
-    const finalizedReceipt = await pollForTransactionFinalization(
-      submittedTxHash,
-      startingBlock,
-      context
-    );
+    const finalizedReceipt = await pollForTransactionFinalization(matcher, startingBlock, context);
 
     this.blockHash = hashToString(finalizedReceipt.status.asFinalized);
     this.blockNumber = u32ToBigNumber(finalizedReceipt.blockNumber!);
     this.txIndex = new BigNumber(finalizedReceipt.txIndex!);
 
     // if the extrinsic failed due to an on-chain error, we should handle it in a special way
-    const [extrinsicFailedEvent] = filterEventRecords(
-      finalizedReceipt,
-      'system',
-      'ExtrinsicFailed',
-      true
-    );
+    const failureError = this.getReceiptFailure(finalizedReceipt);
 
-    if (extrinsicFailedEvent) {
-      const { data } = extrinsicFailedEvent;
-      const error = handleExtrinsicFailure(data[0]);
-
-      throw error;
+    if (failureError) {
+      throw failureError;
     }
 
     return finalizedReceipt;
+  }
+
+  /**
+   * @hidden
+   *
+   * Inspect a receipt for an on-chain failure, returning the corresponding error if the
+   *   transaction did not succeed. Checks both `system.ExtrinsicFailed` (the native path) and
+   *   `revive.EthExtrinsicRevert` (the Ethereum signing path, where the outer extrinsic reports
+   *   success even when the inner dispatch failed)
+   */
+  protected getReceiptFailure(receipt: ISubmittableResult): PolymeshError | undefined {
+    return getExtrinsicFailure(receipt);
   }
 
   /**
@@ -906,6 +921,7 @@ export abstract class PolymeshTransactionBase<
       context,
       context: { polymeshApi },
     } = this;
+
     const tx = this.composeTxForFees(asProposal);
 
     const [tipHash, latestBlockNumber] = await Promise.all([
@@ -978,7 +994,7 @@ export abstract class PolymeshTransactionBase<
    *   this method is called and the time the transaction is run
    */
   private async getPayingAccount(asProposal: boolean): Promise<PayingAccount> {
-    const { paidForBy, multiSig, context } = this;
+    const { paidForBy, multiSig, context, signingAddress } = this;
 
     if (paidForBy) {
       const { account: primaryAccount } = await paidForBy.getPrimaryAccount();
@@ -1056,6 +1072,7 @@ export abstract class PolymeshTransactionBase<
       },
       multiSig: actingMultiSig,
       multiSigOpts,
+      signingAddress,
     } = this;
 
     if (actingMultiSig) {

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -12,7 +12,8 @@ import {
   buildEthTransactionRequest,
   calculateEthGasFee,
   dryRunEthTransaction,
-  getEthSubmissionMode,
+  EthSubmissionStrategy,
+  getEthSubmissionStrategy,
   getNativeToEthRatio,
 } from '~/base/ethTransaction';
 import { EthSigner, EthTransactionPayload, EthTransactionRequest } from '~/base/types';
@@ -498,7 +499,7 @@ export abstract class PolymeshTransactionBase<
     if (isEthDerivedAddress(signingAddress, context.ss58Format)) {
       const { ethSigner, request } = await this.buildEthRequest();
 
-      return this.buildEthPollingSubmission(ethSigner, request);
+      return this.buildEthPollingSubmission(getEthSubmissionStrategy(ethSigner), request);
     }
 
     const { txWithArgs, signerOptions } = this.buildNativeSignerData();
@@ -732,16 +733,17 @@ export abstract class PolymeshTransactionBase<
 
     const { ethSigner, request } = await this.buildEthRequest();
 
-    if (getEthSubmissionMode(ethSigner) === 'sdkBroadcast' && context.supportsSubscription()) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const rawSignedTx = await ethSigner.signTransaction!(request);
+    const strategy = getEthSubmissionStrategy(ethSigner);
+
+    if (strategy.mode === 'sdkBroadcast' && context.supportsSubscription()) {
+      const rawSignedTx = await strategy.signTransaction(request);
 
       const { subscription } = buildSdkBroadcastSubmission(context, rawSignedTx);
 
       return this.runViaSubscription(subscription);
     }
 
-    return this.runViaPolling(this.buildEthPollingSubmission(ethSigner, request));
+    return this.runViaPolling(this.buildEthPollingSubmission(strategy, request));
   }
 
   /**
@@ -796,15 +798,16 @@ export abstract class PolymeshTransactionBase<
    *   signing in `sdkBroadcast`, and the sign-and-send in `walletBroadcast`
    */
   private buildEthPollingSubmission(
-    ethSigner: EthSigner,
+    strategy: EthSubmissionStrategy,
     request: EthTransactionRequest
   ): () => Promise<PollingSubmission> {
     const { context } = this;
 
-    if (getEthSubmissionMode(ethSigner) === 'sdkBroadcast') {
+    if (strategy.mode === 'sdkBroadcast') {
+      const { signTransaction } = strategy;
+
       return async () => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const rawSignedTx = await ethSigner.signTransaction!(request);
+        const rawSignedTx = await signTransaction(request);
 
         return buildSdkBroadcastSubmission(context, rawSignedTx).polling;
       };
@@ -815,7 +818,10 @@ export abstract class PolymeshTransactionBase<
      *   nothing, so there is no extrinsic-status subscription to attach to and the result has to
      *   be located by scanning blocks for the matching `revive.ethTransact` extrinsic
      */
-    const walletBroadcastSubmission = buildWalletBroadcastSubmission(ethSigner, request);
+    const walletBroadcastSubmission = buildWalletBroadcastSubmission(
+      strategy.sendTransaction,
+      request
+    );
 
     return () =>
       Promise.resolve({
@@ -1493,13 +1499,22 @@ export abstract class PolymeshTransactionBase<
    *   {@link api/client/Network!Network.submitEthTransaction | sdk.network.submitEthTransaction}
    *
    * @param metadata - Additional information attached to the payload, such as IDs or memos about the transaction
+   * @param opts.eip1559 - whether to build an EIP-1559 (type 2) transaction. Defaults to `true`;
+   *   pass `false` for a custody service or hardware signer that can only encode legacy (type 0)
+   *   transactions
+   *
+   * @note no Signing Manager is required. The whole point of this method is detached signing, so
+   *   it must work on an SDK instance connected without one — the payload is built entirely from
+   *   chain state and the signing address
    *
    * @throws `ValidationError` if the signing Account is not Ethereum-derived
    */
   public async toEthSignablePayload(
-    metadata: Record<string, string> = {}
+    metadata: Record<string, string> = {},
+    opts: { eip1559?: boolean } = {}
   ): Promise<EthTransactionPayload> {
     const { signingAddress, context } = this;
+    const { eip1559 = true } = opts;
 
     if (!isEthDerivedAddress(signingAddress, context.ss58Format)) {
       throw new PolymeshError({
@@ -1507,16 +1522,6 @@ export abstract class PolymeshTransactionBase<
         message:
           '`toEthSignablePayload` can only be used for a transaction signed by an Ethereum-derived Account. Use `toSignablePayload` instead',
         data: { signingAddress },
-      });
-    }
-
-    const ethSigner = context.getEthSigner();
-
-    if (!ethSigner) {
-      throw new PolymeshError({
-        code: ErrorCode.General,
-        message:
-          'There is no Ethereum signer associated with the SDK instance. Please report this to the Polymesh team',
       });
     }
 
@@ -1529,7 +1534,7 @@ export abstract class PolymeshTransactionBase<
       context,
       signingAddress,
       composedTx,
-      ethSigner.capabilities.eip1559,
+      eip1559,
       nonceOverride
     );
 

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -1569,15 +1569,15 @@ export abstract class PolymeshTransactionBase<
 
     const isEthSigner = isEthDerivedAddress(signingAddress, context.ss58Format);
 
-    if (paidForBy) {
-      if (isEthSigner) {
-        throw new PolymeshError({
-          code: ErrorCode.NotSupported,
-          message:
-            'A third-party paying Account (`paidForBy`) is not supported for a transaction signed by an Ethereum key. The Ethereum-derived Account is both the origin and the fee payer on this transport',
-        });
-      }
-
+    /*
+     * An Ethereum-derived Account always pays its own fees. `revive.ethTransact` is a bare
+     *   extrinsic, so neither `paidForBy` nor a subsidy reaches the chain's fee pipeline — gas is
+     *   charged to the signing Account.
+     *
+     * TODO: revisit both branches below if the chain ever routes third-party payment through this
+     *   transport
+     */
+    if (paidForBy && !isEthSigner) {
       const { account: primaryAccount } = await paidForBy.getPrimaryAccount();
 
       return {
@@ -1586,8 +1586,6 @@ export abstract class PolymeshTransactionBase<
       };
     }
 
-    // subsidies are ignored on the Ethereum path: whether they apply is not established, and
-    //   ignoring one that does apply merely over-reports the fee
     const subsidyWithAllowance = isEthSigner ? null : await context.accountSubsidy();
 
     if (subsidyWithAllowance && !this.ignoresSubsidy()) {

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -6,6 +6,17 @@ import { ISubmittableResult, Signer as PolkadotSigner } from '@polkadot/types/ty
 import BigNumber from 'bignumber.js';
 
 import {
+  buildDetachedEthTransactionRequest,
+  buildSdkBroadcastSubmission,
+  buildWalletBroadcastSubmission,
+  buildEthTransactionRequest,
+  calculateEthGasFee,
+  dryRunEthTransaction,
+  getEthSubmissionMode,
+  getNativeToEthRatio,
+} from '~/base/ethTransaction';
+import { EthTransactionPayload } from '~/base/types';
+import {
   extrinsicHashMatcher,
   getExtrinsicFailure,
   handleTransactionSubmissionError,
@@ -48,6 +59,7 @@ import {
   u32ToBigNumber,
   u64ToBigNumber,
 } from '~/utils/conversion';
+import { isEthDerivedAddress } from '~/utils/eth';
 import { defusePromise, delay, filterEventRecords, optionize } from '~/utils/internal';
 
 /**
@@ -99,8 +111,19 @@ export abstract class PolymeshTransactionBase<
 
   /**
    * transaction hash (status: `Running`, `Succeeded`, `Failed`)
+   *
+   * @note when this transaction was signed by an Ethereum key and the wallet broadcast it
+   *   itself, this is the Ethereum transaction hash, since that is the handle the user
+   *   has and can look up in a block explorer
    */
   public txHash?: string | undefined;
+
+  /**
+   * the Ethereum transaction hash, set only when this transaction was signed by an Ethereum key
+   *   and the wallet broadcast it itself. `undefined` for the native path, and when the SDK
+   *   submits the Ethereum transaction itself
+   */
+  public ethTxHash?: string | undefined;
 
   /**
    * transaction index within its block (status: `Succeeded`, `Failed`)
@@ -395,6 +418,10 @@ export abstract class PolymeshTransactionBase<
 
     await context.assertHasSigningAddress(signingAddress);
 
+    if (isEthDerivedAddress(signingAddress, context.ss58Format)) {
+      return this.internalRunEth();
+    }
+
     // era is how many blocks the transaction remains valid for, `undefined` for default
     const era = mortality.immortal ? 0 : mortality.lifetime?.toNumber();
     const nonce = context.getNonce().toNumber();
@@ -439,6 +466,99 @@ export abstract class PolymeshTransactionBase<
           txHash: submittedTxHash.toString(),
           matcher: extrinsicHashMatcher(submittedTxHash),
         };
+      },
+    });
+  }
+
+  /**
+   * @hidden
+   *
+   * @throws `ValidationError` if the caller explicitly requested a mortality setting.
+   *   Ethereum transactions have no era; replay protection comes from the nonce and chain id, so
+   *   `ProcedureOpts.mortality` is meaningless on this path and silently ignoring a request for
+   *   immortality that the transport cannot honour would be worse than a clear error
+   */
+  private assertMortalitySupportedForEth(): void {
+    const { mortality } = this;
+
+    const wasExplicitlySet = mortality.immortal || mortality.lifetime !== undefined;
+
+    if (wasExplicitlySet) {
+      throw new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message:
+          'Mortality cannot be set for a transaction signed by an Ethereum key. Ethereum transactions have no era; replay protection comes from the nonce and chain id, so they are effectively immortal until the nonce is consumed',
+      });
+    }
+  }
+
+  /**
+   * @hidden
+   *
+   * Ethereum submission strategy: build the request (performing the mandatory dry run
+   *   pre-flight), then either broadcast a raw signed transaction from the SDK, or let the
+   *   wallet broadcast and correlate the result by scanning blocks for a matching
+   *   `revive.ethTransact` extrinsic
+   */
+  private async internalRunEth(): Promise<ISubmittableResult> {
+    const { context, signingAddress } = this;
+
+    this.assertMortalitySupportedForEth();
+
+    const ethSigner = context.getEthSigner();
+
+    if (!ethSigner) {
+      throw new PolymeshError({
+        code: ErrorCode.General,
+        message:
+          'There is no Ethereum signer associated with the SDK instance. Please report this to the Polymesh team',
+      });
+    }
+
+    this.updateStatus(TransactionStatus.Unapproved);
+
+    const composedTx = this.composeTx();
+
+    const nonceValue = context.getNonce();
+    const nonceOverride = nonceValue.isNegative() ? undefined : nonceValue;
+
+    const { request } = await buildEthTransactionRequest({
+      context,
+      signingAddress,
+      composedTx,
+      ethSigner,
+      ...(nonceOverride ? { nonce: nonceOverride } : {}),
+    });
+
+    const mode = getEthSubmissionMode(ethSigner);
+
+    if (mode === 'sdkBroadcast') {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const rawSignedTx = await ethSigner.signTransaction!(request);
+
+      const { subscription, polling } = buildSdkBroadcastSubmission(context, rawSignedTx);
+
+      if (context.supportsSubscription()) {
+        return this.runViaSubscription(subscription);
+      }
+
+      return this.runViaPolling(polling);
+    }
+
+    /*
+     * The wallet broadcasts and returns the Ethereum transaction hash. The SDK submitted
+     *   nothing, so there is no extrinsic-status subscription to attach to and the result has to
+     *   be located by scanning blocks for the matching `revive.ethTransact` extrinsic
+     */
+    const walletBroadcastSubmission = buildWalletBroadcastSubmission(ethSigner, request);
+
+    return this.runViaPolling({
+      send: async () => {
+        const result = await walletBroadcastSubmission.send();
+        // set as soon as the hash is known, even if the transaction later reverts or is not found
+        this.ethTxHash = result.txHash;
+
+        return result;
       },
     });
   }
@@ -539,8 +659,10 @@ export abstract class PolymeshTransactionBase<
   /**
    * @hidden
    *
-   * Submit the transaction, then poll for its finalization. Used when the
-   *   node connection does not support subscriptions
+   * Submit the transaction, then locate it by scanning the chain's blocks. Used when there is no
+   *   extrinsic status subscription to attach to — either because the connection does not support
+   *   subscriptions, or because the transaction was broadcast by an Ethereum wallet rather than
+   *   by the SDK
    */
   private async runViaPolling(submission: PollingSubmission): Promise<ISubmittableResult> {
     const { context } = this;
@@ -557,7 +679,9 @@ export abstract class PolymeshTransactionBase<
 
     /*
      * report inclusion as soon as the transaction lands in a block, rather than leaving the caller
-     *   with no feedback for the whole finalization window
+     *   with no feedback for the whole finalization window. This matters most for an Ethereum
+     *   transaction the wallet broadcast, where block scanning is the only signal
+     *   available
      */
     const onInBlock = ({ blockHash, blockNumber, txIndex }: TransactionInclusionInfo): void => {
       this.blockHash = blockHash;
@@ -629,23 +753,33 @@ export abstract class PolymeshTransactionBase<
    *
    * @note these values might be inaccurate if the transaction is run at a later time. This can be due to a governance vote or other
    *   chain related factors (like modifications to a specific subsidizer relationship or a chain upgrade)
+   * @note for a transaction signed by an Ethereum key, the `gas` component is derived from
+   *   `ethGas * gasPrice / nativeToEthRatio` (a dry run over the `revive` pallet) rather than
+   *   `payment_queryInfo`, and so may differ slightly from the equivalent native call
    */
   public async getTotalFees(asProposal = true): Promise<PayingAccountFees> {
-    const { signingAddress } = this;
+    const { signingAddress, context } = this;
 
     const composedTx = this.composeTxForFees(asProposal);
 
-    const paymentInfoPromise = composedTx.paymentInfo(signingAddress);
+    const isEthSigner = isEthDerivedAddress(signingAddress, context.ss58Format);
+
+    const gasPromise: Promise<BigNumber> = isEthSigner
+      ? dryRunEthTransaction(context, signingAddress, composedTx).then(({ rawEthGas, gasPrice }) =>
+          calculateEthGasFee(rawEthGas, gasPrice, getNativeToEthRatio(context))
+        )
+      : composedTx
+          .paymentInfo(signingAddress)
+          .then(({ partialFee }) => balanceToBigNumber(partialFee));
 
     const protocol = await this.getProtocolFees();
 
     const payingAccount = await this.getPayingAccount(asProposal);
 
-    const [{ partialFee }, { free: balance }] = await Promise.all([
-      paymentInfoPromise,
+    const [gas, { free: balance }] = await Promise.all([
+      gasPromise,
       payingAccount.account.getBalance(),
     ]);
-    const gas = balanceToBigNumber(partialFee);
 
     return {
       fees: {
@@ -943,6 +1077,15 @@ export abstract class PolymeshTransactionBase<
       context: { polymeshApi },
     } = this;
 
+    if (isEthDerivedAddress(signingAddress, context.ss58Format)) {
+      throw new PolymeshError({
+        code: ErrorCode.NotSupported,
+        message:
+          'A SCALE `SignerPayload` cannot be produced for a transaction signed by an Ethereum key, since an Ethereum key cannot sign it. Use `toEthSignablePayload` instead',
+        data: { signingAddress },
+      });
+    }
+
     const tx = this.composeTxForFees(asProposal);
 
     const [tipHash, latestBlockNumber] = await Promise.all([
@@ -995,6 +1138,59 @@ export abstract class PolymeshTransactionBase<
   }
 
   /**
+   * Returns a representation intended for offline/detached signing of a transaction signed by an
+   *   Ethereum-derived Account. Unlocks Fireblocks / KMS / HSM / air-gapped custody flows: the
+   *   caller signs the returned `transaction` and submits the raw signed bytes via
+   *   {@link api/client/Network!Network.submitEthTransaction | sdk.network.submitEthTransaction}
+   *
+   * @param metadata - Additional information attached to the payload, such as IDs or memos about the transaction
+   *
+   * @throws `ValidationError` if the signing Account is not Ethereum-derived
+   */
+  public async toEthSignablePayload(
+    metadata: Record<string, string> = {}
+  ): Promise<EthTransactionPayload> {
+    const { signingAddress, context } = this;
+
+    if (!isEthDerivedAddress(signingAddress, context.ss58Format)) {
+      throw new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message:
+          '`toEthSignablePayload` can only be used for a transaction signed by an Ethereum-derived Account. Use `toSignablePayload` instead',
+        data: { signingAddress },
+      });
+    }
+
+    const ethSigner = context.getEthSigner();
+
+    if (!ethSigner) {
+      throw new PolymeshError({
+        code: ErrorCode.General,
+        message:
+          'There is no Ethereum signer associated with the SDK instance. Please report this to the Polymesh team',
+      });
+    }
+
+    const composedTx = this.composeTxForFees(true);
+
+    const nonceValue = context.getNonce();
+    const nonceOverride = nonceValue.isNegative() ? undefined : nonceValue;
+
+    const transaction = await buildDetachedEthTransactionRequest(
+      context,
+      signingAddress,
+      composedTx,
+      ethSigner.capabilities.eip1559,
+      nonceOverride
+    );
+
+    const tag = transactionHexToTxTag(transaction.data, context);
+    const args = context.getTransactionArguments({ tag });
+
+    return { transaction, tag, args, metadata };
+  }
+
+  /**
    * returns true if transaction has completed successfully
    */
   get isSuccess(): boolean {
@@ -1017,7 +1213,17 @@ export abstract class PolymeshTransactionBase<
   private async getPayingAccount(asProposal: boolean): Promise<PayingAccount> {
     const { paidForBy, multiSig, context, signingAddress } = this;
 
+    const isEthSigner = isEthDerivedAddress(signingAddress, context.ss58Format);
+
     if (paidForBy) {
+      if (isEthSigner) {
+        throw new PolymeshError({
+          code: ErrorCode.NotSupported,
+          message:
+            'A third-party paying Account (`paidForBy`) is not supported for a transaction signed by an Ethereum key. The Ethereum-derived Account is both the origin and the fee payer on this transport',
+        });
+      }
+
       const { account: primaryAccount } = await paidForBy.getPrimaryAccount();
 
       return {
@@ -1026,7 +1232,9 @@ export abstract class PolymeshTransactionBase<
       };
     }
 
-    const subsidyWithAllowance = await context.accountSubsidy();
+    // subsidies are ignored on the Ethereum path: whether they apply is not established, and
+    //   ignoring one that does apply merely over-reports the fee
+    const subsidyWithAllowance = isEthSigner ? null : await context.accountSubsidy();
 
     if (subsidyWithAllowance && !this.ignoresSubsidy()) {
       const {
@@ -1097,6 +1305,20 @@ export abstract class PolymeshTransactionBase<
     } = this;
 
     if (actingMultiSig) {
+      /*
+       * MultiSig + Ethereum is a narrow, untested intersection: `getPayingAccount` resolves fees
+       *   to a *native* primary key for a MultiSig proposal, while the gas-derived fee arithmetic
+       *   describes the transaction the Ethereum key itself submits. Out of scope for now,
+       *   rather than shipping an untested combination of two fee models
+       */
+      if (isEthDerivedAddress(signingAddress, context.ss58Format)) {
+        throw new PolymeshError({
+          code: ErrorCode.NotSupported,
+          message:
+            'Using an Ethereum-derived Account as a MultiSig signer is not currently supported',
+        });
+      }
+
       const rawMultiSigId = stringToAccountId(actingMultiSig.address, context);
       const rawExpiry = optionize(dateToMoment)(multiSigOpts.expiry, context);
 

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -1506,6 +1506,10 @@ export abstract class PolymeshTransactionBase<
    * @note no Signing Manager is required. The whole point of this method is detached signing, so
    *   it must work on an SDK instance connected without one — the payload is built entirely from
    *   chain state and the signing address
+   * @note every field of `transaction` is 0x-prefixed hex, never a number or bigint — the only
+   *   encoding that survives being serialized and sent to a remote signer. ethers and viem both
+   *   need it converted first; `@polymeshassociation/eth-signing-manager` exports
+   *   `toEthersTransaction` / `toViemTransaction` for that, usable without the manager itself
    *
    * @throws `ValidationError` if the signing Account is not Ethereum-derived
    */

--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -350,6 +350,8 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
         immortal: false,
       };
 
+      const submission = opts?.submission;
+
       const ctx = await this.setup(procArgs, context, opts);
 
       // parallelize the async calls
@@ -422,6 +424,7 @@ export class Procedure<Args = void, ReturnValue = void, Storage = Record<string,
         signer,
         signingAddress,
         mortality,
+        submission,
         transformer,
         multiSig: this._signerMultiSig ?? null,
       };

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -67,6 +67,12 @@ jest.mock(
   require('~/testUtils/mocks/entities').mockSubsidyModule('~/api/entities/Subsidy')
 );
 
+// ss58 (format 42) address of an Ethereum-derived Account (the last 12 bytes of the decoded
+//   AccountId32 are 0xEE)
+const ethSs58Address = '5FwyDndroq7u9jGc1WHAohCyYPS8xoPmiKYxJQQujkBgpP79';
+// a validly encoded, non Ethereum-derived ss58 (format 42) address
+const nativeSs58Address = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
 describe('Context class', () => {
   let polymeshApi: ApiPromise & jest.Mocked<ApiPromise> & EventEmitter;
 
@@ -247,6 +253,19 @@ describe('Context class', () => {
       context.setSigningAddress('otherAddress');
 
       expect(context.getSigningAddress()).toBe('otherAddress');
+    });
+
+    it('should allow setting an Ethereum-derived address as the signing address', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+        signingManager: dsMockUtils.getSigningManagerInstance({
+          getAccounts: ['someAddress', ethSs58Address],
+        }),
+      });
+
+      expect(() => context.setSigningAddress(ethSs58Address)).not.toThrow();
+      expect(context.getSigningAddress()).toBe(ethSs58Address);
     });
   });
 
@@ -2726,6 +2745,124 @@ describe('Context class', () => {
       expect(signer.signRaw).toHaveBeenCalledTimes(2);
 
       expect(result).toEqual('0xsignature');
+    });
+
+    it('should throw a NotSupported error for an Ethereum-derived signer', async () => {
+      const signer = {
+        signRaw: jest.fn(),
+      } as unknown as PolkadotSigner;
+
+      dsMockUtils.createTxMock('revive', 'ethTransact');
+      dsMockUtils.createCallMock('reviveApi', 'ethTransactWithConfig');
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+        signingManager: dsMockUtils.getSigningManagerInstance({
+          getExternalSigner: signer,
+          getAccounts: [nativeSs58Address, ethSs58Address],
+        }),
+      });
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.NotSupported,
+        message:
+          'Off-chain signatures are not supported for Ethereum-derived Accounts. The chain only accepts sr25519 and ed25519 signatures for this operation',
+        data: { address: ethSs58Address },
+      });
+
+      await expect(
+        context.getSignature({ rawPayload: '0xRawPayload', signer: ethSs58Address })
+      ).rejects.toThrow(expectedError);
+
+      expect(signer.signRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('method: getEthRuntimePalletsAddress', () => {
+    it('should return the sentinel address, caching the runtime call after the first invocation', async () => {
+      const sentinelAddress = '0x6d6f646c70792f70616464720000000000000000';
+
+      const runtimePalletsAddressMock = dsMockUtils.createCallMock(
+        'reviveApi',
+        'runtimePalletsAddress',
+        {
+          returnValue: { toString: () => sentinelAddress },
+        }
+      );
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      const first = await context.getEthRuntimePalletsAddress();
+      const second = await context.getEthRuntimePalletsAddress();
+
+      expect(first).toBe(sentinelAddress);
+      expect(second).toBe(sentinelAddress);
+      expect(runtimePalletsAddressMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('method: getEthChainId', () => {
+    it('should return the chain id from consts.revive.chainId', async () => {
+      dsMockUtils.setConstMock('revive', 'chainId', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(1641818)),
+      });
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      expect(context.getEthChainId()).toEqual(new BigNumber(1641818));
+    });
+  });
+
+  describe('method: getEthSigner', () => {
+    it('should return undefined if there is no Signing Manager attached', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      expect(context.getEthSigner()).toBeUndefined();
+    });
+
+    it('should return undefined if the Signing Manager is not eth capable', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+        signingManager: dsMockUtils.getSigningManagerInstance({
+          getAccounts: [nativeSs58Address],
+        }),
+      });
+
+      expect(context.getEthSigner()).toBeUndefined();
+    });
+
+    it('should return the Ethereum signer if the Signing Manager provides one', async () => {
+      const ethSigner = {
+        capabilities: { signTransaction: true, sendTransaction: false, eip1559: true },
+        signTransaction: jest.fn(),
+      };
+
+      const signingManager = {
+        getAccounts: jest.fn().mockResolvedValue([nativeSs58Address]),
+        getExternalSigner: jest.fn().mockReturnValue('signer' as PolkadotSigner),
+        setSs58Format: jest.fn(),
+        getEthSigner: jest.fn().mockReturnValue(ethSigner),
+      };
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        signingManager: signingManager as any,
+      });
+
+      expect(context.getEthSigner()).toBe(ethSigner);
     });
   });
 });

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -2844,7 +2844,7 @@ describe('Context class', () => {
 
     it('should return the Ethereum signer if the Signing Manager provides one', async () => {
       const ethSigner = {
-        capabilities: { signTransaction: true, sendTransaction: false, eip1559: true },
+        capabilities: { eip1559: true },
         signTransaction: jest.fn(),
       };
 

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -2385,7 +2385,7 @@ describe('Polymesh Transaction Base class', () => {
         expect(tx.status).toBe(TransactionStatus.Succeeded);
       });
 
-      it('should throw a NotSupported error if a third party is set to pay the fees', async () => {
+      it('should attribute fees to the caller even when a third party is set to pay them', async () => {
         const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
         const tx = new PolymeshTransaction(
           {
@@ -2398,9 +2398,9 @@ describe('Polymesh Transaction Base class', () => {
           context
         );
 
-        await expect(tx.getTotalFees()).rejects.toThrow(
-          expect.objectContaining({ code: ErrorCode.NotSupported })
-        );
+        const { payingAccountData } = await tx.getTotalFees();
+
+        expect(payingAccountData.type).toBe(PayingAccountType.Caller);
       });
 
       it('should throw a NotSupported error when acting as a MultiSig signer', async () => {

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -1433,6 +1433,37 @@ describe('Polymesh Transaction Base class', () => {
       expect(listenerMock.mock.calls[2][0]).toBe(TransactionStatus.Succeeded);
     });
 
+    it('should emit an Idle status change without an error', () => {
+      const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+
+      const tx = new PolymeshTransaction(
+        {
+          ...txSpec,
+          transaction,
+          args: tuple('IDLE'),
+          resolver: undefined,
+        },
+        context
+      );
+
+      const listenerMock = jest.fn();
+
+      tx.onStatusChange(listenerMock);
+
+      /*
+       * `Idle` is the status a transaction is constructed with, so nothing drives it through
+       *   `updateStatus` on its own. It is still emitted as a non-error status, which is what
+       *   this asserts
+       */
+      (tx as unknown as { updateStatus: (status: TransactionStatus) => void }).updateStatus(
+        TransactionStatus.Idle
+      );
+
+      expect(tx.status).toBe(TransactionStatus.Idle);
+      // called with the transaction alone — an error argument is reserved for the failure statuses
+      expect(listenerMock).toHaveBeenCalledWith(tx);
+    });
+
     it('should return an unsubscribe function', async () => {
       const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker', {
         autoResolve: false,
@@ -2479,6 +2510,37 @@ describe('Polymesh Transaction Base class', () => {
         // the SDK submitted this itself, so there is no separate Ethereum hash to expose
         expect(tx.ethTxHash).toBeUndefined();
       });
+
+      it('should sign with the nonce set through `ProcedureOpts` rather than the on-chain one', async () => {
+        const ethSigner = buildEthSigner();
+        context.getEthSigner.mockReturnValue(ethSigner);
+        context.getNonce.mockReturnValue(new BigNumber(9));
+
+        const ethTransact = dsMockUtils.createTxMock('revive', 'ethTransact', {
+          autoResolve: false,
+        });
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        const runPromise = tx.run().catch(noop);
+
+        await fakePromises();
+
+        dsMockUtils.updateTxStatus(ethTransact, MockTxStatus.InBlock);
+        await fakePromise();
+        dsMockUtils.updateTxStatus(ethTransact, MockTxStatus.Succeeded);
+        await fakePromise();
+        await runPromise;
+
+        // the caller's nonce is used verbatim, rather than the `0x0` the chain reports
+        expect(ethSigner.signTransaction).toHaveBeenCalledWith(
+          expect.objectContaining({ nonce: '0x9' })
+        );
+      });
     });
 
     describe('when the wallet broadcasts', () => {
@@ -2655,7 +2717,8 @@ describe('Polymesh Transaction Base class', () => {
 
     describe('method: broadcast', () => {
       const buildWalletBroadcastTx = <T>(
-        resolver: T
+        resolver: T,
+        preRunValidation?: jest.Mock
       ): {
         tx: PolymeshTransaction<T, T, [string]>;
         ethSigner: ReturnType<typeof buildEthSigner>;
@@ -2667,7 +2730,7 @@ describe('Polymesh Transaction Base class', () => {
 
         const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
         const tx = new PolymeshTransaction(
-          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver },
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver, preRunValidation },
           context
         );
 
@@ -2771,6 +2834,93 @@ describe('Polymesh Transaction Base class', () => {
 
         await expect(tx.broadcast()).rejects.toThrow('Cannot re-run a Transaction');
         await expect(tx.run()).rejects.toThrow('Cannot re-run a Transaction');
+      });
+
+      it('should run preRunValidation before anything is submitted', async () => {
+        const preRunValidation = jest.fn().mockResolvedValue(undefined);
+        const { tx, ethSigner } = buildWalletBroadcastTx(undefined, preRunValidation);
+
+        jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockReturnValue(new Promise(noop) as never);
+
+        await tx.broadcast();
+
+        expect(preRunValidation).toHaveBeenCalledWith({ asProposal: false });
+        expect(ethSigner.sendTransaction).toHaveBeenCalled();
+      });
+
+      it('should mark the transaction as failed if the broadcast itself fails', async () => {
+        const validationError = new PolymeshError({
+          code: ErrorCode.InsufficientBalance,
+          message: 'Insufficient balance',
+        });
+        const preRunValidation = jest.fn().mockRejectedValue(validationError);
+        const { tx, ethSigner } = buildWalletBroadcastTx(undefined, preRunValidation);
+
+        await expect(tx.broadcast()).rejects.toThrow(validationError);
+
+        expect(tx.status).toBe(TransactionStatus.Failed);
+        expect(ethSigner.sendTransaction).not.toHaveBeenCalled();
+      });
+
+      it('should report inclusion as soon as the transaction lands in a block', async () => {
+        const { tx } = buildWalletBroadcastTx(undefined);
+
+        jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockImplementation((_matcher, _startingBlock, _context, _pollOptions, onInBlock) => {
+            onInBlock?.({
+              blockHash: 'inBlockHash',
+              blockNumber: new BigNumber(100),
+              txIndex: 3,
+            });
+
+            // the finalized result never arrives, leaving the transaction at its InBlock state
+            return new Promise(noop);
+          });
+
+        const handle = await tx.broadcast();
+
+        handle.watch().catch(noop);
+        await fakePromise();
+
+        expect(tx.status).toBe(TransactionStatus.InBlock);
+        expect(tx.blockHash).toBe('inBlockHash');
+        expect(tx.blockNumber).toEqual(new BigNumber(100));
+        expect(tx.txIndex).toEqual(new BigNumber(3));
+      });
+
+      it('should subscribe for the block scan where the connection supports it', async () => {
+        const { tx } = buildWalletBroadcastTx('resolved value');
+        context.supportsSubscription.mockReturnValue(true);
+
+        const subscribeSpy = jest
+          .spyOn(baseUtils, 'subscribeForTransactionFinalization')
+          .mockResolvedValue(fakeReceipt() as never);
+        const pollSpy = jest.spyOn(baseUtils, 'pollForTransactionFinalization');
+
+        const handle = await tx.broadcast();
+
+        await expect(handle.watch()).resolves.toBe('resolved value');
+
+        expect(subscribeSpy).toHaveBeenCalled();
+        expect(pollSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return the result already watched to completion rather than scanning again', async () => {
+        const { tx } = buildWalletBroadcastTx('resolved value');
+
+        const pollSpy = jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockResolvedValue(fakeReceipt() as never);
+
+        const handle = await tx.broadcast();
+
+        await expect(handle.watch()).resolves.toBe('resolved value');
+        await expect(handle.watch()).resolves.toBe('resolved value');
+
+        expect(pollSpy).toHaveBeenCalledTimes(1);
       });
 
       it('should throw a NotSupported error for a MultiSig signer', async () => {
@@ -2939,6 +3089,24 @@ describe('Polymesh Transaction Base class', () => {
         expect(request.type).toBe('0x0');
         expect(request.gasPrice).toBeDefined();
         expect(request.maxFeePerGas).toBeUndefined();
+      });
+
+      it('should carry the nonce set through `ProcedureOpts` rather than the on-chain one', async () => {
+        jest
+          .spyOn(utilsConversionModule, 'transactionHexToTxTag')
+          .mockReturnValue(TxTags.asset.RegisterUniqueTicker);
+        context.getTransactionArguments.mockReturnValue([]);
+        context.getNonce.mockReturnValue(new BigNumber(7));
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        const { transaction: request } = await tx.toEthSignablePayload();
+
+        expect(request.nonce).toBe('0x7');
       });
 
       it('should throw a ValidationError for a native signing Account', async () => {

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -57,6 +57,12 @@ describe('Polymesh Transaction Base class', () => {
   afterEach(() => {
     dsMockUtils.reset();
     entityMockUtils.reset();
+    /*
+     * several tests stub `~/base/utils` module functions (`getExtrinsicFailure`,
+     *   `pollForTransactionFinalization`). Without this those stubs, and their call counts, leak
+     *   into every test that runs afterwards
+     */
+    jest.restoreAllMocks();
   });
 
   afterAll(() => {
@@ -2498,6 +2504,238 @@ describe('Polymesh Transaction Base class', () => {
         expect(tx.status).toBe(TransactionStatus.Failed);
         // the resolver must not run for a transaction that actually failed
         expect(resolver).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('submission timeouts', () => {
+      /**
+       * A wallet-broadcast transaction with a never-answered confirmation prompt — the case a
+       *   broadcast timeout exists for
+       */
+      const buildStalledBroadcast = (
+        submission: { broadcastTimeout?: number; watchTimeout?: number } = {}
+      ): PolymeshTransaction<undefined, void, [string]> => {
+        const ethSigner = buildEthSigner({ signTransaction: false, sendTransaction: true });
+        ethSigner.sendTransaction.mockReturnValue(new Promise(noop));
+        context.getEthSigner.mockReturnValue(ethSigner);
+        context.supportsSubscription.mockReturnValue(false);
+        dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+
+        return new PolymeshTransaction(
+          { ...ethTxSpec, submission, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+      };
+
+      it('should throw a TransactionTimeout if the wallet does not broadcast in time', async () => {
+        const tx = buildStalledBroadcast({ broadcastTimeout: 5000 });
+
+        const runPromise = tx.run();
+
+        await fakePromise();
+        jest.advanceTimersByTime(5000);
+
+        await expect(runPromise).rejects.toThrow(
+          expect.objectContaining({ code: ErrorCode.TransactionTimeout })
+        );
+      });
+
+      it('should wait indefinitely for the broadcast when no timeout is set', async () => {
+        const tx = buildStalledBroadcast();
+        let settled = false;
+
+        const runPromise = tx.run().catch(noop);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        runPromise.then(() => {
+          settled = true;
+        });
+
+        await fakePromise();
+        jest.advanceTimersByTime(600000);
+        await fakePromise();
+
+        expect(settled).toBe(false);
+      });
+
+      it('should throw a TransactionTimeout if the transaction is not found in time', async () => {
+        const ethSigner = buildEthSigner({ signTransaction: false, sendTransaction: true });
+        context.getEthSigner.mockReturnValue(ethSigner);
+        context.supportsSubscription.mockReturnValue(false);
+        dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
+
+        // the transaction is broadcast, but never turns up in a block
+        jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockReturnValue(new Promise(noop) as never);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          {
+            ...ethTxSpec,
+            submission: { watchTimeout: 5000 },
+            transaction,
+            args: tuple('FOO'),
+            resolver: undefined,
+          },
+          context
+        );
+
+        const runPromise = tx.run();
+
+        await fakePromise();
+        jest.advanceTimersByTime(5000);
+
+        await expect(runPromise).rejects.toThrow(
+          expect.objectContaining({ code: ErrorCode.TransactionTimeout })
+        );
+
+        /*
+         * the transaction was broadcast and may still be included — reporting `Failed` would
+         *   assert something untrue, so the last observed status has to stand
+         */
+        expect(tx.status).toBe(TransactionStatus.Running);
+        expect(tx.ethTxHash).toBe('0xethtxhash');
+      });
+    });
+
+    describe('method: broadcast', () => {
+      const buildWalletBroadcastTx = <T>(
+        resolver: T
+      ): {
+        tx: PolymeshTransaction<T, T, [string]>;
+        ethSigner: ReturnType<typeof buildEthSigner>;
+      } => {
+        const ethSigner = buildEthSigner({ signTransaction: false, sendTransaction: true });
+        context.getEthSigner.mockReturnValue(ethSigner);
+        context.supportsSubscription.mockReturnValue(false);
+        dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver },
+          context
+        );
+
+        return { tx, ethSigner };
+      };
+
+      const fakeReceipt = (): SubmittableResult =>
+        new SubmittableResult({
+          blockNumber: dsMockUtils.createMockU32(new BigNumber(101)),
+          status: dsMockUtils.createMockExtrinsicStatus({
+            Finalized: dsMockUtils.createMockHash('blockHash'),
+          }),
+          txHash: dsMockUtils.createMockHash('txHash'),
+          txIndex: 1,
+        });
+
+      it('should return the hashes without waiting for the transaction to be included', async () => {
+        const { tx, ethSigner } = buildWalletBroadcastTx(undefined);
+
+        const pollSpy = jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockReturnValue(new Promise(noop) as never);
+
+        const handle = await tx.broadcast();
+
+        expect(ethSigner.sendTransaction).toHaveBeenCalled();
+        expect(handle.txHash).toBe('0xethtxhash');
+        expect(handle.ethTxHash).toBe('0xethtxhash');
+        expect(handle.startingBlock).toEqual(new BigNumber(100));
+        expect(tx.status).toBe(TransactionStatus.Running);
+        // the whole point: no block scan was started
+        expect(pollSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return from watch the same value run would have', async () => {
+        const { tx } = buildWalletBroadcastTx('resolved value');
+
+        jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockResolvedValue(fakeReceipt() as never);
+
+        const handle = await tx.broadcast();
+
+        await expect(handle.watch()).resolves.toBe('resolved value');
+
+        expect(tx.status).toBe(TransactionStatus.Succeeded);
+        expect(tx.result).toBe('resolved value');
+        expect(tx.blockHash).toBe('blockHash');
+        expect(tx.txIndex).toEqual(new BigNumber(1));
+      });
+
+      it('should allow watch to be retried after it times out', async () => {
+        const { tx } = buildWalletBroadcastTx('resolved value');
+
+        const pollSpy = jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockReturnValue(new Promise(noop) as never);
+
+        const handle = await tx.broadcast();
+
+        const timingOut = handle.watch({ timeout: 5000 });
+
+        await fakePromise();
+        jest.advanceTimersByTime(5000);
+
+        await expect(timingOut).rejects.toThrow(
+          expect.objectContaining({ code: ErrorCode.TransactionTimeout })
+        );
+
+        // nothing is resubmitted on a retry — the scan simply starts again
+        pollSpy.mockResolvedValue(fakeReceipt() as never);
+
+        await expect(handle.watch()).resolves.toBe('resolved value');
+        expect(tx.status).toBe(TransactionStatus.Succeeded);
+      });
+
+      it('should throw if watch is called while a previous call is still in flight', async () => {
+        const { tx } = buildWalletBroadcastTx(undefined);
+
+        jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockReturnValue(new Promise(noop) as never);
+
+        const handle = await tx.broadcast();
+
+        // still scanning, since the mocked poll never settles
+        const inFlight = handle.watch();
+        inFlight.catch(noop);
+
+        await expect(handle.watch()).rejects.toThrow('already being watched');
+      });
+
+      it('should throw if the transaction has already been broadcast', async () => {
+        const { tx } = buildWalletBroadcastTx(undefined);
+
+        jest
+          .spyOn(baseUtils, 'pollForTransactionFinalization')
+          .mockReturnValue(new Promise(noop) as never);
+
+        await tx.broadcast();
+
+        await expect(tx.broadcast()).rejects.toThrow('Cannot re-run a Transaction');
+        await expect(tx.run()).rejects.toThrow('Cannot re-run a Transaction');
+      });
+
+      it('should throw a NotSupported error for a MultiSig signer', async () => {
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          {
+            ...txSpec,
+            multiSig: entityMockUtils.getMultiSigInstance(),
+            transaction,
+            args: tuple('FOO'),
+            resolver: undefined,
+          },
+          context
+        );
+
+        await expect(tx.broadcast()).rejects.toThrow(
+          expect.objectContaining({ code: ErrorCode.NotSupported })
+        );
       });
     });
 

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -838,6 +838,43 @@ describe('Polymesh Transaction Base class', () => {
       expect(result).toBe('pollingResult');
     });
 
+    it('should broadcast a natively signed transaction without waiting for it', async () => {
+      const transaction = dsMockUtils.createTxMock('staking', 'bond', { autoResolve: false });
+      context.supportsSubscription.mockReturnValue(false);
+
+      const fakeReceipt = new SubmittableResult({
+        blockNumber: dsMockUtils.createMockU32(new BigNumber(101)),
+        status: dsMockUtils.createMockExtrinsicStatus({
+          Finalized: dsMockUtils.createMockHash('blockHash'),
+        }),
+        txHash: dsMockUtils.createMockHash('bond'),
+        txIndex: 1,
+      });
+
+      jest.spyOn(baseUtils, 'pollForTransactionFinalization').mockResolvedValue(fakeReceipt);
+
+      const args = tuple('FOO');
+      const txWithArgsMock = transaction(...args);
+
+      const tx = new PolymeshTransaction(
+        { ...txSpec, transaction, args, resolver: 'pollingResult' },
+        context
+      );
+
+      const handle = await tx.broadcast();
+
+      // the native signer data path: signed and sent, with no Ethereum signer involved
+      expect(txWithArgsMock.signAndSend).toHaveBeenCalledWith(
+        txSpec.signingAddress,
+        expect.objectContaining({ signer: 'signer' })
+      );
+      expect(handle.ethTxHash).toBeUndefined();
+      expect(tx.status).toBe(TransactionStatus.Running);
+
+      await expect(handle.watch()).resolves.toBe('pollingResult');
+      expect(tx.status).toBe(TransactionStatus.Succeeded);
+    });
+
     it('should throw an error when polling if the finalized receipt contains an extrinsic failure', () => {
       const transaction = dsMockUtils.createTxMock('staking', 'bond', { autoResolve: false });
       context.supportsSubscription.mockReturnValue(false);
@@ -2221,26 +2258,42 @@ describe('Polymesh Transaction Base class', () => {
     const ethSs58Address = '5HYRCKHYJN9z5xUtfFkyMj4JUhsAwWyvuU8vKB1FcnYTf9ZQ';
     const sentinelAddress = '0x6d6f646c70792f70616464720000000000000000';
 
-    const buildEthSigner = (
-      capabilities: Partial<{
-        signTransaction: boolean;
-        sendTransaction: boolean;
-        eip1559: boolean;
-      }> = {}
-    ): {
-      capabilities: { signTransaction: boolean; sendTransaction: boolean; eip1559: boolean };
-      signTransaction: jest.Mock;
-      sendTransaction: jest.Mock;
+    /**
+     * `signTransaction` / `sendTransaction` control whether the signer *implements* that method,
+     *   since that is what the SDK derives its submission mode from
+     */
+    const buildEthSigner = ({
+      signTransaction = true,
+      sendTransaction = false,
+      eip1559,
+    }: {
+      signTransaction?: boolean;
+      sendTransaction?: boolean;
+      eip1559?: boolean;
+    } = {}): {
+      capabilities: { eip1559?: boolean };
+      signTransaction?: jest.Mock;
+      sendTransaction?: jest.Mock;
     } => ({
-      capabilities: {
-        signTransaction: true,
-        sendTransaction: false,
-        eip1559: true,
-        ...capabilities,
-      },
-      signTransaction: jest.fn().mockResolvedValue('0xrawsigned'),
-      sendTransaction: jest.fn().mockResolvedValue('0xethtxhash'),
+      capabilities: eip1559 === undefined ? {} : { eip1559 },
+      ...(signTransaction ? { signTransaction: jest.fn().mockResolvedValue('0xrawsigned') } : {}),
+      ...(sendTransaction ? { sendTransaction: jest.fn().mockResolvedValue('0xethtxhash') } : {}),
     });
+
+    /**
+     * The signer's `sendTransaction` mock, for tests that built a broadcasting signer. Throws
+     *   rather than asserting non-null, so a helper misuse fails as itself instead of as an
+     *   inscrutable "cannot read property of undefined"
+     */
+    const sendMockOf = (signer: ReturnType<typeof buildEthSigner>): jest.Mock => {
+      const { sendTransaction } = signer;
+
+      if (!sendTransaction) {
+        throw new Error('expected the signer to implement sendTransaction');
+      }
+
+      return sendTransaction;
+    };
 
     const mockReviveApi = (): void => {
       dsMockUtils.createCallMock('reviveApi', 'gasPrice', {
@@ -2457,7 +2510,7 @@ describe('Polymesh Transaction Base class', () => {
 
         expect(ethSigner.sendTransaction).toHaveBeenCalled();
         // the wallet owns the nonce in this mode
-        expect(ethSigner.sendTransaction.mock.calls[0][0].nonce).toBeUndefined();
+        expect(sendMockOf(ethSigner).mock.calls[0][0].nonce).toBeUndefined();
         expect(tx.ethTxHash).toBe('0xethtxhash');
         expect(tx.txHash).toBe('0xethtxhash');
         expect(tx.status).toBe(TransactionStatus.Succeeded);
@@ -2516,7 +2569,7 @@ describe('Polymesh Transaction Base class', () => {
         submission: { broadcastTimeout?: number; watchTimeout?: number } = {}
       ): PolymeshTransaction<undefined, void, [string]> => {
         const ethSigner = buildEthSigner({ signTransaction: false, sendTransaction: true });
-        ethSigner.sendTransaction.mockReturnValue(new Promise(noop));
+        sendMockOf(ethSigner).mockReturnValue(new Promise(noop));
         context.getEthSigner.mockReturnValue(ethSigner);
         context.supportsSubscription.mockReturnValue(false);
         dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
@@ -2830,8 +2883,12 @@ describe('Polymesh Transaction Base class', () => {
         expect(result.tag).toBe(tag);
       });
 
-      it('should throw if no Ethereum signer is attached to the SDK instance', async () => {
+      it('should build the payload with no Ethereum signer attached, since detached signing is the point', async () => {
         context.getEthSigner.mockReturnValue(undefined);
+        jest
+          .spyOn(utilsConversionModule, 'transactionHexToTxTag')
+          .mockReturnValue(TxTags.asset.RegisterUniqueTicker);
+        context.getTransactionArguments.mockReturnValue([]);
 
         const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
         const tx = new PolymeshTransaction(
@@ -2839,9 +2896,49 @@ describe('Polymesh Transaction Base class', () => {
           context
         );
 
-        await expect(tx.toEthSignablePayload()).rejects.toThrow(
-          'There is no Ethereum signer associated with the SDK instance'
+        const result = await tx.toEthSignablePayload();
+
+        expect(result.transaction).toEqual(
+          expect.objectContaining({ to: sentinelAddress, type: 2 })
         );
+      });
+
+      it('should default to an EIP-1559 transaction', async () => {
+        jest
+          .spyOn(utilsConversionModule, 'transactionHexToTxTag')
+          .mockReturnValue(TxTags.asset.RegisterUniqueTicker);
+        context.getTransactionArguments.mockReturnValue([]);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        const { transaction: request } = await tx.toEthSignablePayload();
+
+        expect(request.type).toBe(2);
+        expect(request.maxFeePerGas).toBeDefined();
+        expect(request.gasPrice).toBeUndefined();
+      });
+
+      it('should build a legacy transaction when the caller asks for one', async () => {
+        jest
+          .spyOn(utilsConversionModule, 'transactionHexToTxTag')
+          .mockReturnValue(TxTags.asset.RegisterUniqueTicker);
+        context.getTransactionArguments.mockReturnValue([]);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        const { transaction: request } = await tx.toEthSignablePayload({}, { eip1559: false });
+
+        expect(request.type).toBe(0);
+        expect(request.gasPrice).toBeDefined();
+        expect(request.maxFeePerGas).toBeUndefined();
       });
 
       it('should throw a ValidationError for a native signing Account', async () => {

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -2206,4 +2206,420 @@ describe('Polymesh Transaction Base class', () => {
       expect(result.multiSig).toEqual(DUMMY_ACCOUNT_ID);
     });
   });
+
+  describe('Ethereum signing path', () => {
+    /**
+     * SS58 (format 42) encoding of `<ALITH_H160> ++ [0xEE; 12]` — the Account the `revive` pallet
+     *   dispatches as for Alith's Ethereum key
+     */
+    const ethSs58Address = '5HYRCKHYJN9z5xUtfFkyMj4JUhsAwWyvuU8vKB1FcnYTf9ZQ';
+    const sentinelAddress = '0x6d6f646c70792f70616464720000000000000000';
+
+    const buildEthSigner = (
+      capabilities: Partial<{
+        signTransaction: boolean;
+        sendTransaction: boolean;
+        eip1559: boolean;
+      }> = {}
+    ): {
+      capabilities: { signTransaction: boolean; sendTransaction: boolean; eip1559: boolean };
+      signTransaction: jest.Mock;
+      sendTransaction: jest.Mock;
+    } => ({
+      capabilities: {
+        signTransaction: true,
+        sendTransaction: false,
+        eip1559: true,
+        ...capabilities,
+      },
+      signTransaction: jest.fn().mockResolvedValue('0xrawsigned'),
+      sendTransaction: jest.fn().mockResolvedValue('0xethtxhash'),
+    });
+
+    const mockReviveApi = (): void => {
+      dsMockUtils.createCallMock('reviveApi', 'gasPrice', {
+        returnValue: { toString: () => '100000000000000' },
+      });
+      dsMockUtils.createCallMock('reviveApi', 'nonce', {
+        returnValue: { toString: () => '0' },
+      });
+      dsMockUtils.createCallMock('reviveApi', 'ethTransactWithConfig', {
+        returnValue: { isErr: false, asOk: { ethGas: { toString: () => '1842' } } },
+      });
+      dsMockUtils.setConstMock('revive', 'nativeToEthRatio', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(1000000000000)),
+      });
+    };
+
+    const ethTxSpec = { ...txSpec, signingAddress: ethSs58Address };
+
+    beforeEach(() => {
+      context = dsMockUtils.getContextInstance({
+        // the gas-derived fee on this path is ~184,200 base units, so fund well past it
+        balance: {
+          free: new BigNumber(10000000),
+          locked: new BigNumber(0),
+          total: new BigNumber(10000000),
+        },
+        getEthSigner: buildEthSigner() as never,
+        getEthRuntimePalletsAddress: sentinelAddress,
+        getEthChainId: new BigNumber(1641818),
+      });
+      context.ss58Format = new BigNumber(42);
+      mockReviveApi();
+
+      dsMockUtils.createRpcMock('chain', 'getBlock').mockResolvedValue(
+        dsMockUtils.createMockSignedBlock({
+          block: {
+            header: {
+              number: dsMockUtils.createMockCompact(dsMockUtils.createMockU32(new BigNumber(1))),
+              parentHash: 'hash',
+              stateRoot: 'hash',
+              extrinsicsRoot: 'hash',
+            },
+            extrinsics: undefined,
+          },
+        })
+      );
+    });
+
+    describe('routing', () => {
+      it('should throw if no Ethereum signer is attached to the SDK instance', async () => {
+        context.getEthSigner.mockReturnValue(undefined);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        await expect(tx.run()).rejects.toThrow(
+          'There is no Ethereum signer associated with the SDK instance'
+        );
+      });
+
+      it('should fall back to polling when the connection has no subscription support', async () => {
+        context.supportsSubscription.mockReturnValue(false);
+        dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
+
+        const fakeReceipt = new SubmittableResult({
+          blockNumber: dsMockUtils.createMockU32(new BigNumber(101)),
+          status: dsMockUtils.createMockExtrinsicStatus({
+            Finalized: dsMockUtils.createMockHash('blockHash'),
+          }),
+          txHash: dsMockUtils.createMockHash('txHash'),
+          txIndex: 1,
+        });
+
+        // these exercise wallet-broadcast mechanics, not the scan strategy
+        context.supportsSubscription.mockReturnValue(false);
+        jest.spyOn(baseUtils, 'pollForTransactionFinalization').mockResolvedValue(fakeReceipt);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        await tx.run();
+
+        expect(tx.status).toBe(TransactionStatus.Succeeded);
+      });
+
+      it('should throw a NotSupported error if a third party is set to pay the fees', async () => {
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          {
+            ...ethTxSpec,
+            paidForBy: entityMockUtils.getIdentityInstance(),
+            transaction,
+            args: tuple('FOO'),
+            resolver: undefined,
+          },
+          context
+        );
+
+        await expect(tx.getTotalFees()).rejects.toThrow(
+          expect.objectContaining({ code: ErrorCode.NotSupported })
+        );
+      });
+
+      it('should throw a NotSupported error when acting as a MultiSig signer', async () => {
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          {
+            ...ethTxSpec,
+            multiSig: entityMockUtils.getMultiSigInstance(),
+            transaction,
+            args: tuple('FOO'),
+            resolver: undefined,
+          },
+          context
+        );
+
+        await expect(tx.runAsProposal()).rejects.toThrow(
+          expect.objectContaining({ code: ErrorCode.NotSupported })
+        );
+      });
+
+      it('should throw a ValidationError if mortality was explicitly set', async () => {
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          {
+            ...ethTxSpec,
+            mortality: { immortal: true },
+            transaction,
+            args: tuple('FOO'),
+            resolver: undefined,
+          },
+          context
+        );
+
+        await expect(tx.run()).rejects.toThrow(
+          'Mortality cannot be set for a transaction signed by an Ethereum key'
+        );
+      });
+    });
+
+    describe('when the SDK broadcasts', () => {
+      it('should sign, submit as a bare revive.ethTransact and track it like a native transaction', async () => {
+        const ethSigner = buildEthSigner();
+        context.getEthSigner.mockReturnValue(ethSigner);
+
+        const ethTransact = dsMockUtils.createTxMock('revive', 'ethTransact', {
+          autoResolve: false,
+        });
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        const runPromise = tx.run().catch(noop);
+
+        await fakePromises();
+
+        dsMockUtils.updateTxStatus(ethTransact, MockTxStatus.InBlock);
+        await fakePromise();
+        dsMockUtils.updateTxStatus(ethTransact, MockTxStatus.Succeeded);
+        await fakePromise();
+        await runPromise;
+
+        expect(ethSigner.signTransaction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: sentinelAddress,
+            value: '0x0',
+            chainId: '0x190d5a',
+            nonce: '0x0',
+            type: 2,
+          })
+        );
+        expect(ethTransact).toHaveBeenCalledWith('0xrawsigned');
+        expect(tx.status).toBe(TransactionStatus.Succeeded);
+        // the SDK submitted this itself, so there is no separate Ethereum hash to expose
+        expect(tx.ethTxHash).toBeUndefined();
+      });
+    });
+
+    describe('when the wallet broadcasts', () => {
+      it('should broadcast through the wallet and expose the Ethereum transaction hash', async () => {
+        const ethSigner = buildEthSigner({ signTransaction: false, sendTransaction: true });
+        context.getEthSigner.mockReturnValue(ethSigner);
+        dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
+
+        const fakeReceipt = new SubmittableResult({
+          blockNumber: dsMockUtils.createMockU32(new BigNumber(101)),
+          status: dsMockUtils.createMockExtrinsicStatus({
+            Finalized: dsMockUtils.createMockHash('blockHash'),
+          }),
+          txHash: dsMockUtils.createMockHash('txHash'),
+          txIndex: 1,
+        });
+
+        // these exercise wallet-broadcast mechanics, not the scan strategy
+        context.supportsSubscription.mockReturnValue(false);
+        jest.spyOn(baseUtils, 'pollForTransactionFinalization').mockResolvedValue(fakeReceipt);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        await tx.run();
+
+        expect(ethSigner.sendTransaction).toHaveBeenCalled();
+        // the wallet owns the nonce in this mode
+        expect(ethSigner.sendTransaction.mock.calls[0][0].nonce).toBeUndefined();
+        expect(tx.ethTxHash).toBe('0xethtxhash');
+        expect(tx.txHash).toBe('0xethtxhash');
+        expect(tx.status).toBe(TransactionStatus.Succeeded);
+      });
+
+      it('should surface a reverted inner dispatch as an error rather than a success', async () => {
+        /*
+         * the outer `revive.ethTransact` extrinsic emits `ExtrinsicSuccess` even when the inner
+         *   call failed, so without the `EthExtrinsicRevert` check this would resolve successfully
+         */
+        const ethSigner = buildEthSigner({ signTransaction: false, sendTransaction: true });
+        context.getEthSigner.mockReturnValue(ethSigner);
+        dsMockUtils.createTxMock('revive', 'ethTransact', { autoResolve: false });
+
+        const fakeReceipt = new SubmittableResult({
+          blockNumber: dsMockUtils.createMockU32(new BigNumber(101)),
+          status: dsMockUtils.createMockExtrinsicStatus({
+            Finalized: dsMockUtils.createMockHash('blockHash'),
+          }),
+          txHash: dsMockUtils.createMockHash('txHash'),
+          txIndex: 1,
+        });
+
+        const revertError = new PolymeshError({
+          code: ErrorCode.TransactionReverted,
+          message:
+            'identity.AlreadyLinked: One secondary or primary key can only belong to one DID',
+        });
+
+        // these exercise wallet-broadcast mechanics, not the scan strategy
+        context.supportsSubscription.mockReturnValue(false);
+        jest.spyOn(baseUtils, 'pollForTransactionFinalization').mockResolvedValue(fakeReceipt);
+        jest.spyOn(baseUtils, 'getExtrinsicFailure').mockReturnValue(revertError);
+
+        const resolver = jest.fn();
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver },
+          context
+        );
+
+        await expect(tx.run()).rejects.toThrowError(revertError);
+
+        expect(tx.status).toBe(TransactionStatus.Failed);
+        // the resolver must not run for a transaction that actually failed
+        expect(resolver).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('method: getTotalFees', () => {
+      it('should derive the gas fee from the dry run rather than payment_queryInfo', async () => {
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        const { fees } = await tx.getTotalFees();
+
+        // 1842 gas * 10^14 wei / 10^12 ratio = 184,200 base units = 0.1842 POLYX
+        expect(fees.gas).toEqual(new BigNumber(0.1842));
+      });
+
+      it('should report the gas fee in the same units as the native path', async () => {
+        /*
+         * the unit contract between the two branches: the Ethereum branch derives a base-unit
+         *   figure from the dry run while the native branch goes through `balanceToBigNumber`.
+         *   Both must end up as display POLYX, since `getTotalFees` sums the result with protocol
+         *   fees and `assertFeesCovered` compares it against an Account balance, both of which are
+         *   display values
+         */
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker', {
+          // price the same call natively: 1842 gas * 10^14 / 10^12 = 184,200 base units
+          gas: dsMockUtils.createMockBalance(new BigNumber(184200)),
+        });
+
+        const ethTx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+        const { fees: ethFees } = await ethTx.getTotalFees();
+
+        const nativeContext = dsMockUtils.getContextInstance({
+          balance: {
+            free: new BigNumber(10000000),
+            locked: new BigNumber(0),
+            total: new BigNumber(10000000),
+          },
+        });
+        nativeContext.ss58Format = new BigNumber(42);
+
+        const nativeTx = new PolymeshTransaction(
+          { ...txSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          nativeContext
+        );
+        const { fees: nativeFees } = await nativeTx.getTotalFees();
+
+        expect(ethFees.gas).toEqual(nativeFees.gas);
+      });
+    });
+
+    describe('method: toSignablePayload', () => {
+      it('should throw NotSupported, since an Ethereum key cannot sign a SCALE payload', async () => {
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        await expect(tx.toSignablePayload()).rejects.toThrow(
+          'A SCALE `SignerPayload` cannot be produced for a transaction signed by an Ethereum key'
+        );
+      });
+    });
+
+    describe('method: toEthSignablePayload', () => {
+      it('should build a detached payload carrying the request and the decoded call', async () => {
+        const tag = TxTags.asset.RegisterUniqueTicker;
+        jest.spyOn(utilsConversionModule, 'transactionHexToTxTag').mockReturnValue(tag);
+        context.getTransactionArguments.mockReturnValue([]);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        const result = await tx.toEthSignablePayload();
+
+        expect(result.transaction).toEqual(
+          expect.objectContaining({
+            to: sentinelAddress,
+            value: '0x0',
+            // a detached signer cannot own the nonce, so it is always resolved
+            nonce: '0x0',
+          })
+        );
+        expect(result.tag).toBe(tag);
+      });
+
+      it('should throw if no Ethereum signer is attached to the SDK instance', async () => {
+        context.getEthSigner.mockReturnValue(undefined);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...ethTxSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          context
+        );
+
+        await expect(tx.toEthSignablePayload()).rejects.toThrow(
+          'There is no Ethereum signer associated with the SDK instance'
+        );
+      });
+
+      it('should throw a ValidationError for a native signing Account', async () => {
+        const nativeContext = dsMockUtils.getContextInstance();
+        nativeContext.ss58Format = new BigNumber(42);
+
+        const transaction = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+        const tx = new PolymeshTransaction(
+          { ...txSpec, transaction, args: tuple('FOO'), resolver: undefined },
+          nativeContext
+        );
+
+        await expect(tx.toEthSignablePayload()).rejects.toThrow(
+          '`toEthSignablePayload` can only be used for a transaction signed by an Ethereum-derived Account'
+        );
+      });
+    });
+  });
 });

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -2471,7 +2471,7 @@ describe('Polymesh Transaction Base class', () => {
             value: '0x0',
             chainId: '0x190d5a',
             nonce: '0x0',
-            type: 2,
+            type: '0x2',
           })
         );
         expect(ethTransact).toHaveBeenCalledWith('0xrawsigned');
@@ -2899,7 +2899,7 @@ describe('Polymesh Transaction Base class', () => {
         const result = await tx.toEthSignablePayload();
 
         expect(result.transaction).toEqual(
-          expect.objectContaining({ to: sentinelAddress, type: 2 })
+          expect.objectContaining({ to: sentinelAddress, type: '0x2' })
         );
       });
 
@@ -2917,7 +2917,7 @@ describe('Polymesh Transaction Base class', () => {
 
         const { transaction: request } = await tx.toEthSignablePayload();
 
-        expect(request.type).toBe(2);
+        expect(request.type).toBe('0x2');
         expect(request.maxFeePerGas).toBeDefined();
         expect(request.gasPrice).toBeUndefined();
       });
@@ -2936,7 +2936,7 @@ describe('Polymesh Transaction Base class', () => {
 
         const { transaction: request } = await tx.toEthSignablePayload({}, { eip1559: false });
 
-        expect(request.type).toBe(0);
+        expect(request.type).toBe('0x0');
         expect(request.gasPrice).toBeDefined();
         expect(request.maxFeePerGas).toBeUndefined();
       });

--- a/src/base/__tests__/Procedure.ts
+++ b/src/base/__tests__/Procedure.ts
@@ -362,6 +362,57 @@ describe('Procedure class', () => {
       );
     });
 
+    it('should pass the submission options through to the transaction', async () => {
+      const tx = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+
+      const func = function (
+        this: Procedure<typeof procArgs, string>,
+        args: typeof procArgs
+      ): Promise<TransactionSpec<string, [string]>> {
+        return Promise.resolve({
+          transaction: tx,
+          args: [args.ticker],
+          resolver: returnValue,
+        });
+      };
+
+      const submission = { broadcastTimeout: 30000, watchTimeout: 60000 };
+
+      await new Procedure(func).prepare({ args: procArgs }, context, {
+        signingAccount: entityMockUtils.getAccountInstance(),
+        submission,
+      });
+
+      expect(polymeshTransactionMockUtils.getTransactionConstructorMock()).toHaveBeenCalledWith(
+        expect.objectContaining({ submission }),
+        expect.anything()
+      );
+    });
+
+    it('should leave the submission options undefined when none are given', async () => {
+      const tx = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
+
+      const func = function (
+        this: Procedure<typeof procArgs, string>,
+        args: typeof procArgs
+      ): Promise<TransactionSpec<string, [string]>> {
+        return Promise.resolve({
+          transaction: tx,
+          args: [args.ticker],
+          resolver: returnValue,
+        });
+      };
+
+      await new Procedure(func).prepare({ args: procArgs }, context, {
+        signingAccount: entityMockUtils.getAccountInstance(),
+      });
+
+      expect(polymeshTransactionMockUtils.getTransactionConstructorMock()).toHaveBeenCalledWith(
+        expect.objectContaining({ submission: undefined }),
+        expect.anything()
+      );
+    });
+
     it('should prepare and return a transaction spec with the corresponding transactions, arguments, fees and return value', async () => {
       const tx1 = dsMockUtils.createTxMock('asset', 'registerUniqueTicker');
       const tx2 = dsMockUtils.createTxMock('identity', 'cddRegisterDid');

--- a/src/base/__tests__/ethTransaction.ts
+++ b/src/base/__tests__/ethTransaction.ts
@@ -225,7 +225,7 @@ describe('ethTransaction', () => {
       expect(request.gas).toBe('0x732');
       expect(request.chainId).toBe('0x190d5a');
       expect(request.nonce).toBe('0x7');
-      expect(request.type).toBe(2);
+      expect(request.type).toBe('0x2');
       expect(request.maxFeePerGas).toBe('0x5af3107a4000');
       expect(request.maxPriorityFeePerGas).toBe('0x0');
       expect(request.gasPrice).toBeUndefined();
@@ -243,7 +243,7 @@ describe('ethTransaction', () => {
         ethSigner: buildEthSigner({ eip1559: false }),
       });
 
-      expect(request.type).toBe(0);
+      expect(request.type).toBe('0x0');
       expect(request.gasPrice).toBe('0x5af3107a4000');
       expect(request.maxFeePerGas).toBeUndefined();
       expect(request.maxPriorityFeePerGas).toBeUndefined();
@@ -340,7 +340,7 @@ describe('ethTransaction', () => {
 
       expect(request.nonce).toBe('0x3');
       expect(request.gas).toBe('0x732');
-      expect(request.type).toBe(2);
+      expect(request.type).toBe('0x2');
     });
 
     it('should honour an explicitly passed nonce, and emit a legacy transaction when asked', async () => {
@@ -355,7 +355,7 @@ describe('ethTransaction', () => {
       );
 
       expect(request.nonce).toBe('0x9');
-      expect(request.type).toBe(0);
+      expect(request.type).toBe('0x0');
       expect(request.gasPrice).toBe('0x5af3107a4000');
     });
   });

--- a/src/base/__tests__/ethTransaction.ts
+++ b/src/base/__tests__/ethTransaction.ts
@@ -1,0 +1,503 @@
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { GenericExtrinsic } from '@polkadot/types';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { HexString } from '@polkadot/util/types';
+import { keccakAsHex } from '@polkadot/util-crypto';
+import BigNumber from 'bignumber.js';
+
+import {
+  buildDetachedEthTransactionRequest,
+  buildEthTransactionRequest,
+  buildSdkBroadcastSubmission,
+  buildWalletBroadcastSubmission,
+  calculateEthGasFee,
+  dryRunEthTransaction,
+  ethTransactKeccakMatcher,
+  getEthSubmissionMode,
+  getNativeToEthRatio,
+} from '~/base/ethTransaction';
+import { EthSigner } from '~/base/types';
+import { Context } from '~/internal';
+import { dsMockUtils } from '~/testUtils/mocks';
+import { MockContext } from '~/testUtils/mocks/dataSources';
+import { ErrorCode } from '~/types';
+
+describe('ethTransaction', () => {
+  /**
+   * SS58 (format 42) encoding of `<ALITH_H160> ++ [0xEE; 12]`, i.e. the Polymesh Account the
+   *   `revive` pallet dispatches as for Alith's key
+   */
+  const ethSs58Address = '5HYRCKHYJN9z5xUtfFkyMj4JUhsAwWyvuU8vKB1FcnYTf9ZQ';
+  const alithH160 = '0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac';
+  const sentinelAddress = '0x6d6f646c70792f70616464720000000000000000';
+  const calldata = '0x0719';
+  const chainId = new BigNumber(1641818);
+
+  let context: MockContext;
+
+  /**
+   * A composed transaction whose SCALE-encoded call becomes the `data` field
+   */
+  const composedTx = {
+    method: { toHex: (): string => calldata },
+  } as unknown as SubmittableExtrinsic<'promise', ISubmittableResult>;
+
+  const buildEthSigner = (
+    capabilities: Partial<EthSigner['capabilities']> = {},
+    overrides: Partial<EthSigner> = {}
+  ): EthSigner =>
+    ({
+      capabilities: {
+        signTransaction: true,
+        sendTransaction: false,
+        eip1559: true,
+        ...capabilities,
+      },
+      signTransaction: jest.fn().mockResolvedValue('0xrawsigned'),
+      sendTransaction: jest.fn().mockResolvedValue('0xethtxhash'),
+      ...overrides,
+    } as unknown as EthSigner);
+
+  /**
+   * Mock the `reviveApi` runtime calls the eth path depends on
+   */
+  const mockReviveApi = ({
+    ethGas = 1842,
+    gasPrice = 100000000000000,
+    nonce = 0,
+    dryRunError,
+  }: {
+    ethGas?: number;
+    gasPrice?: number;
+    nonce?: number;
+    dryRunError?: unknown;
+  } = {}): void => {
+    dsMockUtils.createCallMock('reviveApi', 'gasPrice', {
+      returnValue: { toString: () => `${gasPrice}` },
+    });
+    dsMockUtils.createCallMock('reviveApi', 'nonce', {
+      returnValue: { toString: () => `${nonce}` },
+    });
+    dsMockUtils.createCallMock('reviveApi', 'ethTransactWithConfig', {
+      returnValue: dryRunError
+        ? { isErr: true, asErr: dryRunError }
+        : { isErr: false, asOk: { ethGas: { toString: () => `${ethGas}` } } },
+    });
+  };
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance({
+      getEthRuntimePalletsAddress: sentinelAddress,
+      getEthChainId: chainId,
+    });
+    context.ss58Format = new BigNumber(42);
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  describe('getEthSubmissionMode', () => {
+    it('should prefer SDK broadcast when the signer can return raw signed bytes', () => {
+      const signer = buildEthSigner({ signTransaction: true, sendTransaction: true });
+
+      expect(getEthSubmissionMode(signer)).toBe('sdkBroadcast');
+    });
+
+    it('should fall back to wallet broadcast when the signer can only broadcast', () => {
+      const signer = buildEthSigner({ signTransaction: false, sendTransaction: true });
+
+      expect(getEthSubmissionMode(signer)).toBe('walletBroadcast');
+    });
+
+    it('should throw if the signer advertises neither capability', () => {
+      const signer = buildEthSigner({ signTransaction: false, sendTransaction: false });
+
+      expect(() => getEthSubmissionMode(signer)).toThrow(
+        'does not support signing or sending transactions'
+      );
+    });
+  });
+
+  describe('dryRunEthTransaction', () => {
+    it('should return the gas, price and chain data needed to build the transaction', async () => {
+      mockReviveApi({ ethGas: 1842, gasPrice: 100000000000000 });
+
+      const result = await dryRunEthTransaction(
+        context as unknown as Context,
+        ethSs58Address,
+        composedTx
+      );
+
+      expect(result.from.toLowerCase()).toBe(alithH160.toLowerCase());
+      expect(result.to).toBe(sentinelAddress);
+      expect(result.calldata).toBe(calldata);
+      expect(result.rawEthGas).toEqual(new BigNumber(1842));
+      expect(result.gasPrice).toEqual(new BigNumber(100000000000000));
+      expect(result.chainId).toEqual(chainId);
+    });
+
+    it('should throw the parsed error when the dry run fails, before the wallet is consulted', async () => {
+      const dispatchFailure =
+        'Failed to dispatch call: Module(ModuleError { index: 7, error: [0, 0, 0, 0], message: Some("AlreadyLinked") })';
+
+      dsMockUtils.getApiInstance().registry.findMetaError = jest.fn().mockReturnValue({
+        section: 'identity',
+        name: 'AlreadyLinked',
+        docs: ['One secondary or primary key can only belong to one DID'],
+      });
+
+      mockReviveApi({
+        dryRunError: {
+          isData: false,
+          asMessage: { toString: () => dispatchFailure },
+        },
+      });
+
+      let error;
+      try {
+        await dryRunEthTransaction(context as unknown as Context, ethSs58Address, composedTx);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error.code).toBe(ErrorCode.TransactionReverted);
+      expect(error.message).toBe(
+        'identity.AlreadyLinked: One secondary or primary key can only belong to one DID'
+      );
+    });
+  });
+
+  describe('buildEthTransactionRequest', () => {
+    it('should build an EIP-1559 request, resolving the nonce on chain when the SDK broadcasts', async () => {
+      mockReviveApi({ ethGas: 1842, gasPrice: 100000000000000, nonce: 7 });
+
+      const { request, rawEthGas, gasPrice } = await buildEthTransactionRequest({
+        context: context as unknown as Context,
+        signingAddress: ethSs58Address,
+        composedTx,
+        ethSigner: buildEthSigner(),
+      });
+
+      expect(request.to).toBe(sentinelAddress);
+      expect(request.data).toBe(calldata);
+      expect(request.value).toBe('0x0');
+      expect(request.gas).toBe('0x732');
+      expect(request.chainId).toBe('0x190d5a');
+      expect(request.nonce).toBe('0x7');
+      expect(request.type).toBe(2);
+      expect(request.maxFeePerGas).toBe('0x5af3107a4000');
+      expect(request.maxPriorityFeePerGas).toBe('0x0');
+      expect(request.gasPrice).toBeUndefined();
+      expect(rawEthGas).toEqual(new BigNumber(1842));
+      expect(gasPrice).toEqual(new BigNumber(100000000000000));
+    });
+
+    it('should build a legacy (type 0) request when the signer does not support EIP-1559', async () => {
+      mockReviveApi();
+
+      const { request } = await buildEthTransactionRequest({
+        context: context as unknown as Context,
+        signingAddress: ethSs58Address,
+        composedTx,
+        ethSigner: buildEthSigner({ eip1559: false }),
+      });
+
+      expect(request.type).toBe(0);
+      expect(request.gasPrice).toBe('0x5af3107a4000');
+      expect(request.maxFeePerGas).toBeUndefined();
+      expect(request.maxPriorityFeePerGas).toBeUndefined();
+    });
+
+    it('should use an explicitly passed nonce when the SDK broadcasts', async () => {
+      mockReviveApi({ nonce: 7 });
+
+      const { request } = await buildEthTransactionRequest({
+        context: context as unknown as Context,
+        signingAddress: ethSs58Address,
+        composedTx,
+        ethSigner: buildEthSigner(),
+        nonce: new BigNumber(42),
+      });
+
+      expect(request.nonce).toBe('0x2a');
+    });
+
+    it('should omit the nonce when the wallet broadcasts, leaving it to the wallet', async () => {
+      mockReviveApi();
+
+      const { request } = await buildEthTransactionRequest({
+        context: context as unknown as Context,
+        signingAddress: ethSs58Address,
+        composedTx,
+        ethSigner: buildEthSigner({ signTransaction: false, sendTransaction: true }),
+      });
+
+      expect(request.nonce).toBeUndefined();
+    });
+
+    it('should throw a ValidationError if a nonce is passed while the wallet owns it', async () => {
+      mockReviveApi();
+
+      let error;
+      try {
+        await buildEthTransactionRequest({
+          context: context as unknown as Context,
+          signingAddress: ethSs58Address,
+          composedTx,
+          ethSigner: buildEthSigner({ signTransaction: false, sendTransaction: true }),
+          nonce: new BigNumber(1),
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error.code).toBe(ErrorCode.ValidationError);
+      expect(error.message).toContain('nonce cannot be set explicitly');
+    });
+
+    it('should apply a gas multiplier, rounding up', async () => {
+      mockReviveApi({ ethGas: 1000 });
+
+      const { request, rawEthGas } = await buildEthTransactionRequest({
+        context: context as unknown as Context,
+        signingAddress: ethSs58Address,
+        composedTx,
+        ethSigner: buildEthSigner(),
+        gasMultiplier: new BigNumber(1.5),
+      });
+
+      expect(request.gas).toBe('0x5dc');
+      // the fee estimate is based on the un-multiplied gas, since headroom is not part of the fee
+      expect(rawEthGas).toEqual(new BigNumber(1000));
+    });
+
+    it('should never reduce the gas below the dry run estimate', async () => {
+      mockReviveApi({ ethGas: 1000 });
+
+      const { request } = await buildEthTransactionRequest({
+        context: context as unknown as Context,
+        signingAddress: ethSs58Address,
+        composedTx,
+        ethSigner: buildEthSigner(),
+        gasMultiplier: new BigNumber(0.5),
+      });
+
+      expect(request.gas).toBe('0x3e8');
+    });
+  });
+
+  describe('buildDetachedEthTransactionRequest', () => {
+    it('should always resolve a nonce, since a detached signer cannot own it', async () => {
+      mockReviveApi({ nonce: 3, ethGas: 1842 });
+
+      const request = await buildDetachedEthTransactionRequest(
+        context as unknown as Context,
+        ethSs58Address,
+        composedTx,
+        true
+      );
+
+      expect(request.nonce).toBe('0x3');
+      expect(request.gas).toBe('0x732');
+      expect(request.type).toBe(2);
+    });
+
+    it('should honour an explicitly passed nonce, and emit a legacy transaction when asked', async () => {
+      mockReviveApi({ nonce: 3 });
+
+      const request = await buildDetachedEthTransactionRequest(
+        context as unknown as Context,
+        ethSs58Address,
+        composedTx,
+        false,
+        new BigNumber(9)
+      );
+
+      expect(request.nonce).toBe('0x9');
+      expect(request.type).toBe(0);
+      expect(request.gasPrice).toBe('0x5af3107a4000');
+    });
+  });
+
+  describe('calculateEthGasFee', () => {
+    it('should derive the fee as ethGas * gasPrice / nativeToEthRatio, as a display POLYX value', () => {
+      /*
+       * 1,339 gas at 10^14 wei over a 10^12 ratio is 133,900 base units,
+       *   which is 0.1339 POLYX. The result must be a display value, since it is summed with
+       *   protocol fees and compared against Account balances, both of which are display values
+       */
+      const result = calculateEthGasFee(
+        new BigNumber(1339),
+        new BigNumber(100000000000000),
+        new BigNumber(1000000000000)
+      );
+
+      expect(result).toEqual(new BigNumber(0.1339));
+    });
+
+    it('should round up to a whole base unit, so the estimate is never short', () => {
+      // 3/2 base units rounds up to 2 base units, i.e. 0.000002 POLYX
+      const result = calculateEthGasFee(new BigNumber(1), new BigNumber(3), new BigNumber(2));
+
+      expect(result).toEqual(new BigNumber(0.000002));
+    });
+  });
+
+  describe('getNativeToEthRatio', () => {
+    it('should read the ratio from chain constants', () => {
+      dsMockUtils.setConstMock('revive', 'nativeToEthRatio', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(1000000000000)),
+      });
+
+      expect(getNativeToEthRatio(context as unknown as Context)).toEqual(
+        new BigNumber(1000000000000)
+      );
+    });
+  });
+
+  describe('ethTransactKeccakMatcher', () => {
+    const payloadBytes = new Uint8Array([1, 2, 3, 4]);
+    const ethTxHash = keccakAsHex(payloadBytes);
+
+    const buildExtrinsic = (section: string, method: string, args: unknown[]): GenericExtrinsic =>
+      ({ method: { section, method }, args } as unknown as GenericExtrinsic);
+
+    it('should match the revive.ethTransact extrinsic carrying the payload', () => {
+      const matcher = ethTransactKeccakMatcher(ethTxHash);
+
+      expect(
+        matcher(
+          buildExtrinsic('revive', 'ethTransact', [{ toU8a: (): Uint8Array => payloadBytes }])
+        )
+      ).toBe(true);
+    });
+
+    it('should be case insensitive about the hash', () => {
+      const matcher = ethTransactKeccakMatcher(ethTxHash.toUpperCase());
+
+      expect(
+        matcher(
+          buildExtrinsic('revive', 'ethTransact', [{ toU8a: (): Uint8Array => payloadBytes }])
+        )
+      ).toBe(true);
+    });
+
+    it('should not match an extrinsic from another pallet or call', () => {
+      const matcher = ethTransactKeccakMatcher(ethTxHash);
+
+      expect(
+        matcher(buildExtrinsic('balances', 'transfer', [{ toU8a: (): Uint8Array => payloadBytes }]))
+      ).toBe(false);
+      expect(
+        matcher(
+          buildExtrinsic('revive', 'ethSubstrateCall', [{ toU8a: (): Uint8Array => payloadBytes }])
+        )
+      ).toBe(false);
+    });
+
+    it('should not match a revive.ethTransact carrying a different payload', () => {
+      const matcher = ethTransactKeccakMatcher(ethTxHash);
+
+      expect(
+        matcher(
+          buildExtrinsic('revive', 'ethTransact', [
+            { toU8a: (): Uint8Array => new Uint8Array([9, 9, 9]) },
+          ])
+        )
+      ).toBe(false);
+    });
+
+    it('should not match an extrinsic with no payload argument', () => {
+      const matcher = ethTransactKeccakMatcher(ethTxHash);
+
+      expect(matcher(buildExtrinsic('revive', 'ethTransact', []))).toBe(false);
+    });
+  });
+
+  describe('buildSdkBroadcastSubmission', () => {
+    it('should submit the raw signed bytes as a bare revive.ethTransact extrinsic', async () => {
+      const send = jest.fn().mockResolvedValue(jest.fn());
+      const hash = dsMockUtils.createMockHash('0xextrinsichash');
+      const ethTransactMock = dsMockUtils.createTxMock('revive', 'ethTransact');
+      ethTransactMock.mockReturnValue({ send, hash });
+
+      const { subscription } = buildSdkBroadcastSubmission(
+        context as unknown as Context,
+        '0xrawsigned' as HexString
+      );
+
+      const callback = jest.fn();
+      await subscription.subscribe(callback);
+
+      expect(ethTransactMock).toHaveBeenCalledWith('0xrawsigned');
+      expect(send).toHaveBeenCalledWith(callback);
+      expect(subscription.getTxHash()).toBe(hash.toString());
+    });
+
+    it('should expose a polling submission that matches on the extrinsic hash', async () => {
+      const hash = dsMockUtils.createMockHash('0xextrinsichash');
+      const send = jest.fn().mockResolvedValue(hash);
+      const ethTransactMock = dsMockUtils.createTxMock('revive', 'ethTransact');
+      ethTransactMock.mockReturnValue({ send, hash });
+
+      const { polling } = buildSdkBroadcastSubmission(
+        context as unknown as Context,
+        '0xrawsigned' as HexString
+      );
+
+      const { txHash, matcher } = await polling.send();
+
+      expect(txHash).toBe(hash.toString());
+      expect(matcher({ hash } as unknown as GenericExtrinsic)).toBe(true);
+    });
+  });
+
+  describe('buildWalletBroadcastSubmission', () => {
+    it('should broadcast through the wallet and match on the returned eth tx hash', async () => {
+      const payloadBytes = new Uint8Array([1, 2, 3, 4]);
+      const ethTxHash = keccakAsHex(payloadBytes);
+      const sendTransaction = jest.fn().mockResolvedValue(ethTxHash);
+      const ethSigner = buildEthSigner(
+        { signTransaction: false, sendTransaction: true },
+        { sendTransaction }
+      );
+      const request = { from: alithH160 } as never;
+
+      const { txHash, matcher } = await buildWalletBroadcastSubmission(ethSigner, request).send();
+
+      expect(sendTransaction).toHaveBeenCalledWith(request);
+      expect(txHash).toBe(ethTxHash);
+      expect(
+        matcher({
+          method: { section: 'revive', method: 'ethTransact' },
+          args: [{ toU8a: (): Uint8Array => payloadBytes }],
+        } as unknown as GenericExtrinsic)
+      ).toBe(true);
+    });
+
+    it('should throw if the signer advertised sendTransaction but does not implement it', async () => {
+      const ethSigner = {
+        capabilities: { signTransaction: false, sendTransaction: true, eip1559: true },
+      } as unknown as EthSigner;
+
+      let error;
+      try {
+        await buildWalletBroadcastSubmission(ethSigner, {} as never).send();
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error.code).toBe(ErrorCode.General);
+      expect(error.message).toContain('does not implement sendTransaction');
+    });
+  });
+});

--- a/src/base/__tests__/ethTransaction.ts
+++ b/src/base/__tests__/ethTransaction.ts
@@ -13,7 +13,7 @@ import {
   calculateEthGasFee,
   dryRunEthTransaction,
   ethTransactKeccakMatcher,
-  getEthSubmissionMode,
+  getEthSubmissionStrategy,
   getNativeToEthRatio,
 } from '~/base/ethTransaction';
 import { EthSigner } from '~/base/types';
@@ -42,21 +42,26 @@ describe('ethTransaction', () => {
     method: { toHex: (): string => calldata },
   } as unknown as SubmittableExtrinsic<'promise', ISubmittableResult>;
 
+  /**
+   * Build an `EthSigner` mock.
+   *
+   * `signTransaction` / `sendTransaction` control whether the signer *implements* that method,
+   *   since that is what the SDK derives its submission mode from. `eip1559` is left off the
+   *   capabilities entirely unless given, so the default (`true`) is what most tests exercise
+   */
   const buildEthSigner = (
-    capabilities: Partial<EthSigner['capabilities']> = {},
+    {
+      signTransaction = true,
+      sendTransaction = false,
+      eip1559,
+    }: { signTransaction?: boolean; sendTransaction?: boolean; eip1559?: boolean } = {},
     overrides: Partial<EthSigner> = {}
-  ): EthSigner =>
-    ({
-      capabilities: {
-        signTransaction: true,
-        sendTransaction: false,
-        eip1559: true,
-        ...capabilities,
-      },
-      signTransaction: jest.fn().mockResolvedValue('0xrawsigned'),
-      sendTransaction: jest.fn().mockResolvedValue('0xethtxhash'),
-      ...overrides,
-    } as unknown as EthSigner);
+  ): EthSigner => ({
+    capabilities: eip1559 === undefined ? {} : { eip1559 },
+    ...(signTransaction ? { signTransaction: jest.fn().mockResolvedValue('0xrawsigned') } : {}),
+    ...(sendTransaction ? { sendTransaction: jest.fn().mockResolvedValue('0xethtxhash') } : {}),
+    ...overrides,
+  });
 
   /**
    * Mock the `reviveApi` runtime calls the eth path depends on
@@ -105,25 +110,52 @@ describe('ethTransaction', () => {
     dsMockUtils.cleanup();
   });
 
-  describe('getEthSubmissionMode', () => {
+  describe('getEthSubmissionStrategy', () => {
     it('should prefer SDK broadcast when the signer can return raw signed bytes', () => {
       const signer = buildEthSigner({ signTransaction: true, sendTransaction: true });
 
-      expect(getEthSubmissionMode(signer)).toBe('sdkBroadcast');
+      expect(getEthSubmissionStrategy(signer).mode).toBe('sdkBroadcast');
     });
 
     it('should fall back to wallet broadcast when the signer can only broadcast', () => {
       const signer = buildEthSigner({ signTransaction: false, sendTransaction: true });
 
-      expect(getEthSubmissionMode(signer)).toBe('walletBroadcast');
+      expect(getEthSubmissionStrategy(signer).mode).toBe('walletBroadcast');
     });
 
-    it('should throw if the signer advertises neither capability', () => {
+    it('should throw if the signer implements neither method', () => {
       const signer = buildEthSigner({ signTransaction: false, sendTransaction: false });
 
-      expect(() => getEthSubmissionMode(signer)).toThrow(
-        'does not support signing or sending transactions'
+      expect(() => getEthSubmissionStrategy(signer)).toThrow(
+        'implements neither signTransaction nor sendTransaction'
       );
+    });
+
+    it('should bind the resolved method to the signer', async () => {
+      /**
+       * A signer implemented with ordinary class methods rather than arrow function properties.
+       *   Destructuring such a method drops `this`, so this is what proves the strategy binds it
+       */
+      class ClassBasedSigner implements EthSigner {
+        public capabilities = {};
+
+        private readonly raw = '0xboundraw' as const;
+
+        /**
+         * reading `this.raw` is the point: an unbound method would throw here
+         */
+        public signTransaction(): Promise<HexString> {
+          return Promise.resolve(this.raw);
+        }
+      }
+
+      const strategy = getEthSubmissionStrategy(new ClassBasedSigner());
+
+      if (strategy.mode !== 'sdkBroadcast') {
+        throw new Error('expected the strategy to resolve to sdkBroadcast');
+      }
+
+      await expect(strategy.signTransaction({} as never)).resolves.toBe('0xboundraw');
     });
   });
 
@@ -466,13 +498,12 @@ describe('ethTransaction', () => {
       const payloadBytes = new Uint8Array([1, 2, 3, 4]);
       const ethTxHash = keccakAsHex(payloadBytes);
       const sendTransaction = jest.fn().mockResolvedValue(ethTxHash);
-      const ethSigner = buildEthSigner(
-        { signTransaction: false, sendTransaction: true },
-        { sendTransaction }
-      );
       const request = { from: alithH160 } as never;
 
-      const { txHash, matcher } = await buildWalletBroadcastSubmission(ethSigner, request).send();
+      const { txHash, matcher } = await buildWalletBroadcastSubmission(
+        sendTransaction,
+        request
+      ).send();
 
       expect(sendTransaction).toHaveBeenCalledWith(request);
       expect(txHash).toBe(ethTxHash);
@@ -482,22 +513,6 @@ describe('ethTransaction', () => {
           args: [{ toU8a: (): Uint8Array => payloadBytes }],
         } as unknown as GenericExtrinsic)
       ).toBe(true);
-    });
-
-    it('should throw if the signer advertised sendTransaction but does not implement it', async () => {
-      const ethSigner = {
-        capabilities: { signTransaction: false, sendTransaction: true, eip1559: true },
-      } as unknown as EthSigner;
-
-      let error;
-      try {
-        await buildWalletBroadcastSubmission(ethSigner, {} as never).send();
-      } catch (err) {
-        error = err;
-      }
-
-      expect(error.code).toBe(ErrorCode.General);
-      expect(error.message).toContain('does not implement sendTransaction');
     });
   });
 });

--- a/src/base/__tests__/utils.ts
+++ b/src/base/__tests__/utils.ts
@@ -6,6 +6,7 @@ import { when } from 'jest-when';
 import {
   dispatchErrorToMessage,
   extrinsicHashMatcher,
+  handleTransactionSubmissionError,
   pollForTransactionFinalization,
   processType,
   subscribeForTransactionFinalization,
@@ -120,6 +121,38 @@ describe('dispatchErrorToMessage', () => {
 
   it('should only report "Unknown error" when there is genuinely nothing to report', () => {
     expect(dispatchErrorToMessage(buildDispatchError(''))).toBe('Unknown error');
+  });
+});
+
+describe('handleTransactionSubmissionError', () => {
+  it('should map a Polkadot signer cancellation, which reports rejection in the message', () => {
+    const error = handleTransactionSubmissionError(new Error('Error: Cancelled'));
+
+    expect(error.code).toBe(ErrorCode.TransactionRejectedByUser);
+  });
+
+  it('should map an EIP-1193 rejection, which reports it as code 4001', () => {
+    const rejection = Object.assign(new Error('User rejected the request'), { code: 4001 });
+
+    const error = handleTransactionSubmissionError(rejection);
+
+    expect(error.code).toBe(ErrorCode.TransactionRejectedByUser);
+  });
+
+  it('should not treat another provider error code as a rejection', () => {
+    const disconnected = Object.assign(new Error('The wallet is disconnected'), { code: 4900 });
+
+    const error = handleTransactionSubmissionError(disconnected);
+
+    expect(error.code).toBe(ErrorCode.UnexpectedError);
+    expect(error.message).toBe('The wallet is disconnected');
+  });
+
+  it('should report anything else as an unexpected error', () => {
+    const error = handleTransactionSubmissionError(new Error('something broke'));
+
+    expect(error.code).toBe(ErrorCode.UnexpectedError);
+    expect(error.message).toBe('something broke');
   });
 });
 

--- a/src/base/__tests__/utils.ts
+++ b/src/base/__tests__/utils.ts
@@ -1,17 +1,19 @@
 import { SpRuntimeDispatchError } from '@polkadot/types/lookup';
-import { TypeDef } from '@polkadot/types/types';
+import { ISubmittableResult, TypeDef } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
 import {
   dispatchErrorToMessage,
   extrinsicHashMatcher,
+  getExtrinsicFailure,
   handleTransactionSubmissionError,
   pollForTransactionFinalization,
   processType,
   subscribeForTransactionFinalization,
 } from '~/base/utils';
 import { PolymeshError } from '~/internal';
+import { fakePromise } from '~/testUtils';
 import { dsMockUtils } from '~/testUtils/mocks';
 import {
   createMockEventRecord,
@@ -153,6 +155,57 @@ describe('handleTransactionSubmissionError', () => {
 
     expect(error.code).toBe(ErrorCode.UnexpectedError);
     expect(error.message).toBe('something broke');
+  });
+});
+
+describe('getExtrinsicFailure', () => {
+  /**
+   * Build a receipt whose `filterRecords` answers for the given `module.event` keys only
+   */
+  const buildReceipt = ({
+    extrinsicFailed,
+    ethExtrinsicRevert,
+  }: {
+    extrinsicFailed?: SpRuntimeDispatchError;
+    ethExtrinsicRevert?: SpRuntimeDispatchError;
+  }): ISubmittableResult =>
+    ({
+      filterRecords: (mod: string, eventName: string) => {
+        const error =
+          mod === 'system' && eventName === 'ExtrinsicFailed'
+            ? extrinsicFailed
+            : ethExtrinsicRevert;
+
+        return error ? [{ event: { data: [error] } }] : [];
+      },
+    } as unknown as ISubmittableResult);
+
+  const badOrigin = {
+    isModule: false,
+    isBadOrigin: true,
+    isCannotLookup: false,
+    isToken: false,
+    isArithmetic: false,
+    isTransactional: false,
+    type: 'BadOrigin',
+  } as unknown as SpRuntimeDispatchError;
+
+  it('should return undefined when the receipt carries neither failure event', () => {
+    expect(getExtrinsicFailure(buildReceipt({}))).toBeUndefined();
+  });
+
+  it('should report a native `system.ExtrinsicFailed`', () => {
+    const error = getExtrinsicFailure(buildReceipt({ extrinsicFailed: badOrigin }));
+
+    expect(error?.code).toBe(ErrorCode.TransactionReverted);
+    expect(error?.message).toBe('Bad origin');
+  });
+
+  it('should report a `revive.EthExtrinsicRevert`, which the Ethereum path emits instead', () => {
+    const error = getExtrinsicFailure(buildReceipt({ ethExtrinsicRevert: badOrigin }));
+
+    expect(error?.code).toBe(ErrorCode.TransactionReverted);
+    expect(error?.message).toBe('Bad origin');
   });
 });
 
@@ -461,6 +514,102 @@ describe('pollForTransactionFinalization', () => {
 
       // both subscriptions must be torn down once the transaction settles
       expect(unsubNew).toHaveBeenCalled();
+      expect(unsubFinalized).toHaveBeenCalled();
+    });
+
+    it('should ignore any head that arrives after the transaction has settled', async () => {
+      mockBlockWithTx();
+
+      // a second head of each kind arrives once the transaction has already been located
+      const unsubNew = mockHeadSubscription('subscribeNewHeads', [
+        new BigNumber(2),
+        new BigNumber(3),
+      ]);
+      mockHeadSubscription('subscribeFinalizedHeads', [new BigNumber(2), new BigNumber(3)]);
+
+      const onInBlock = jest.fn();
+
+      const result = await subscribeForTransactionFinalization(
+        extrinsicHashMatcher(txHash),
+        startingBlock,
+        context,
+        onInBlock
+      );
+
+      // let the trailing callbacks drain, so a second settle would be observed if it happened
+      await fakePromise(3);
+
+      expect(result).toEqual(expect.objectContaining({ txIndex: 0, txHash }));
+      // inclusion is reported exactly once, no matter how many best heads follow
+      expect(onInBlock).toHaveBeenCalledTimes(1);
+      expect(unsubNew).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not scan the best head when no inclusion callback was passed', async () => {
+      mockBlockWithTx();
+
+      mockHeadSubscription('subscribeNewHeads', [new BigNumber(2)]);
+      mockHeadSubscription('subscribeFinalizedHeads', [new BigNumber(2)]);
+
+      const result = await subscribeForTransactionFinalization(
+        extrinsicHashMatcher(txHash),
+        startingBlock,
+        context
+      );
+
+      expect(result).toEqual(expect.objectContaining({ txIndex: 0, txHash }));
+    });
+
+    it('should keep scanning the best head while it does not carry the transaction', async () => {
+      dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+        returnValue: dsMockUtils.createMockBlockHash('someBlockHash'),
+      });
+
+      dsMockUtils.createRpcMock('chain', 'getBlock', {
+        returnValue: dsMockUtils.createMockSignedBlock({
+          block: dsMockUtils.createMockBlock({
+            header: dsMockUtils.createMockHeader(),
+            extrinsics: dsMockUtils.createMockExtrinsics([
+              { toHex: (): string => '0x', hash: dsMockUtils.createMockHash('someOtherTx') },
+            ]),
+          }),
+        }),
+      });
+
+      dsMockUtils.createQueryMock('system', 'events', { returnValue: [] });
+
+      mockHeadSubscription('subscribeNewHeads', [new BigNumber(2)]);
+      const unsubNew = mockHeadSubscription('subscribeFinalizedHeads', [new BigNumber(2)]);
+
+      const onInBlock = jest.fn();
+
+      await expect(
+        subscribeForTransactionFinalization(
+          extrinsicHashMatcher(txHash),
+          startingBlock,
+          context,
+          onInBlock,
+          { maxFinalizedBlocks: 1 }
+        )
+      ).rejects.toThrowError('The block containing the transaction was not found');
+
+      // the best head moved on without the transaction, so nothing was reported as included
+      expect(onInBlock).not.toHaveBeenCalled();
+      expect(unsubNew).toHaveBeenCalled();
+    });
+
+    it('should reject and unsubscribe if a scan fails', async () => {
+      const scanError = new Error('the node went away');
+
+      dsMockUtils.createRpcMock('chain', 'getBlockHash').mockRejectedValue(scanError);
+
+      mockHeadSubscription('subscribeNewHeads', []);
+      const unsubFinalized = mockHeadSubscription('subscribeFinalizedHeads', [new BigNumber(2)]);
+
+      await expect(
+        subscribeForTransactionFinalization(extrinsicHashMatcher(txHash), startingBlock, context)
+      ).rejects.toThrowError(scanError);
+
       expect(unsubFinalized).toHaveBeenCalled();
     });
 

--- a/src/base/__tests__/utils.ts
+++ b/src/base/__tests__/utils.ts
@@ -1,8 +1,14 @@
+import { SpRuntimeDispatchError } from '@polkadot/types/lookup';
 import { TypeDef } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
-import { extrinsicHashMatcher, pollForTransactionFinalization, processType } from '~/base/utils';
+import {
+  dispatchErrorToMessage,
+  extrinsicHashMatcher,
+  pollForTransactionFinalization,
+  processType,
+} from '~/base/utils';
 import { PolymeshError } from '~/internal';
 import { dsMockUtils } from '~/testUtils/mocks';
 import {
@@ -24,6 +30,95 @@ describe('Process Type', () => {
     const result = processType(rawType, name);
 
     expect(result.type).toBe(TransactionArgumentType.Unknown);
+  });
+});
+
+describe('dispatchErrorToMessage', () => {
+  /**
+   * Build a `SpRuntimeDispatchError`-shaped mock for a given variant
+   */
+  const buildDispatchError = (
+    variant: string,
+    extra: Record<string, unknown> = {}
+  ): SpRuntimeDispatchError =>
+    ({
+      isModule: false,
+      isBadOrigin: false,
+      isCannotLookup: false,
+      isToken: false,
+      isArithmetic: false,
+      isTransactional: false,
+      type: variant,
+      ...extra,
+    } as unknown as SpRuntimeDispatchError);
+
+  it('should resolve a Module error through chain metadata', () => {
+    const error = buildDispatchError('Module', {
+      isModule: true,
+      asModule: {
+        registry: {
+          findMetaError: (): unknown => ({
+            section: 'identity',
+            name: 'AlreadyLinked',
+            docs: ['One secondary or primary key can only belong to one DID'],
+          }),
+        },
+      },
+    });
+
+    expect(dispatchErrorToMessage(error)).toBe(
+      'identity.AlreadyLinked: One secondary or primary key can only belong to one DID'
+    );
+  });
+
+  it('should name a Token error rather than reporting it as unknown', () => {
+    // the common failure when an Account cannot cover a transfer
+    const error = buildDispatchError('Token', {
+      isToken: true,
+      asToken: { type: 'FundsUnavailable' },
+    });
+
+    expect(dispatchErrorToMessage(error)).toBe('Token error: FundsUnavailable');
+  });
+
+  it('should name Arithmetic and Transactional errors', () => {
+    expect(
+      dispatchErrorToMessage(
+        buildDispatchError('Arithmetic', {
+          isArithmetic: true,
+          asArithmetic: { type: 'Overflow' },
+        })
+      )
+    ).toBe('Arithmetic error: Overflow');
+
+    expect(
+      dispatchErrorToMessage(
+        buildDispatchError('Transactional', {
+          isTransactional: true,
+          asTransactional: { type: 'LimitReached' },
+        })
+      )
+    ).toBe('Transactional error: LimitReached');
+  });
+
+  it('should report BadOrigin and CannotLookup', () => {
+    expect(dispatchErrorToMessage(buildDispatchError('BadOrigin', { isBadOrigin: true }))).toBe(
+      'Bad origin'
+    );
+    expect(
+      dispatchErrorToMessage(buildDispatchError('CannotLookup', { isCannotLookup: true }))
+    ).toBe('Could not lookup information required to validate the transaction');
+  });
+
+  it('should fall back to the variant name for any other error', () => {
+    // a variant with no dedicated handling still produces something actionable
+    expect(dispatchErrorToMessage(buildDispatchError('Exhausted'))).toBe(
+      'Dispatch error: Exhausted'
+    );
+  });
+
+  it('should only report "Unknown error" when there is genuinely nothing to report', () => {
+    expect(dispatchErrorToMessage(buildDispatchError(''))).toBe('Unknown error');
   });
 });
 

--- a/src/base/__tests__/utils.ts
+++ b/src/base/__tests__/utils.ts
@@ -8,6 +8,7 @@ import {
   extrinsicHashMatcher,
   pollForTransactionFinalization,
   processType,
+  subscribeForTransactionFinalization,
 } from '~/base/utils';
 import { PolymeshError } from '~/internal';
 import { dsMockUtils } from '~/testUtils/mocks';
@@ -147,8 +148,8 @@ describe('pollForTransactionFinalization', () => {
 
   it('should return finalized transaction info', async () => {
     context.getLatestBlock.mockResolvedValue(new BigNumber(2));
-    dsMockUtils.createQueryMock('system', 'blockHash', {
-      multi: [dsMockUtils.createMockBlockHash('someBlockHash')],
+    dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+      returnValue: dsMockUtils.createMockBlockHash('someBlockHash'),
     });
 
     dsMockUtils.createRpcMock('chain', 'getBlock', {
@@ -202,8 +203,8 @@ describe('pollForTransactionFinalization', () => {
     const otherHash = dsMockUtils.createMockHash('otherHash');
 
     context.getLatestBlock.mockResolvedValue(new BigNumber(2));
-    dsMockUtils.createQueryMock('system', 'blockHash', {
-      multi: [dsMockUtils.createMockBlockHash('someBlockHash')],
+    dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+      returnValue: dsMockUtils.createMockBlockHash('someBlockHash'),
     });
 
     dsMockUtils.createRpcMock('chain', 'getBlock', {
@@ -235,6 +236,242 @@ describe('pollForTransactionFinalization', () => {
         events: [],
       })
     );
+  });
+
+  it('should report inclusion before finalization, without letting it decide the result', async () => {
+    /*
+     * the extrinsic lands in block 2 while only block 1 is finalized, so inclusion is reported
+     *   straight away but the returned result must still wait for block 2 to be finalized
+     */
+    context.getLatestBlock
+      .mockResolvedValueOnce(new BigNumber(1))
+      .mockResolvedValue(new BigNumber(2));
+
+    dsMockUtils.createRpcMock('chain', 'getHeader', {
+      returnValue: dsMockUtils.createMockHeader({
+        parentHash: dsMockUtils.createMockHash(),
+        number: dsMockUtils.createMockCompact(dsMockUtils.createMockU32(new BigNumber(2))),
+        stateRoot: dsMockUtils.createMockHash(),
+        extrinsicsRoot: dsMockUtils.createMockHash(),
+      }),
+    });
+
+    dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+      returnValue: dsMockUtils.createMockBlockHash('someBlockHash'),
+    });
+
+    dsMockUtils.createRpcMock('chain', 'getBlock', {
+      returnValue: dsMockUtils.createMockSignedBlock({
+        block: dsMockUtils.createMockBlock({
+          header: dsMockUtils.createMockHeader(),
+          extrinsics: dsMockUtils.createMockExtrinsics([
+            { toHex: (): string => '0x', hash: txHash },
+          ]),
+        }),
+      }),
+    });
+
+    dsMockUtils.createQueryMock('system', 'events', { returnValue: [] });
+
+    const onInBlock = jest.fn();
+
+    const result = await pollForTransactionFinalization(
+      extrinsicHashMatcher(txHash),
+      startingBlock,
+      context,
+      { delayMs: 0, maxAttempts: 10 },
+      onInBlock
+    );
+
+    expect(onInBlock).toHaveBeenCalledTimes(1);
+    expect(onInBlock).toHaveBeenCalledWith(
+      expect.objectContaining({ blockNumber: new BigNumber(2), txIndex: 0 })
+    );
+    // the returned result is still the finalized one
+    expect(result).toEqual(expect.objectContaining({ txIndex: 0, txHash }));
+  });
+
+  it('should skip a block whose hash cannot be resolved yet, rather than fetching it', async () => {
+    /*
+     * the `system.blockHash` storage map only records a block's hash once its child is
+     *   initialized, so the current best block can read back as the zero hash. An unresolvable
+     *   hash must be skipped and retried on a later pass rather than fetched
+     */
+    context.getLatestBlock.mockResolvedValue(new BigNumber(1));
+
+    dsMockUtils.createRpcMock('chain', 'getHeader', {
+      returnValue: dsMockUtils.createMockHeader({
+        parentHash: dsMockUtils.createMockHash(),
+        number: dsMockUtils.createMockCompact(dsMockUtils.createMockU32(new BigNumber(2))),
+        stateRoot: dsMockUtils.createMockHash(),
+        extrinsicsRoot: dsMockUtils.createMockHash(),
+      }),
+    });
+
+    // the head block's hash is not yet readable
+    dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+      returnValue: dsMockUtils.createMockBlockHash(),
+    });
+
+    const getBlockMock = dsMockUtils.createRpcMock('chain', 'getBlock');
+
+    dsMockUtils.createQueryMock('system', 'events', { returnValue: [] });
+
+    await expect(
+      pollForTransactionFinalization(extrinsicHashMatcher(txHash), startingBlock, context, {
+        delayMs: 0,
+        maxAttempts: 2,
+      })
+    ).rejects.toThrow('The block containing the transaction was not found');
+
+    expect(getBlockMock).not.toHaveBeenCalled();
+  });
+
+  it('should not report inclusion when the containing block is already finalized', async () => {
+    context.getLatestBlock.mockResolvedValue(new BigNumber(2));
+
+    dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+      returnValue: dsMockUtils.createMockBlockHash('someBlockHash'),
+    });
+
+    dsMockUtils.createRpcMock('chain', 'getBlock', {
+      returnValue: dsMockUtils.createMockSignedBlock({
+        block: dsMockUtils.createMockBlock({
+          header: dsMockUtils.createMockHeader(),
+          extrinsics: dsMockUtils.createMockExtrinsics([
+            { toHex: (): string => '0x', hash: txHash },
+          ]),
+        }),
+      }),
+    });
+
+    dsMockUtils.createQueryMock('system', 'events', { returnValue: [] });
+
+    const onInBlock = jest.fn();
+
+    await pollForTransactionFinalization(
+      extrinsicHashMatcher(txHash),
+      startingBlock,
+      context,
+      { delayMs: 0, maxAttempts: 10 },
+      onInBlock
+    );
+
+    expect(onInBlock).not.toHaveBeenCalled();
+  });
+
+  describe('subscribeForTransactionFinalization', () => {
+    /**
+     * Drive a head subscription, invoking its callback with each of the given block numbers
+     */
+    const mockHeadSubscription = (
+      rpcName: 'subscribeNewHeads' | 'subscribeFinalizedHeads',
+      blockNumbers: BigNumber[]
+    ): jest.Mock => {
+      const unsub = jest.fn();
+      const mock = dsMockUtils.createRpcMock('chain', rpcName);
+
+      mock.mockImplementation((callback: (header: unknown) => void) => {
+        blockNumbers.forEach(blockNumber =>
+          setImmediate(() =>
+            callback({
+              number: dsMockUtils.createMockCompact(dsMockUtils.createMockU32(blockNumber)),
+            })
+          )
+        );
+
+        return Promise.resolve(unsub);
+      });
+
+      return unsub;
+    };
+
+    const mockBlockWithTx = (): void => {
+      dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+        returnValue: dsMockUtils.createMockBlockHash('someBlockHash'),
+      });
+
+      dsMockUtils.createRpcMock('chain', 'getBlock', {
+        returnValue: dsMockUtils.createMockSignedBlock({
+          block: dsMockUtils.createMockBlock({
+            header: dsMockUtils.createMockHeader(),
+            extrinsics: dsMockUtils.createMockExtrinsics([
+              { toHex: (): string => '0x', hash: txHash },
+            ]),
+          }),
+        }),
+      });
+
+      dsMockUtils.createQueryMock('system', 'events', { returnValue: [] });
+    };
+
+    it('should resolve from a finalized block and report inclusion beforehand', async () => {
+      mockBlockWithTx();
+
+      // seen at the best head first, finalized a moment later
+      const unsubNew = mockHeadSubscription('subscribeNewHeads', [new BigNumber(2)]);
+      const unsubFinalized = mockHeadSubscription('subscribeFinalizedHeads', [new BigNumber(2)]);
+
+      const onInBlock = jest.fn();
+
+      const result = await subscribeForTransactionFinalization(
+        extrinsicHashMatcher(txHash),
+        startingBlock,
+        context,
+        onInBlock
+      );
+
+      expect(onInBlock).toHaveBeenCalledWith(
+        expect.objectContaining({ blockNumber: new BigNumber(2), txIndex: 0 })
+      );
+      expect(result).toEqual(expect.objectContaining({ txIndex: 0, txHash }));
+
+      // both subscriptions must be torn down once the transaction settles
+      expect(unsubNew).toHaveBeenCalled();
+      expect(unsubFinalized).toHaveBeenCalled();
+    });
+
+    it('should throw and unsubscribe if the transaction is never found', async () => {
+      dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+        returnValue: dsMockUtils.createMockBlockHash('someBlockHash'),
+      });
+
+      // blocks are produced, but none of them carry the transaction
+      dsMockUtils.createRpcMock('chain', 'getBlock', {
+        returnValue: dsMockUtils.createMockSignedBlock({
+          block: dsMockUtils.createMockBlock({
+            header: dsMockUtils.createMockHeader(),
+            extrinsics: dsMockUtils.createMockExtrinsics([
+              { toHex: (): string => '0x', hash: dsMockUtils.createMockHash('someOtherTx') },
+            ]),
+          }),
+        }),
+      });
+
+      mockHeadSubscription('subscribeNewHeads', []);
+      const unsubFinalized = mockHeadSubscription(
+        'subscribeFinalizedHeads',
+        // more finalized blocks than the search is willing to wait for
+        [1, 2, 3].map(n => new BigNumber(n + 1))
+      );
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.UnexpectedError,
+        message: 'The block containing the transaction was not found',
+      });
+
+      await expect(
+        subscribeForTransactionFinalization(
+          extrinsicHashMatcher(txHash),
+          startingBlock,
+          context,
+          undefined,
+          { maxFinalizedBlocks: 3 }
+        )
+      ).rejects.toThrowError(expectedError);
+
+      expect(unsubFinalized).toHaveBeenCalled();
+    });
   });
 
   it('should throw an error if transaction location is not found within polling window', () => {

--- a/src/base/__tests__/utils.ts
+++ b/src/base/__tests__/utils.ts
@@ -2,7 +2,7 @@ import { TypeDef } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
-import { pollForTransactionFinalization, processType } from '~/base/utils';
+import { extrinsicHashMatcher, pollForTransactionFinalization, processType } from '~/base/utils';
 import { PolymeshError } from '~/internal';
 import { dsMockUtils } from '~/testUtils/mocks';
 import {
@@ -88,12 +88,55 @@ describe('pollForTransactionFinalization', () => {
       ],
     });
 
-    const result = await pollForTransactionFinalization(txHash, startingBlock, context);
+    const result = await pollForTransactionFinalization(
+      extrinsicHashMatcher(txHash),
+      startingBlock,
+      context
+    );
 
     expect(result).toEqual(
       expect.objectContaining({
         txIndex: 0,
         txHash,
+        events: [],
+      })
+    );
+  });
+
+  it('should locate the extrinsic with an arbitrary matcher and read its hash back', async () => {
+    const otherHash = dsMockUtils.createMockHash('otherHash');
+
+    context.getLatestBlock.mockResolvedValue(new BigNumber(2));
+    dsMockUtils.createQueryMock('system', 'blockHash', {
+      multi: [dsMockUtils.createMockBlockHash('someBlockHash')],
+    });
+
+    dsMockUtils.createRpcMock('chain', 'getBlock', {
+      returnValue: dsMockUtils.createMockSignedBlock({
+        block: dsMockUtils.createMockBlock({
+          header: dsMockUtils.createMockHeader(),
+          extrinsics: dsMockUtils.createMockExtrinsics([
+            { toHex: (): string => '0x', hash: txHash },
+            { toHex: (): string => '0x', hash: otherHash },
+          ]),
+        }),
+      }),
+    });
+
+    dsMockUtils.createQueryMock('system', 'events', {
+      returnValue: [],
+    });
+
+    const result = await pollForTransactionFinalization(
+      extrinsic => extrinsic.hash.toString() === 'otherHash',
+      startingBlock,
+      context
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        txIndex: 1,
+        txHash: otherHash,
         events: [],
       })
     );
@@ -106,7 +149,10 @@ describe('pollForTransactionFinalization', () => {
     });
 
     return expect(
-      pollForTransactionFinalization(txHash, startingBlock, context, { delayMs: 0, maxAttempts: 0 })
+      pollForTransactionFinalization(extrinsicHashMatcher(txHash), startingBlock, context, {
+        delayMs: 0,
+        maxAttempts: 0,
+      })
     ).rejects.toThrow(expectedError);
   });
 });

--- a/src/base/ethTransaction.ts
+++ b/src/base/ethTransaction.ts
@@ -263,12 +263,12 @@ export async function buildEthTransactionRequest(
     ...(nonce ? { nonce } : {}),
     ...(eip1559
       ? {
-          type: 2 as const,
+          type: '0x2' as const,
           maxFeePerGas: toQuantityHex(gasPrice),
           maxPriorityFeePerGas: toQuantityHex(new BigNumber(0)),
         }
       : {
-          type: 0 as const,
+          type: '0x0' as const,
           gasPrice: toQuantityHex(gasPrice),
         }),
   };
@@ -319,12 +319,12 @@ export async function buildDetachedEthTransactionRequest(
     nonce,
     ...(eip1559
       ? {
-          type: 2 as const,
+          type: '0x2' as const,
           maxFeePerGas: toQuantityHex(gasPrice),
           maxPriorityFeePerGas: toQuantityHex(new BigNumber(0)),
         }
       : {
-          type: 0 as const,
+          type: '0x0' as const,
           gasPrice: toQuantityHex(gasPrice),
         }),
   };

--- a/src/base/ethTransaction.ts
+++ b/src/base/ethTransaction.ts
@@ -1,0 +1,437 @@
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { GenericExtrinsic } from '@polkadot/types';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { HexString } from '@polkadot/util/types';
+import { keccakAsHex } from '@polkadot/util-crypto';
+import BigNumber from 'bignumber.js';
+
+import { EthSigner, EthTransactionRequest } from '~/base/types';
+import { extrinsicHashMatcher, ExtrinsicMatcher } from '~/base/utils';
+import { Context, PolymeshError } from '~/internal';
+import { ErrorCode } from '~/types';
+import { PollingSubmission, SubscriptionSubmission } from '~/types/internal';
+import { u64ToBigNumber } from '~/utils/conversion';
+import { ethAddressFromSs58, parseEthTransactError } from '~/utils/eth';
+
+/**
+ * @hidden
+ *
+ * Which of the two submission strategies an {@link EthSigner} supports. The SDK reads
+ *   `capabilities` to make this decision; it never probes the provider itself
+ *
+ * - `sdkBroadcast` (`signTransaction`): the signer returns raw signed bytes, and the SDK submits
+ *   and tracks the transaction the same way it would a native one. The SDK owns the nonce
+ * - `walletBroadcast` (`sendTransaction`): the wallet signs AND broadcasts, so the wallet owns the
+ *   nonce and the SDK correlates the result by scanning blocks for the matching
+ *   `revive.ethTransact` extrinsic
+ */
+export type EthSubmissionMode = 'sdkBroadcast' | 'walletBroadcast';
+
+/**
+ * @hidden
+ */
+export function getEthSubmissionMode(ethSigner: EthSigner): EthSubmissionMode {
+  if (ethSigner.capabilities.signTransaction) {
+    return 'sdkBroadcast';
+  }
+
+  if (ethSigner.capabilities.sendTransaction) {
+    return 'walletBroadcast';
+  }
+
+  throw new PolymeshError({
+    code: ErrorCode.General,
+    message:
+      'The attached Ethereum signer does not support signing or sending transactions. Please report this to the Polymesh team',
+  });
+}
+
+/**
+ * @hidden
+ *
+ * `0x`-prefixed, minimal (no leading zeros) hex "quantity" encoding, as used throughout the
+ *   Ethereum JSON-RPC spec for `gas`, `gasPrice`, `chainId`, `nonce`, etc
+ */
+function toQuantityHex(value: BigNumber): HexString {
+  return `0x${value.integerValue(BigNumber.ROUND_FLOOR).toString(16)}` as HexString;
+}
+
+/**
+ * @hidden
+ */
+export interface BuildEthTransactionRequestParams {
+  context: Context;
+  /** ss58 address of the Ethereum-derived Account signing the transaction */
+  signingAddress: string;
+  /** the composed transaction (or MultiSig-wrapped proposal), whose SCALE-encoded call becomes the `data` field */
+  composedTx: SubmittableExtrinsic<'promise', ISubmittableResult>;
+  ethSigner: EthSigner;
+  /**
+   * explicit nonce (`ProcedureOpts.nonce`). Only accepted when the SDK broadcasts; passing it
+   *   when the wallet broadcasts is a `ValidationError`, since the wallet owns the nonce there
+   */
+  nonce?: BigNumber;
+  /**
+   * multiplier applied to the dry run's `ethGas` to build the `gas` field passed to the signer,
+   *   so headroom can be added for calls whose weight depends on state read at execution time.
+   *   Defaults to `1`, i.e. no headroom
+   */
+  gasMultiplier?: BigNumber;
+}
+
+/**
+ * @hidden
+ */
+export interface EthTransactionBuildResult {
+  request: EthTransactionRequest;
+  /**
+   * the dry run's raw `ethGas`, i.e. before `gasMultiplier` is applied. This is what fee
+   *   derivation is based on, since the multiplier is headroom for the wallet rather than part
+   *   of the fee estimate
+   */
+  rawEthGas: BigNumber;
+  gasPrice: BigNumber;
+}
+
+/**
+ * @hidden
+ */
+export interface EthDryRunResult {
+  from: HexString;
+  to: HexString;
+  calldata: HexString;
+  /** the dry run's raw `ethGas`, before any headroom multiplier is applied */
+  rawEthGas: BigNumber;
+  gasPrice: BigNumber;
+  chainId: BigNumber;
+}
+
+/**
+ * @hidden
+ *
+ * Perform the mandatory dry run pre-flight for a Polymesh call carried through the
+ *   `revive` pallet's sentinel address. This is the SDK's only pre-flight signal, and doing it
+ *   over the Substrate connection means a structured error arrives before the wallet is ever
+ *   consulted
+ *
+ * Split out from {@link buildEthTransactionRequest} so that fee estimation
+ *   ({@link base/PolymeshTransactionBase!PolymeshTransactionBase.getTotalFees | getTotalFees}) can
+ *   use it without requiring an {@link EthSigner} to be attached
+ *
+ * @throws the parsed dry run error (via {@link utils/eth!parseEthTransactError}) if the dry run itself fails
+ */
+export async function dryRunEthTransaction(
+  context: Context,
+  signingAddress: string,
+  composedTx: SubmittableExtrinsic<'promise', ISubmittableResult>
+): Promise<EthDryRunResult> {
+  const {
+    polymeshApi: { call },
+  } = context;
+
+  const from = ethAddressFromSs58(signingAddress, context.ss58Format);
+  const [to, gasPriceRaw] = await Promise.all([
+    context.getEthRuntimePalletsAddress(),
+    call.reviveApi.gasPrice(),
+  ]);
+  const chainId = context.getEthChainId();
+  const calldata = composedTx.method.toHex() as HexString;
+  const gasPrice = new BigNumber(gasPriceRaw.toString());
+
+  const dryRun = await call.reviveApi.ethTransactWithConfig(
+    {
+      from,
+      to,
+      input: { data: calldata },
+      value: 0,
+    },
+    {}
+  );
+
+  if (dryRun.isErr) {
+    throw parseEthTransactError(dryRun.asErr, context);
+  }
+
+  const { ethGas: rawEthGasCodec } = dryRun.asOk;
+  const rawEthGas = new BigNumber(rawEthGasCodec.toString());
+
+  return { from: from as HexString, to: to as HexString, calldata, rawEthGas, gasPrice, chainId };
+}
+
+/**
+ * @hidden
+ *
+ * Build the {@link EthTransactionRequest} that carries a Polymesh runtime call through the
+ *   `revive` pallet's sentinel address, performing the mandatory dry run pre-flight along the
+ *   way
+ *
+ * @throws
+ * - the parsed dry run error (via {@link utils/eth!parseEthTransactError}) if the dry run itself fails
+ * - `ValidationError` if `nonce` is passed while the signer can only broadcast, and so owns the
+ *   nonce itself
+ */
+export async function buildEthTransactionRequest(
+  params: BuildEthTransactionRequestParams
+): Promise<EthTransactionBuildResult> {
+  const {
+    context,
+    signingAddress,
+    composedTx,
+    ethSigner,
+    nonce: nonceOverride,
+    gasMultiplier = new BigNumber(1),
+  } = params;
+
+  const mode = getEthSubmissionMode(ethSigner);
+
+  if (mode === 'walletBroadcast' && nonceOverride) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message:
+        'The nonce cannot be set explicitly when the Ethereum signer broadcasts the transaction itself. The wallet is responsible for nonce management in this mode',
+    });
+  }
+
+  const { from, to, calldata, rawEthGas, gasPrice, chainId } = await dryRunEthTransaction(
+    context,
+    signingAddress,
+    composedTx
+  );
+
+  const gasToUse = BigNumber.max(
+    rawEthGas.multipliedBy(gasMultiplier).integerValue(BigNumber.ROUND_CEIL),
+    rawEthGas
+  );
+
+  let nonce: HexString | undefined;
+  if (mode === 'sdkBroadcast') {
+    if (nonceOverride) {
+      nonce = toQuantityHex(nonceOverride);
+    } else {
+      const {
+        polymeshApi: { call },
+      } = context;
+      const onChainNonce = await call.reviveApi.nonce(from);
+      nonce = toQuantityHex(new BigNumber(onChainNonce.toString()));
+    }
+  }
+
+  const { eip1559 } = ethSigner.capabilities;
+
+  const request: EthTransactionRequest = {
+    from,
+    to,
+    data: calldata,
+    value: '0x0',
+    gas: toQuantityHex(gasToUse),
+    chainId: toQuantityHex(chainId),
+    ...(nonce ? { nonce } : {}),
+    ...(eip1559
+      ? {
+          type: 2 as const,
+          maxFeePerGas: toQuantityHex(gasPrice),
+          maxPriorityFeePerGas: toQuantityHex(new BigNumber(0)),
+        }
+      : {
+          type: 0 as const,
+          gasPrice: toQuantityHex(gasPrice),
+        }),
+  };
+
+  return { request, rawEthGas, gasPrice };
+}
+
+/**
+ * @hidden
+ *
+ * Build an {@link EthTransactionRequest} for detached/custody signing
+ * ({@link base/PolymeshTransactionBase!PolymeshTransactionBase.toEthSignablePayload | toEthSignablePayload}),
+ *   where there is no {@link EthSigner} attached to consult for routing. The nonce is always
+ *   resolved (either the caller's `ProcedureOpts.nonce`, or fetched on-chain), since a detached
+ *   signer cannot own the nonce the way a broadcasting wallet does
+ */
+export async function buildDetachedEthTransactionRequest(
+  context: Context,
+  signingAddress: string,
+  composedTx: SubmittableExtrinsic<'promise', ISubmittableResult>,
+  eip1559: boolean,
+  nonceOverride?: BigNumber
+): Promise<EthTransactionRequest> {
+  const { from, to, calldata, rawEthGas, gasPrice, chainId } = await dryRunEthTransaction(
+    context,
+    signingAddress,
+    composedTx
+  );
+
+  let nonce: HexString;
+  if (nonceOverride) {
+    nonce = toQuantityHex(nonceOverride);
+  } else {
+    const {
+      polymeshApi: { call },
+    } = context;
+    const onChainNonce = await call.reviveApi.nonce(from);
+    nonce = toQuantityHex(new BigNumber(onChainNonce.toString()));
+  }
+
+  return {
+    from,
+    to,
+    data: calldata,
+    value: '0x0',
+    gas: toQuantityHex(rawEthGas),
+    chainId: toQuantityHex(chainId),
+    nonce,
+    ...(eip1559
+      ? {
+          type: 2 as const,
+          maxFeePerGas: toQuantityHex(gasPrice),
+          maxPriorityFeePerGas: toQuantityHex(new BigNumber(0)),
+        }
+      : {
+          type: 0 as const,
+          gasPrice: toQuantityHex(gasPrice),
+        }),
+  };
+}
+
+/**
+ * @hidden
+ *
+ * Derive the network fee for a transaction submitted through the `revive` pallet's sentinel
+ *   address:
+ *
+ * ```
+ * feeInBaseUnits = ethGas * gasPrice / nativeToEthRatio
+ * ```
+ *
+ * The result is returned as a **display POLYX value**, i.e. shifted down by the chain's 6
+ *   decimals, so that it is directly comparable with everything else in `PayingAccountFees` —
+ *   protocol fees and Account balances both arrive that way, via `balanceToBigNumber`. Returning
+ *   base units here would make the Ethereum path report fees 10^6 too large, and every fee check
+ *   against a balance would fail
+ *
+ * @note the rounding is applied to whole base units *before* the shift, since a fee cannot be a
+ *   fraction of a base unit
+ * @note this is a slight, safe overestimate of the fee the chain actually charges — measured at
+ *   1.008-1.011x. It does **not** include protocol fees, which are charged separately and must
+ *   still be summed in by the caller
+ */
+export function calculateEthGasFee(
+  rawEthGas: BigNumber,
+  gasPrice: BigNumber,
+  nativeToEthRatio: BigNumber
+): BigNumber {
+  return rawEthGas
+    .multipliedBy(gasPrice)
+    .dividedBy(nativeToEthRatio)
+    .integerValue(BigNumber.ROUND_CEIL)
+    .shiftedBy(-6);
+}
+
+/**
+ * @hidden
+ *
+ * Retrieve `consts.revive.nativeToEthRatio` as a `BigNumber`
+ */
+export function getNativeToEthRatio(context: Context): BigNumber {
+  return u64ToBigNumber(context.polymeshApi.consts.revive.nativeToEthRatio);
+}
+
+/**
+ * @hidden
+ *
+ * Build the predicate that correlates an Ethereum transaction hash (returned by a broadcasting
+ *   wallet's `sendTransaction`) to the Substrate extrinsic that carries it:
+ *
+ * ```
+ * extrinsic.method.section === 'revive' &&
+ * extrinsic.method.method === 'ethTransact' &&
+ * keccakAsHex(extrinsic.args[0].toU8a(true)) === ethTxHash
+ * ```
+ *
+ * This is deterministic, not a heuristic: the Ethereum transaction hash is `keccak256` of the raw
+ *   signed transaction, and those exact bytes are the `payload` argument of the `revive.ethTransact`
+ *   extrinsic recorded in the block — byte-identical, including in blocks carrying several
+ *   Ethereum extrinsics
+ */
+export function ethTransactKeccakMatcher(ethTxHash: string): ExtrinsicMatcher {
+  const normalizedHash = ethTxHash.toLowerCase();
+
+  return (extrinsic: GenericExtrinsic): boolean => {
+    if (extrinsic.method.section !== 'revive' || extrinsic.method.method !== 'ethTransact') {
+      return false;
+    }
+
+    const [payload] = extrinsic.args;
+
+    if (!payload) {
+      return false;
+    }
+
+    return keccakAsHex(payload.toU8a(true)).toLowerCase() === normalizedHash;
+  };
+}
+
+/**
+ * @hidden
+ *
+ * The SDK holds the raw signed bytes and submits them itself via
+ *   `api.tx.revive.ethTransact(raw)`. Since this is a *bare* (unsigned) extrinsic — the
+ *   signature is embedded in the Ethereum payload itself — it is broadcast with `.send()`
+ *   rather than `.signAndSend()`, exactly like the offline-signed path in
+ *   `Network.submitTransaction`. From here on, the lifecycle is identical to the native path:
+ *   same `ISubmittableResult` status transitions, same `outer.hash` semantics
+ */
+export function buildSdkBroadcastSubmission(
+  context: Context,
+  rawSignedTx: HexString
+): { subscription: SubscriptionSubmission; polling: PollingSubmission } {
+  const outer = context.polymeshApi.tx.revive.ethTransact(rawSignedTx);
+
+  return {
+    subscription: {
+      subscribe: callback => outer.send(callback),
+      getTxHash: () => outer.hash.toString(),
+    },
+    polling: {
+      send: async (): Promise<{ txHash: string; matcher: ExtrinsicMatcher }> => {
+        const txHash = await outer.send();
+
+        return { txHash: txHash.toString(), matcher: extrinsicHashMatcher(txHash) };
+      },
+    },
+  };
+}
+
+/**
+ * @hidden
+ *
+ * The wallet signs AND broadcasts, returning the Ethereum transaction hash.
+ *   The SDK never submits anything itself here, so there is no extrinsic-status subscription
+ *   channel to attach to — the only way to locate the result is to scan blocks for the matching
+ *   `revive.ethTransact` extrinsic (via {@link ethTransactKeccakMatcher}).
+ *
+ * The block scan is shared with the native path rather than duplicated: the same
+ *   {@link ExtrinsicMatcher} drives both, so there is one implementation and one set of tests
+ */
+export function buildWalletBroadcastSubmission(
+  ethSigner: EthSigner,
+  request: EthTransactionRequest
+): PollingSubmission {
+  return {
+    send: async (): Promise<{ txHash: string; matcher: ExtrinsicMatcher }> => {
+      if (!ethSigner.sendTransaction) {
+        throw new PolymeshError({
+          code: ErrorCode.General,
+          message:
+            'The attached Ethereum signer does not implement sendTransaction. Please report this to the Polymesh team',
+        });
+      }
+
+      const ethTxHash = await ethSigner.sendTransaction(request);
+
+      return { txHash: ethTxHash, matcher: ethTransactKeccakMatcher(ethTxHash) };
+    },
+  };
+}

--- a/src/base/ethTransaction.ts
+++ b/src/base/ethTransaction.ts
@@ -16,8 +16,9 @@ import { ethAddressFromSs58, parseEthTransactError } from '~/utils/eth';
 /**
  * @hidden
  *
- * Which of the two submission strategies an {@link EthSigner} supports. The SDK reads
- *   `capabilities` to make this decision; it never probes the provider itself
+ * Which of the two submission strategies an {@link EthSigner} supports. This is derived from
+ *   which methods the signer implements, so it cannot disagree with what the signer can actually
+ *   do; the SDK never probes the provider itself
  *
  * - `sdkBroadcast` (`signTransaction`): the signer returns raw signed bytes, and the SDK submits
  *   and tracks the transaction the same way it would a native one. The SDK owns the nonce
@@ -29,21 +30,55 @@ export type EthSubmissionMode = 'sdkBroadcast' | 'walletBroadcast';
 
 /**
  * @hidden
+ *
+ * The submission mode together with the signer method that implements it, already bound to the
+ *   signer. Resolving both at once is what lets the rest of the Ethereum path stay total: there is
+ *   no point downstream at which the method might turn out to be missing
  */
-export function getEthSubmissionMode(ethSigner: EthSigner): EthSubmissionMode {
-  if (ethSigner.capabilities.signTransaction) {
-    return 'sdkBroadcast';
+export type EthSubmissionStrategy =
+  | { mode: 'sdkBroadcast'; signTransaction: NonNullable<EthSigner['signTransaction']> }
+  | { mode: 'walletBroadcast'; sendTransaction: NonNullable<EthSigner['sendTransaction']> };
+
+/**
+ * @hidden
+ *
+ * Resolve how to submit for the given signer, from the methods it actually implements.
+ *
+ * `signTransaction` wins when a signer implements both, since it lets the SDK keep control of the
+ *   nonce and of the full submission lifecycle
+ *
+ * @note the returned method is bound to the signer. Callers have to destructure it to narrow the
+ *   optional property, which would otherwise silently drop `this` for any signer implementing the
+ *   interface with ordinary class methods rather than arrow function properties
+ *
+ * @throws if the signer implements neither method
+ */
+export function getEthSubmissionStrategy(ethSigner: EthSigner): EthSubmissionStrategy {
+  const { signTransaction, sendTransaction } = ethSigner;
+
+  if (signTransaction) {
+    return { mode: 'sdkBroadcast', signTransaction: signTransaction.bind(ethSigner) };
   }
 
-  if (ethSigner.capabilities.sendTransaction) {
-    return 'walletBroadcast';
+  if (sendTransaction) {
+    return { mode: 'walletBroadcast', sendTransaction: sendTransaction.bind(ethSigner) };
   }
 
   throw new PolymeshError({
     code: ErrorCode.General,
     message:
-      'The attached Ethereum signer does not support signing or sending transactions. Please report this to the Polymesh team',
+      'The attached Ethereum signer implements neither signTransaction nor sendTransaction, so it cannot submit a transaction. Please report this to the Polymesh team',
   });
+}
+
+/**
+ * @hidden
+ *
+ * Whether to build an EIP-1559 (type 2) transaction for the given signer. Defaults to `true`, so
+ *   a signer only has to declare the capability when it *cannot* encode type 2
+ */
+export function supportsEip1559(ethSigner: EthSigner): boolean {
+  return ethSigner.capabilities.eip1559 ?? true;
 }
 
 /**
@@ -182,7 +217,7 @@ export async function buildEthTransactionRequest(
     gasMultiplier = new BigNumber(1),
   } = params;
 
-  const mode = getEthSubmissionMode(ethSigner);
+  const { mode } = getEthSubmissionStrategy(ethSigner);
 
   if (mode === 'walletBroadcast' && nonceOverride) {
     throw new PolymeshError({
@@ -216,7 +251,7 @@ export async function buildEthTransactionRequest(
     }
   }
 
-  const { eip1559 } = ethSigner.capabilities;
+  const eip1559 = supportsEip1559(ethSigner);
 
   const request: EthTransactionRequest = {
     from,
@@ -414,22 +449,19 @@ export function buildSdkBroadcastSubmission(
  *
  * The block scan is shared with the native path rather than duplicated: the same
  *   {@link ExtrinsicMatcher} drives both, so there is one implementation and one set of tests
+ *
+ * @param sendTransaction - the signer's `sendTransaction`, resolved by the caller. Taking the
+ *   bound method rather than the signer is what makes this total: reaching here at all means
+ *   {@link getEthSubmissionStrategy} found the method, so there is no "signer said it could broadcast
+ *   but cannot" case left to guard against
  */
 export function buildWalletBroadcastSubmission(
-  ethSigner: EthSigner,
+  sendTransaction: NonNullable<EthSigner['sendTransaction']>,
   request: EthTransactionRequest
 ): PollingSubmission {
   return {
     send: async (): Promise<{ txHash: string; matcher: ExtrinsicMatcher }> => {
-      if (!ethSigner.sendTransaction) {
-        throw new PolymeshError({
-          code: ErrorCode.General,
-          message:
-            'The attached Ethereum signer does not implement sendTransaction. Please report this to the Polymesh team',
-        });
-      }
-
-      const ethTxHash = await ethSigner.sendTransaction(request);
+      const ethTxHash = await sendTransaction(request);
 
       return { txHash: ethTxHash, matcher: ethTransactKeccakMatcher(ethTxHash) };
     },

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -2,13 +2,14 @@
 
 import { SignerPayloadJSON, SignerPayloadRaw, TypeDef } from '@polkadot/types/types';
 import { HexString } from '@polkadot/util/types';
+import { SigningManager } from '@polymeshassociation/signing-manager-types';
 import BigNumber from 'bignumber.js';
 
 import { PolymeshError as PolymeshErrorClass } from '~/base/PolymeshError';
 import { PolymeshTransaction as PolymeshTransactionClass } from '~/base/PolymeshTransaction';
 import { PolymeshTransactionBatch as PolymeshTransactionBatchClass } from '~/base/PolymeshTransactionBatch';
 import { Account } from '~/internal';
-import { Fees, TxData } from '~/types';
+import { Fees, TxData, TxTag } from '~/types';
 
 /**
  * Apply the {@link TxData} type to all args in an array
@@ -242,3 +243,98 @@ export type PolymeshTransactionBatch<
   Args extends unknown[][] = unknown[][]
 > = PolymeshTransactionBatchClass<ReturnValue, TransformedReturnValue, Args>;
 export type PolymeshError = PolymeshErrorClass;
+
+/*
+ * -------------------------------------------------------------------------------------------
+ * Ethereum key signing
+ *
+ * TODO: replace with imports from @polymeshassociation/signing-manager-types once >=3.8.0 is
+ *   published. They mirror the interfaces being added to that package, so that any real
+ *   implementation of `EthSigningManager` is usable today by structural typing.
+ * -------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Parameters for an Ethereum transaction that dispatches a Polymesh runtime call through the
+ *   `revive` pallet's sentinel address
+ *
+ * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
+ */
+export interface EthTransactionRequest {
+  /** the `0x` H160 address of the Ethereum-derived Account sending the transaction */
+  from: string;
+  /** the sentinel address, i.e. `reviveApi.runtimePalletsAddress()` */
+  to: string;
+  /** SCALE-encoded `RuntimeCall` */
+  data: HexString;
+  value: '0x0';
+  gas: HexString;
+  chainId: HexString;
+  /** set when the SDK broadcasts; omitted when the wallet broadcasts and owns the nonce */
+  nonce?: HexString;
+  // EIP-1559 when the signer supports it, else legacy gasPrice
+  maxFeePerGas?: HexString;
+  maxPriorityFeePerGas?: HexString;
+  gasPrice?: HexString;
+  /** EIP-4844 (3) / EIP-7702 (4) are rejected by the runtime and must never be emitted */
+  type?: 0 | 1 | 2;
+}
+
+/**
+ * Describes what an {@link EthSigner} is capable of. The SDK reads this to choose whether it
+ *   broadcasts the transaction itself (`signTransaction`) or the wallet does (`sendTransaction`),
+ *   and to choose the transaction type; it never probes the provider itself
+ *
+ * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
+ */
+export interface EthSignerCapabilities {
+  /** `true` if the signer can return raw signed bytes, letting the SDK broadcast and track it */
+  signTransaction: boolean;
+  /** `true` if the signer broadcasts the transaction itself, and so owns the nonce */
+  sendTransaction: boolean;
+  /** `false` for signers that only support legacy (type 0) transactions */
+  eip1559: boolean;
+}
+
+/**
+ * An Ethereum-key signer capable of signing (and optionally broadcasting) the raw Ethereum
+ *   transaction that carries a Polymesh runtime call through the `revive` pallet
+ *
+ * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
+ */
+export interface EthSigner {
+  /**
+   * What this signer can do. The SDK reads this to choose who broadcasts, and
+   * the transaction type; it never probes the provider itself.
+   */
+  readonly capabilities: EthSignerCapabilities;
+  /** raw signed transaction bytes. Preferred — lets the SDK broadcast and track natively */
+  signTransaction?(tx: EthTransactionRequest): Promise<HexString>;
+  /** wallet signs AND broadcasts; returns the Ethereum transaction hash */
+  sendTransaction?(tx: EthTransactionRequest): Promise<HexString>;
+}
+
+/**
+ * A {@link SigningManager} that additionally exposes an {@link EthSigner} for its
+ *   Ethereum-derived Accounts
+ *
+ * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
+ */
+export interface EthSigningManager extends SigningManager {
+  getEthSigner(): EthSigner;
+}
+
+/**
+ * A representation of an Ethereum transaction intended for offline/detached signing, along with
+ *   the decoded call for display
+ */
+export interface EthTransactionPayload {
+  /** the parameters that would be passed to `EthSigner.signTransaction` / `sendTransaction` */
+  transaction: EthTransactionRequest;
+  /** the transaction tag identifying the underlying Polymesh call */
+  tag: TxTag;
+  /** argument metadata for the underlying Polymesh call */
+  args: TransactionArgument[];
+  /** additional information attached to the payload, such as IDs or memos about the transaction */
+  metadata: Record<string, string>;
+}

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -306,13 +306,14 @@ export type PolymeshError = PolymeshErrorClass;
  */
 export interface EthTransactionRequest {
   /** the `0x` H160 address of the Ethereum-derived Account sending the transaction */
-  from: string;
+  from: HexString;
   /** the sentinel address, i.e. `reviveApi.runtimePalletsAddress()` */
-  to: string;
+  to: HexString;
   /** SCALE-encoded `RuntimeCall` */
   data: HexString;
   value: '0x0';
   gas: HexString;
+  /** the signer must sign for exactly this chain, never the one its provider is connected to */
   chainId: HexString;
   /** set when the SDK broadcasts; omitted when the wallet broadcasts and owns the nonce */
   nonce?: HexString;
@@ -320,36 +321,41 @@ export interface EthTransactionRequest {
   maxFeePerGas?: HexString;
   maxPriorityFeePerGas?: HexString;
   gasPrice?: HexString;
-  /** EIP-4844 (3) / EIP-7702 (4) are rejected by the runtime and must never be emitted */
-  type?: 0 | 1 | 2;
+  /**
+   * only legacy (0) and EIP-1559 (2) are emitted. EIP-2930 (1) has no use on the sentinel path,
+   *   and EIP-4844 (3) / EIP-7702 (4) are rejected by the runtime
+   */
+  type: 0 | 2;
 }
 
 /**
- * Describes what an {@link EthSigner} is capable of. The SDK reads this to choose whether it
- *   broadcasts the transaction itself (`signTransaction`) or the wallet does (`sendTransaction`),
- *   and to choose the transaction type; it never probes the provider itself
+ * Describes what an {@link EthSigner} can do beyond what the presence of its methods already
+ *   says. Whether a signer can sign or broadcast is expressed by implementing `signTransaction` /
+ *   `sendTransaction`, so this covers only what cannot be derived from the object's shape
  *
  * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
  */
 export interface EthSignerCapabilities {
-  /** `true` if the signer can return raw signed bytes, letting the SDK broadcast and track it */
-  signTransaction: boolean;
-  /** `true` if the signer broadcasts the transaction itself, and so owns the nonce */
-  sendTransaction: boolean;
-  /** `false` for signers that only support legacy (type 0) transactions */
-  eip1559: boolean;
+  /**
+   * whether the signer supports EIP-1559 (type 2) transactions. Defaults to `true` when omitted.
+   *   `false` for signers that can only encode legacy (type 0) transactions
+   */
+  eip1559?: boolean;
 }
 
 /**
  * An Ethereum-key signer capable of signing (and optionally broadcasting) the raw Ethereum
  *   transaction that carries a Polymesh runtime call through the `revive` pallet
  *
+ * At least one of `signTransaction` and `sendTransaction` must be implemented; the SDK chooses
+ *   how to submit from whichever is present
+ *
  * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
  */
 export interface EthSigner {
   /**
-   * What this signer can do. The SDK reads this to choose who broadcasts, and
-   * the transaction type; it never probes the provider itself.
+   * What this signer can do beyond what its methods imply. The SDK reads this rather than probing
+   * the provider, since probing would mean a speculative request to the user's wallet.
    */
   readonly capabilities: EthSignerCapabilities;
   /** raw signed transaction bytes. Preferred — lets the SDK broadcast and track natively */

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -2,7 +2,12 @@
 
 import { SignerPayloadJSON, SignerPayloadRaw, TypeDef } from '@polkadot/types/types';
 import { HexString } from '@polkadot/util/types';
-import { SigningManager } from '@polymeshassociation/signing-manager-types';
+import {
+  EthSigner,
+  EthSignerCapabilities,
+  EthSigningManager,
+  EthTransactionRequest,
+} from '@polymeshassociation/signing-manager-types';
 import BigNumber from 'bignumber.js';
 
 import { PolymeshError as PolymeshErrorClass } from '~/base/PolymeshError';
@@ -292,87 +297,13 @@ export type PolymeshError = PolymeshErrorClass;
  * -------------------------------------------------------------------------------------------
  * Ethereum key signing
  *
- * TODO: replace with imports from @polymeshassociation/signing-manager-types once >=3.8.0 is
- *   published. They mirror the interfaces being added to that package, so that any real
- *   implementation of `EthSigningManager` is usable today by structural typing.
+ * The interfaces themselves live in `@polymeshassociation/signing-manager-types`, since a
+ *   Signing Manager has to implement them without depending on the SDK. They are re-exported
+ *   here so that consumers reach them from `~/types` alongside everything else.
  * -------------------------------------------------------------------------------------------
  */
 
-/**
- * Parameters for an Ethereum transaction that dispatches a Polymesh runtime call through the
- *   `revive` pallet's sentinel address
- *
- * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
- */
-export interface EthTransactionRequest {
-  /** the `0x` H160 address of the Ethereum-derived Account sending the transaction */
-  from: HexString;
-  /** the sentinel address, i.e. `reviveApi.runtimePalletsAddress()` */
-  to: HexString;
-  /** SCALE-encoded `RuntimeCall` */
-  data: HexString;
-  value: '0x0';
-  gas: HexString;
-  /** the signer must sign for exactly this chain, never the one its provider is connected to */
-  chainId: HexString;
-  /** set when the SDK broadcasts; omitted when the wallet broadcasts and owns the nonce */
-  nonce?: HexString;
-  // EIP-1559 when the signer supports it, else legacy gasPrice
-  maxFeePerGas?: HexString;
-  maxPriorityFeePerGas?: HexString;
-  gasPrice?: HexString;
-  /**
-   * only legacy (0) and EIP-1559 (2) are emitted. EIP-2930 (1) has no use on the sentinel path,
-   *   and EIP-4844 (3) / EIP-7702 (4) are rejected by the runtime
-   */
-  type: 0 | 2;
-}
-
-/**
- * Describes what an {@link EthSigner} can do beyond what the presence of its methods already
- *   says. Whether a signer can sign or broadcast is expressed by implementing `signTransaction` /
- *   `sendTransaction`, so this covers only what cannot be derived from the object's shape
- *
- * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
- */
-export interface EthSignerCapabilities {
-  /**
-   * whether the signer supports EIP-1559 (type 2) transactions. Defaults to `true` when omitted.
-   *   `false` for signers that can only encode legacy (type 0) transactions
-   */
-  eip1559?: boolean;
-}
-
-/**
- * An Ethereum-key signer capable of signing (and optionally broadcasting) the raw Ethereum
- *   transaction that carries a Polymesh runtime call through the `revive` pallet
- *
- * At least one of `signTransaction` and `sendTransaction` must be implemented; the SDK chooses
- *   how to submit from whichever is present
- *
- * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
- */
-export interface EthSigner {
-  /**
-   * What this signer can do beyond what its methods imply. The SDK reads this rather than probing
-   * the provider, since probing would mean a speculative request to the user's wallet.
-   */
-  readonly capabilities: EthSignerCapabilities;
-  /** raw signed transaction bytes. Preferred — lets the SDK broadcast and track natively */
-  signTransaction?(tx: EthTransactionRequest): Promise<HexString>;
-  /** wallet signs AND broadcasts; returns the Ethereum transaction hash */
-  sendTransaction?(tx: EthTransactionRequest): Promise<HexString>;
-}
-
-/**
- * A {@link SigningManager} that additionally exposes an {@link EthSigner} for its
- *   Ethereum-derived Accounts
- *
- * TODO: replace with import from @polymeshassociation/signing-manager-types once >=3.8.0 is published
- */
-export interface EthSigningManager extends SigningManager {
-  getEthSigner(): EthSigner;
-}
+export { EthSigner, EthSignerCapabilities, EthSigningManager, EthTransactionRequest };
 
 /**
  * A representation of an Ethereum transaction intended for offline/detached signing, along with

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -2,12 +2,7 @@
 
 import { SignerPayloadJSON, SignerPayloadRaw, TypeDef } from '@polkadot/types/types';
 import { HexString } from '@polkadot/util/types';
-import {
-  EthSigner,
-  EthSignerCapabilities,
-  EthSigningManager,
-  EthTransactionRequest,
-} from '@polymeshassociation/signing-manager-types';
+import { EthTransactionRequest } from '@polymeshassociation/signing-manager-types';
 import BigNumber from 'bignumber.js';
 
 import { PolymeshError as PolymeshErrorClass } from '~/base/PolymeshError';
@@ -303,7 +298,12 @@ export type PolymeshError = PolymeshErrorClass;
  * -------------------------------------------------------------------------------------------
  */
 
-export { EthSigner, EthSignerCapabilities, EthSigningManager, EthTransactionRequest };
+export {
+  EthSigner,
+  EthSignerCapabilities,
+  EthSigningManager,
+} from '@polymeshassociation/signing-manager-types';
+export { EthTransactionRequest };
 
 /**
  * A representation of an Ethereum transaction intended for offline/detached signing, along with

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -310,7 +310,13 @@ export { EthSigner, EthSignerCapabilities, EthSigningManager, EthTransactionRequ
  *   the decoded call for display
  */
 export interface EthTransactionPayload {
-  /** the parameters that would be passed to `EthSigner.signTransaction` / `sendTransaction` */
+  /**
+   * the parameters that would be passed to `EthSigner.signTransaction` / `sendTransaction`
+   *
+   * @note every field is 0x-prefixed hex, never a number or bigint. ethers and viem both need it
+   *   converted first — `@polymeshassociation/eth-signing-manager` exports `toEthersTransaction` /
+   *   `toViemTransaction` for that, usable without the manager itself
+   */
   transaction: EthTransactionRequest;
   /** the transaction tag identifying the underlying Polymesh call */
   tag: TxTag;

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -18,6 +18,50 @@ export type MapTxData<ArgsArray extends unknown[][]> = {
   [K in keyof ArgsArray]: ArgsArray[K] extends unknown[] ? TxData<ArgsArray[K]> : never;
 };
 
+/**
+ * Handle to a transaction that has been broadcast but is not being tracked. Returned by
+ *   {@link base/PolymeshTransactionBase!PolymeshTransactionBase.broadcast | transaction.broadcast},
+ *   which is `run` split at its natural seam: the transaction is on its way to the chain, and
+ *   whether to wait for it is now the caller's decision
+ */
+export interface TransactionBroadcastHandle<ReturnValue> {
+  /**
+   * the hash the transaction can be looked up by. Normally the Substrate extrinsic hash, but the
+   *   Ethereum transaction hash when an Ethereum wallet broadcast it, since that is the handle the
+   *   user has and can find in a block explorer
+   */
+  txHash: string;
+
+  /**
+   * the Ethereum transaction hash, set only when an Ethereum wallet broadcast the transaction
+   *   itself. `undefined` otherwise
+   */
+  ethTxHash?: string;
+
+  /**
+   * the block height the search for this transaction has to start from. Persist this alongside
+   *   `txHash` to resume tracking later via
+   *   {@link api/client/Network!Network.watchTransaction | network.watchTransaction}, for example
+   *   after a page reload, when `watch` itself is long gone
+   */
+  startingBlock: BigNumber;
+
+  /**
+   * Wait for the transaction to be included in a finalized block and return the same value
+   *   `run` would have returned
+   *
+   * Safe to retry if it times out — nothing is resubmitted, the search simply resumes. Calling it
+   *   while a previous call is still in flight throws
+   *
+   * @param opts.timeout - milliseconds to wait before giving up. Overrides `submission.watchTimeout`
+   *   from the Procedure options. Defaults to waiting indefinitely
+   *
+   * @throws `TransactionTimeout` if the transaction is not found in time. The transaction was still
+   *   broadcast and may yet be included — this reports only that the SDK stopped looking
+   */
+  watch: (opts?: { timeout?: number }) => Promise<ReturnValue>;
+}
+
 export enum TransactionStatus {
   /**
    * the transaction is prepped to run

--- a/src/base/utils.ts
+++ b/src/base/utils.ts
@@ -1,10 +1,11 @@
 import { SubmittableResult } from '@polkadot/api';
 import { GenericExtrinsic, getTypeDef, u32 } from '@polkadot/types';
-import { DispatchError, Hash, SignedBlock } from '@polkadot/types/interfaces';
+import { DispatchError, Hash, Header, SignedBlock } from '@polkadot/types/interfaces';
 import { SpRuntimeDispatchError } from '@polkadot/types/lookup';
 import { ISubmittableResult, RegistryError, TypeDef, TypeDefInfo } from '@polkadot/types/types';
 import { polymesh } from '@polymeshassociation/polymesh-types/polkadot/definitions';
 import { BigNumber } from 'bignumber.js';
+import { noop } from 'lodash';
 
 import { Context, PolymeshError } from '~/internal';
 import {
@@ -17,9 +18,10 @@ import {
   TransactionArgument,
   TransactionArgumentType,
   TxTag,
+  UnsubCallback,
 } from '~/types';
 import { ROOT_TYPES } from '~/utils/constants';
-import { bigNumberToU32, createRawExtrinsicStatus } from '~/utils/conversion';
+import { bigNumberToU32, createRawExtrinsicStatus, u32ToBigNumber } from '~/utils/conversion';
 import { delay, filterEventRecords } from '~/utils/internal';
 
 const { types } = polymesh;
@@ -250,6 +252,20 @@ export type ExtrinsicMatcher = (extrinsic: GenericExtrinsic) => boolean;
 /**
  * @hidden
  *
+ * A transaction found within a block's body, along with where it was found. The height and hash
+ *   come from the scanned range rather than the block header, since they are already known there
+ *   and do not depend on the header being fully populated
+ */
+interface LocatedTransaction {
+  block: SignedBlock;
+  txIndex: number;
+  blockNumber: BigNumber;
+  blockHash: string;
+}
+
+/**
+ * @hidden
+ *
  * Build a matcher that recognizes an extrinsic by its hash. This is the native submission path
  */
 export const extrinsicHashMatcher = (txHash: Hash): ExtrinsicMatcher => {
@@ -258,46 +274,124 @@ export const extrinsicHashMatcher = (txHash: Hash): ExtrinsicMatcher => {
 
 /**
  * @hidden
+ *
+ * Where a transaction was found, reported as soon as it is included in a block — before that
+ *   block is finalized
+ */
+export interface TransactionInclusionInfo {
+  blockHash: string;
+  blockNumber: BigNumber;
+  txIndex: number;
+}
+
+/**
+ * @hidden
+ *
+ * Number of the best (not necessarily finalized) block.
+ *
+ * {@link base/Context!Context.getLatestBlock | Context.getLatestBlock} deliberately reports the
+ *   latest *finalized* block, which is the right floor for a result but lags inclusion by the
+ *   finalization window
+ */
+const getBestBlockNumber = async (context: Context): Promise<BigNumber> => {
+  const header = await context.polymeshApi.rpc.chain.getHeader();
+
+  return u32ToBigNumber(header.number.unwrap());
+};
+
+/**
+ * @hidden
  */
 async function getLocationInfoForTx(
   matcher: ExtrinsicMatcher,
   context: Context,
-  lastCheckedBlock: BigNumber
+  lastCheckedBlock: BigNumber,
+  headBlockNumber: BigNumber
 ): Promise<{
-  locationInfo: { block: SignedBlock; txIndex: number } | undefined;
+  locationInfo: LocatedTransaction | undefined;
   latestBlockNumber: BigNumber;
 }> {
-  let locationInfo: { block: SignedBlock; txIndex: number } | undefined;
-  const latestBlockNumber = await context.getLatestBlock();
-  if (!latestBlockNumber.eq(lastCheckedBlock)) {
+  let locationInfo: LocatedTransaction | undefined;
+  let highestCheckedBlock = lastCheckedBlock;
+
+  if (!headBlockNumber.eq(lastCheckedBlock)) {
     const blocksToCheck: u32[] = [];
-    const numberOfCandidateBlocks = latestBlockNumber.minus(lastCheckedBlock).toNumber();
+    const numberOfCandidateBlocks = headBlockNumber.minus(lastCheckedBlock).toNumber();
 
     for (let i = 1; i <= numberOfCandidateBlocks; i++) {
       const blockNumber = lastCheckedBlock.plus(i);
       blocksToCheck.push(bigNumberToU32(blockNumber, context));
     }
 
-    const blockHashesToCheck = await context.polymeshApi.query.system.blockHash.multi(
-      blocksToCheck
+    /*
+     * `chain_getBlockHash` is used rather than the `system.blockHash` storage map because that map
+     *   only records a block's hash once its *child* has been initialized, so the current best
+     *   block reads back from storage as the zero hash. The RPC reads the client's block database
+     *   and is correct for the best block
+     */
+    const blockHashesToCheck = await Promise.all(
+      blocksToCheck.map(blockNumber => context.polymeshApi.rpc.chain.getBlockHash(blockNumber))
     );
+
+    /*
+     * a hash can still come back empty if the block went away between the two calls. Skip those
+     *   rather than resolving them, and do not count them as checked, so the next pass sees them
+     */
+    const candidates = blockHashesToCheck
+      .map((hash, index) => ({ hash, blockNumber: lastCheckedBlock.plus(index + 1) }))
+      .filter(({ hash }) => !hash.isEmpty);
 
     const newBlocks = await Promise.all(
-      blockHashesToCheck.map(hash => context.polymeshApi.rpc.chain.getBlock(hash))
+      candidates.map(({ hash }) => context.polymeshApi.rpc.chain.getBlock(hash))
     );
 
-    for (const newBlock of newBlocks) {
+    for (const [index, newBlock] of newBlocks.entries()) {
       const txIndex = newBlock.block.extrinsics.findIndex(value => matcher(value));
       if (txIndex >= 0) {
-        locationInfo = { txIndex, block: newBlock };
+        /*
+         * the height and hash come from the scanned range rather than the block header, since both
+         *   are already known here and do not depend on the header being fully populated
+         */
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const { hash, blockNumber } = candidates[index]!;
+
+        locationInfo = {
+          txIndex,
+          block: newBlock,
+          blockNumber,
+          blockHash: hash.toString(),
+        };
         break;
       }
     }
+
+    const [lastCandidate] = candidates.slice(-1);
+
+    if (lastCandidate) {
+      highestCheckedBlock = lastCandidate.blockNumber;
+    }
   }
 
-  return { locationInfo, latestBlockNumber };
+  return { locationInfo, latestBlockNumber: highestCheckedBlock };
 }
 
+/**
+ * @hidden
+ *
+ * given a way of recognizing a transaction, this will poll the chain until it is included in a
+ *   finalized block
+ *
+ * @note this method should only be used when there is no subscription support for efficiency
+ *
+ * @throws if transaction is not found after a certain amount of time
+ *
+ * @param matcher Predicate that recognizes the submitted extrinsic in a block's body. Use
+ *   {@link base/utils!extrinsicHashMatcher | extrinsicHashMatcher} for the native path
+ * @param startingBlock The block number from before the transaction was submitted
+ * @param context
+ * @param pollOptions Controls max time to poll, defaults should be OK (finalization takes ~15 seconds)
+ * @returns
+ */
 /**
  * @hidden
  *
@@ -343,10 +437,12 @@ export const pollForTransactionFinalization = async (
   matcher: ExtrinsicMatcher,
   startingBlock: BigNumber,
   context: Context,
-  pollOptions = { delayMs: 3000, maxAttempts: 10 }
+  pollOptions = { delayMs: 3000, maxAttempts: 10 },
+  onInBlock?: (info: TransactionInclusionInfo) => void
 ): Promise<SubmittableResult> => {
   let lastCheckedBlock = startingBlock;
   let locationInfo: { block: SignedBlock; txIndex: number } | undefined;
+  let notifiedInclusion = false;
 
   // Finalization is expected to take ~15 seconds
   const { delayMs, maxAttempts } = pollOptions;
@@ -354,15 +450,56 @@ export const pollForTransactionFinalization = async (
   let attemptCounter = 0;
   while (!locationInfo && attemptCounter < maxAttempts) {
     attemptCounter += 1;
-    await delay(delayMs);
 
-    const result = await getLocationInfoForTx(matcher, context, lastCheckedBlock);
+    /*
+     * The scan runs against the *best* head rather than the finalized one, so that inclusion can
+     *   be reported as soon as the transaction makes it into a block — roughly a block time,
+     *   rather than the ~15 seconds finalization takes. The result is only ever *advisory*: the
+     *   value this function returns still comes from a finalized block (see the wait below), so a
+     *   best block that is later re-orged away can do no more than fire a progress callback early
+     */
+    const [finalizedBlockNumber, bestBlockNumber] = await Promise.all([
+      context.getLatestBlock(),
+      getBestBlockNumber(context),
+    ]);
+
+    const result = await getLocationInfoForTx(
+      matcher,
+      context,
+      lastCheckedBlock,
+      // never scan behind the finalized head, which is the authoritative floor
+      BigNumber.max(bestBlockNumber, finalizedBlockNumber)
+    );
 
     if (result.locationInfo) {
-      locationInfo = result.locationInfo;
+      const includedIn = result.locationInfo.blockNumber;
+
+      if (finalizedBlockNumber.gte(includedIn)) {
+        // the containing block is already finalized, so this location is authoritative
+        locationInfo = result.locationInfo;
+      } else if (onInBlock && !notifiedInclusion) {
+        notifiedInclusion = true;
+
+        onInBlock({
+          blockHash: result.locationInfo.blockHash,
+          blockNumber: includedIn,
+          txIndex: result.locationInfo.txIndex,
+        });
+      }
+
+      /*
+       * Found but not yet finalized — do not advance `lastCheckedBlock` past it, so the next pass
+       *   re-reads the canonical block at that height. If the chain re-organised, the matcher
+       *   simply will not match there again and the search continues
+       */
+      lastCheckedBlock = includedIn.minus(1);
+    } else {
+      lastCheckedBlock = result.latestBlockNumber;
     }
 
-    lastCheckedBlock = result.latestBlockNumber;
+    if (!locationInfo) {
+      await delay(delayMs);
+    }
   }
 
   if (!locationInfo) {
@@ -373,6 +510,156 @@ export const pollForTransactionFinalization = async (
   }
 
   return buildFinalizedResult(locationInfo, context);
+};
+
+/**
+ * @hidden
+ *
+ * Locate a submitted transaction by subscribing to the chain's blocks, rather than polling for
+ *   them. Preferred whenever the connection supports subscriptions: inclusion is reported the
+ *   moment the block arrives instead of on the next poll tick, and it removes a repeating
+ *   `getHeader`/`getBlock` cycle per in-flight transaction
+ *
+ * Two independent scans run off two subscriptions:
+ *
+ * - **new heads** are advisory. They exist only to report inclusion early, via `onInBlock`. A
+ *   block seen here may still be re-organised away, which is harmless because nothing but a
+ *   progress callback depends on it
+ * - **finalized heads** are authoritative. The resolved result always comes from a finalized
+ *   block, so a re-org cannot produce a wrong result — the transaction simply will not be found
+ *   at that height on the canonical chain, and the scan continues
+ *
+ * @throws if the transaction is not found within `maxFinalizedBlocks` finalized blocks
+ */
+export const subscribeForTransactionFinalization = (
+  matcher: ExtrinsicMatcher,
+  startingBlock: BigNumber,
+  context: Context,
+  onInBlock?: (info: TransactionInclusionInfo) => void,
+  { maxFinalizedBlocks } = { maxFinalizedBlocks: 10 }
+): Promise<SubmittableResult> => {
+  const { chain } = context.polymeshApi.rpc;
+
+  return new Promise<SubmittableResult>((resolve, reject) => {
+    let lastBestBlock = startingBlock;
+    let lastFinalizedBlock = startingBlock;
+    let notifiedInclusion = false;
+    let settled = false;
+    let finalizedBlocksSeen = 0;
+    const unsubscribers: Promise<UnsubCallback>[] = [];
+
+    /*
+     * subscription callbacks can overlap, since each scan is asynchronous. Serializing them keeps
+     *   the cursors consistent and stops the same block being scanned twice
+     */
+    let scanning: Promise<void> = Promise.resolve();
+
+    /**
+     * Tear down both subscriptions
+     */
+    const cleanup = (): void => {
+      unsubscribers.forEach(getting => {
+        getting.then(unsub => unsub()).catch(noop);
+      });
+    };
+
+    /**
+     * Settle the promise exactly once, releasing both subscriptions first
+     */
+    const settle = (action: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      action();
+    };
+
+    /**
+     * Surface a failure from either scan
+     */
+    const handleError = (err: Error): void => {
+      settle(() => reject(err));
+    };
+
+    /**
+     * Advisory scan of the best head — reports inclusion early and nothing more
+     */
+    const scanBest = async (header: Header): Promise<void> => {
+      if (settled || !onInBlock || notifiedInclusion) {
+        return;
+      }
+
+      const headNumber = u32ToBigNumber(header.number.unwrap());
+      const { locationInfo, latestBlockNumber } = await getLocationInfoForTx(
+        matcher,
+        context,
+        lastBestBlock,
+        headNumber
+      );
+
+      if (locationInfo) {
+        notifiedInclusion = true;
+
+        onInBlock({
+          blockHash: locationInfo.blockHash,
+          blockNumber: locationInfo.blockNumber,
+          txIndex: locationInfo.txIndex,
+        });
+      }
+
+      lastBestBlock = locationInfo ? locationInfo.blockNumber : latestBlockNumber;
+    };
+
+    /**
+     * Authoritative scan of the finalized head — the only thing that can resolve the transaction
+     */
+    const scanFinalized = async (header: Header): Promise<void> => {
+      if (settled) {
+        return;
+      }
+
+      finalizedBlocksSeen += 1;
+
+      const headNumber = u32ToBigNumber(header.number.unwrap());
+      const { locationInfo, latestBlockNumber } = await getLocationInfoForTx(
+        matcher,
+        context,
+        lastFinalizedBlock,
+        headNumber
+      );
+
+      if (locationInfo) {
+        const result = await buildFinalizedResult(locationInfo, context);
+
+        settle(() => resolve(result));
+
+        return;
+      }
+
+      lastFinalizedBlock = latestBlockNumber;
+
+      if (finalizedBlocksSeen >= maxFinalizedBlocks) {
+        settle(() =>
+          reject(
+            new PolymeshError({
+              code: ErrorCode.UnexpectedError,
+              message: 'The block containing the transaction was not found',
+            })
+          )
+        );
+      }
+    };
+
+    unsubscribers.push(
+      chain.subscribeNewHeads(header => {
+        scanning = scanning.then(() => scanBest(header)).catch(handleError);
+      }),
+      chain.subscribeFinalizedHeads(header => {
+        scanning = scanning.then(() => scanFinalized(header)).catch(handleError);
+      })
+    );
+  });
 };
 
 /**

--- a/src/base/utils.ts
+++ b/src/base/utils.ts
@@ -266,7 +266,7 @@ const ETH_USER_REJECTED_CODE = 4001;
  */
 const isRejectedByUser = (err: Error): boolean =>
   (err as Error & { code?: unknown }).code === ETH_USER_REJECTED_CODE ||
-  err.message.indexOf('Cancelled') > -1;
+  err.message.includes('Cancelled');
 
 export const handleTransactionSubmissionError = (err: Error): PolymeshError => {
   let error;
@@ -476,18 +476,24 @@ const buildFinalizedResult = async (
   });
 };
 
+/**
+ * @hidden
+ *
+ * Finalization is expected to take ~15 seconds, so the defaults allow for twice that
+ */
+const DEFAULT_POLL_OPTIONS = { delayMs: 3000, maxAttempts: 10 };
+
 export const pollForTransactionFinalization = async (
   matcher: ExtrinsicMatcher,
   startingBlock: BigNumber,
   context: Context,
-  pollOptions = { delayMs: 3000, maxAttempts: 10 },
+  pollOptions = DEFAULT_POLL_OPTIONS,
   onInBlock?: (info: TransactionInclusionInfo) => void
 ): Promise<SubmittableResult> => {
   let lastCheckedBlock = startingBlock;
   let locationInfo: { block: SignedBlock; txIndex: number } | undefined;
   let notifiedInclusion = false;
 
-  // Finalization is expected to take ~15 seconds
   const { delayMs, maxAttempts } = pollOptions;
 
   let attemptCounter = 0;
@@ -558,6 +564,13 @@ export const pollForTransactionFinalization = async (
 /**
  * @hidden
  *
+ * How many finalized blocks the scan is willing to wait for before giving up
+ */
+const DEFAULT_SUBSCRIPTION_OPTIONS = { maxFinalizedBlocks: 10 };
+
+/**
+ * @hidden
+ *
  * Locate a submitted transaction by subscribing to the chain's blocks, rather than polling for
  *   them. Preferred whenever the connection supports subscriptions: inclusion is reported the
  *   moment the block arrives instead of on the next poll tick, and it removes a repeating
@@ -579,7 +592,7 @@ export const subscribeForTransactionFinalization = (
   startingBlock: BigNumber,
   context: Context,
   onInBlock?: (info: TransactionInclusionInfo) => void,
-  { maxFinalizedBlocks } = { maxFinalizedBlocks: 10 }
+  { maxFinalizedBlocks } = DEFAULT_SUBSCRIPTION_OPTIONS
 ): Promise<SubmittableResult> => {
   const { chain } = context.polymeshApi.rpc;
 
@@ -607,12 +620,9 @@ export const subscribeForTransactionFinalization = (
     };
 
     /**
-     * Settle the promise exactly once, releasing both subscriptions first
+     * Settle the promise, releasing both subscriptions first
      */
     const settle = (action: () => void): void => {
-      if (settled) {
-        return;
-      }
       settled = true;
       cleanup();
       action();

--- a/src/base/utils.ts
+++ b/src/base/utils.ts
@@ -1,8 +1,8 @@
 import { SubmittableResult } from '@polkadot/api';
-import { getTypeDef, u32 } from '@polkadot/types';
+import { GenericExtrinsic, getTypeDef, u32 } from '@polkadot/types';
 import { DispatchError, Hash, SignedBlock } from '@polkadot/types/interfaces';
 import { SpRuntimeDispatchError } from '@polkadot/types/lookup';
-import { RegistryError, TypeDef, TypeDefInfo } from '@polkadot/types/types';
+import { ISubmittableResult, RegistryError, TypeDef, TypeDefInfo } from '@polkadot/types/types';
 import { polymesh } from '@polymeshassociation/polymesh-types/polkadot/definitions';
 import { BigNumber } from 'bignumber.js';
 
@@ -20,7 +20,7 @@ import {
 } from '~/types';
 import { ROOT_TYPES } from '~/utils/constants';
 import { bigNumberToU32, createRawExtrinsicStatus } from '~/utils/conversion';
-import { delay } from '~/utils/internal';
+import { delay, filterEventRecords } from '~/utils/internal';
 
 const { types } = polymesh;
 
@@ -182,6 +182,22 @@ export const handleExtrinsicFailure = (
   return new PolymeshError({ code: ErrorCode.TransactionReverted, message, ...(data && { data }) });
 };
 
+/**
+ * @hidden
+ *
+ * Inspect a transaction receipt for an on-chain failure and return the corresponding error, or
+ *   `undefined` if the transaction succeeded
+ */
+export const getExtrinsicFailure = (receipt: ISubmittableResult): PolymeshError | undefined => {
+  const [extrinsicFailedEvent] = filterEventRecords(receipt, 'system', 'ExtrinsicFailed', true);
+
+  if (extrinsicFailedEvent) {
+    return handleExtrinsicFailure(extrinsicFailedEvent.data[0]);
+  }
+
+  return undefined;
+};
+
 export const handleTransactionSubmissionError = (err: Error): PolymeshError => {
   let error;
   /* istanbul ignore else */
@@ -198,9 +214,28 @@ export const handleTransactionSubmissionError = (err: Error): PolymeshError => {
 
 /**
  * @hidden
+ *
+ * Predicate used to recognize a submitted transaction within a block's body. The native path
+ *   matches on the extrinsic hash, while Ethereum signed transactions match on the keccak hash
+ *   of the `revive.ethTransact` payload (since the extrinsic itself is unsigned and its hash is
+ *   not known to the wallet that broadcast it)
+ */
+export type ExtrinsicMatcher = (extrinsic: GenericExtrinsic) => boolean;
+
+/**
+ * @hidden
+ *
+ * Build a matcher that recognizes an extrinsic by its hash. This is the native submission path
+ */
+export const extrinsicHashMatcher = (txHash: Hash): ExtrinsicMatcher => {
+  return (extrinsic: GenericExtrinsic): boolean => txHash.eq(extrinsic.hash);
+};
+
+/**
+ * @hidden
  */
 async function getLocationInfoForTx(
-  txHash: Hash,
+  matcher: ExtrinsicMatcher,
   context: Context,
   lastCheckedBlock: BigNumber
 ): Promise<{
@@ -227,7 +262,7 @@ async function getLocationInfoForTx(
     );
 
     for (const newBlock of newBlocks) {
-      const txIndex = newBlock.block.extrinsics.findIndex(value => txHash.eq(value.hash));
+      const txIndex = newBlock.block.extrinsics.findIndex(value => matcher(value));
       if (txIndex >= 0) {
         locationInfo = { txIndex, block: newBlock };
         break;
@@ -241,20 +276,46 @@ async function getLocationInfoForTx(
 /**
  * @hidden
  *
- * given a transaction hash this will poll the chain until it is included in a finalized block
- *
- * @note this method should only be used when there is no subscription support for efficiency
- *
- * @throws if transaction is not found after a certain amount of time
- *
- * @param txHash The hash of the transaction
- * @param startingBlock The block number from before the transaction was submitted
- * @param context
- * @param pollOptions Controls max time to poll, defaults should be OK (finalization takes ~15 seconds)
- * @returns
+ * Assemble the `SubmittableResult` for a transaction that has been located in a finalized block,
+ *   reading back the events belonging to it
  */
+const buildFinalizedResult = async (
+  locationInfo: { block: SignedBlock; txIndex: number },
+  context: Context
+): Promise<SubmittableResult> => {
+  const queryAt = await context.polymeshApi.at(locationInfo.block.block.header.hash);
+  const allEvents = await queryAt.query.system.events();
+
+  const relatedEvents = allEvents.filter(event => {
+    if (event.phase.isApplyExtrinsic) {
+      return event.phase.asApplyExtrinsic.eq(locationInfo.txIndex);
+    }
+
+    return false;
+  });
+
+  const blockHash = locationInfo.block.block.header.hash;
+  const rawStatus = createRawExtrinsicStatus('Finalized', blockHash, context);
+
+  /*
+   * the hash is read back from the located extrinsic rather than taken from the caller, since
+   *   an Ethereum signed transaction is correlated by its payload and the Substrate extrinsic
+   *   hash is only known once the extrinsic has been found
+   */
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const txHash = locationInfo.block.block.extrinsics[locationInfo.txIndex]!.hash;
+
+  return new SubmittableResult({
+    blockNumber: locationInfo.block.block.header.number.unwrap(),
+    txIndex: locationInfo.txIndex,
+    txHash,
+    status: rawStatus,
+    events: relatedEvents,
+  });
+};
+
 export const pollForTransactionFinalization = async (
-  txHash: Hash,
+  matcher: ExtrinsicMatcher,
   startingBlock: BigNumber,
   context: Context,
   pollOptions = { delayMs: 3000, maxAttempts: 10 }
@@ -270,7 +331,7 @@ export const pollForTransactionFinalization = async (
     attemptCounter += 1;
     await delay(delayMs);
 
-    const result = await getLocationInfoForTx(txHash, context, lastCheckedBlock);
+    const result = await getLocationInfoForTx(matcher, context, lastCheckedBlock);
 
     if (result.locationInfo) {
       locationInfo = result.locationInfo;
@@ -286,27 +347,7 @@ export const pollForTransactionFinalization = async (
     });
   }
 
-  const queryAt = await context.polymeshApi.at(locationInfo.block.block.header.hash);
-  const allEvents = await queryAt.query.system.events();
-
-  const relatedEvents = allEvents.filter(event => {
-    if (event.phase.isApplyExtrinsic) {
-      return event.phase.asApplyExtrinsic.eq(locationInfo!.txIndex);
-    }
-
-    return false;
-  });
-
-  const blockHash = locationInfo.block.block.header.hash;
-  const rawStatus = createRawExtrinsicStatus('Finalized', blockHash, context);
-
-  return new SubmittableResult({
-    blockNumber: locationInfo.block.block.header.number.unwrap(),
-    txIndex: locationInfo.txIndex,
-    txHash,
-    status: rawStatus,
-    events: relatedEvents,
-  });
+  return buildFinalizedResult(locationInfo, context);
 };
 
 /**

--- a/src/base/utils.ts
+++ b/src/base/utils.ts
@@ -214,12 +214,31 @@ export const handleExtrinsicFailure = (
  *
  * Inspect a transaction receipt for an on-chain failure and return the corresponding error, or
  *   `undefined` if the transaction succeeded
+ *
+ * Two distinct failure shapes feed into the same {@link handleExtrinsicFailure}:
+ *
+ * - `system.ExtrinsicFailed`, the native path's failure signal
+ * - `revive.EthExtrinsicRevert`, emitted instead on the Ethereum signing path. There, the outer
+ *   `revive.ethTransact` extrinsic still emits `system.ExtrinsicSuccess` even when the inner
+ *   dispatch failed, so this check must run (and take priority) before the receipt is otherwise
+ *   treated as a success
  */
 export const getExtrinsicFailure = (receipt: ISubmittableResult): PolymeshError | undefined => {
   const [extrinsicFailedEvent] = filterEventRecords(receipt, 'system', 'ExtrinsicFailed', true);
 
   if (extrinsicFailedEvent) {
     return handleExtrinsicFailure(extrinsicFailedEvent.data[0]);
+  }
+
+  const [ethExtrinsicRevertEvent] = filterEventRecords(
+    receipt,
+    'revive',
+    'EthExtrinsicRevert',
+    true
+  );
+
+  if (ethExtrinsicRevertEvent) {
+    return handleExtrinsicFailure(ethExtrinsicRevertEvent.data[0]);
   }
 
   return undefined;

--- a/src/base/utils.ts
+++ b/src/base/utils.ts
@@ -244,10 +244,34 @@ export const getExtrinsicFailure = (receipt: ISubmittableResult): PolymeshError 
   return undefined;
 };
 
+/**
+ * @hidden
+ *
+ * [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193#provider-errors) code for "the user rejected
+ *   the request". Every injected provider produces it, so it is the reliable signal on the
+ *   Ethereum path — more so than the message, which is the wallet's to word
+ */
+const ETH_USER_REJECTED_CODE = 4001;
+
+/**
+ * @hidden
+ *
+ * Whether the error reports that the user declined to sign.
+ *
+ * Two signals, because the two signing paths report rejection differently. Polkadot signers throw
+ *   a message containing `Cancelled`, while an {@link base/types!EthSigner} is specified to throw
+ *   the EIP-1193 `code`. Checking the code as well means a third-party Ethereum signer that simply
+ *   re-throws its provider's error is understood, rather than having to format its message to suit
+ *   the SDK
+ */
+const isRejectedByUser = (err: Error): boolean =>
+  (err as Error & { code?: unknown }).code === ETH_USER_REJECTED_CODE ||
+  err.message.indexOf('Cancelled') > -1;
+
 export const handleTransactionSubmissionError = (err: Error): PolymeshError => {
   let error;
-  /* istanbul ignore else */
-  if (err.message.indexOf('Cancelled') > -1) {
+
+  if (isRejectedByUser(err)) {
     // tx rejected by signer
     error = { code: ErrorCode.TransactionRejectedByUser };
   } else {

--- a/src/base/utils.ts
+++ b/src/base/utils.ts
@@ -152,21 +152,46 @@ export const processType = (rawType: TypeDef, name: string): TransactionArgument
 };
 
 export const dispatchErrorToMessage = (error: SpRuntimeDispatchError | DispatchError): string => {
-  let message: string;
   if (error.isModule) {
     // known error
     const mod = error.asModule;
 
     const { section, name, docs }: RegistryError = mod.registry.findMetaError(mod);
-    message = `${section}.${name}: ${docs.join(' ')}`;
-  } else if (error.isBadOrigin) {
-    message = 'Bad origin';
-  } else if (error.isCannotLookup) {
-    message = 'Could not lookup information required to validate the transaction';
-  } else {
-    message = 'Unknown error';
+
+    return `${section}.${name}: ${docs.join(' ')}`;
   }
-  return message;
+
+  if (error.isBadOrigin) {
+    return 'Bad origin';
+  }
+
+  if (error.isCannotLookup) {
+    return 'Could not lookup information required to validate the transaction';
+  }
+
+  /*
+   * The remaining variants carry no metadata to resolve against, but their own names are
+   *   meaningful. `Token(FundsUnavailable)` in particular is a common outcome — the Account
+   *   cannot cover the amount it is trying to move
+   */
+  if (error.isToken) {
+    return `Token error: ${error.asToken.type}`;
+  }
+
+  if (error.isArithmetic) {
+    return `Arithmetic error: ${error.asArithmetic.type}`;
+  }
+
+  if (error.isTransactional) {
+    return `Transactional error: ${error.asTransactional.type}`;
+  }
+
+  /*
+   * anything else (`Exhausted`, `Corruption`, `Unavailable`, `RootNotAllowed`, `NoProviders`, …)
+   *   is reported by name rather than swallowed, so a new runtime variant degrades to a useful
+   *   message instead of an opaque one
+   */
+  return error.type ? `Dispatch error: ${error.type}` : 'Unknown error';
 };
 
 /**

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -151,6 +151,7 @@ export { modifyCaDefaultConfig } from '~/api/procedures/modifyCaDefaultConfig';
 export { removeCorporateAction } from '~/api/procedures/removeCorporateAction';
 export { reclaimDividendDistributionFunds } from '~/api/procedures/reclaimDividendDistributionFunds';
 export { transferTickerOwnership } from '~/api/procedures/transferTickerOwnership';
+export { toggleEvmAccountMapping } from '~/api/procedures/toggleEvmAccountMapping';
 export { toggleFreezeSecondaryAccounts } from '~/api/procedures/toggleFreezeSecondaryAccounts';
 export { modifyVenue } from '~/api/procedures/modifyVenue';
 export { leaveIdentity } from '~/api/procedures/leaveIdentity';

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -186,6 +186,7 @@ import { cloneDeep, map, merge, upperFirst } from 'lodash';
 
 import { HistoricPolyxTransaction } from '~/api/entities/Account/types';
 import { BallotMotion } from '~/api/entities/CorporateBallot/types';
+import { EthSigner } from '~/base/types';
 import { Account, AuthorizationRequest, Context, Identity } from '~/internal';
 import { BalanceTypeEnum, CallIdEnum, EventIdEnum, ModuleIdEnum } from '~/middleware/types';
 import { dsMockUtils } from '~/testUtils/mocks';
@@ -488,6 +489,9 @@ interface ContextOptions {
   getSignature?: `0x${string}`;
   getNextAssetId?: string;
   getPendingSubsidies?: SubsidyWithAllowance[];
+  getEthSigner?: EthSigner | undefined;
+  getEthRuntimePalletsAddress?: string;
+  getEthChainId?: BigNumber;
 }
 
 interface SigningManagerOptions {
@@ -832,6 +836,9 @@ const defaultContextOptions: ContextOptions = {
   getSignature: '0xsignature',
   getNextAssetId: '0x12341234123412341234123412341234',
   getPendingSubsidies: [],
+  getEthSigner: undefined,
+  getEthRuntimePalletsAddress: '0x6d6f646c70792f70616464720000000000000000',
+  getEthChainId: new BigNumber(1641818),
 };
 let contextOptions: ContextOptions = defaultContextOptions;
 const defaultSigningManagerOptions: SigningManagerOptions = {
@@ -970,6 +977,9 @@ function configureContext(opts: ContextOptions): void {
     assertSupportsSubscription: jest.fn(),
     getSignature: jest.fn().mockReturnValue(opts.getSignature),
     getPendingSubsidies: jest.fn().mockResolvedValue(opts.getPendingSubsidies),
+    getEthSigner: jest.fn().mockReturnValue(opts.getEthSigner),
+    getEthRuntimePalletsAddress: jest.fn().mockResolvedValue(opts.getEthRuntimePalletsAddress),
+    getEthChainId: jest.fn().mockReturnValue(opts.getEthChainId),
   } as unknown as MockContext;
 
   contextInstance.clone = jest.fn().mockReturnValue(contextInstance);

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -1096,6 +1096,29 @@ function initTx(): void {
 function initRpc(): void {
   const mod = {} as any;
 
+  /*
+   * `chain.getHeader` reports the best (not necessarily finalized) block, and is used to detect
+   *   that a transaction has been included before its block is finalized. A real API always
+   *   exposes it, so a default keeps every suite that polls for a transaction working without
+   *   having to mock it explicitly. Override with `createRpcMock('chain', 'getHeader', ...)`
+   */
+  mod.chain = {
+    getHeader: jest.fn().mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      createMockHeader({
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        parentHash: createMockHash(),
+        // block 0 by default, so the finalized head governs unless a test says otherwise
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        number: createMockCompact(createMockU32(new BigNumber(0))),
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        stateRoot: createMockHash(),
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        extrinsicsRoot: createMockHash(),
+      })
+    ),
+  };
+
   updateRpc(mod);
 }
 
@@ -1150,6 +1173,7 @@ function initApi(): void {
   mockInstanceContainer.apiInstance.registry = {
     get: jest.fn(),
     register: jest.fn(),
+    findMetaError: jest.fn(),
   } as unknown as Registry;
   mockInstanceContainer.apiInstance.createType = jest.fn();
   mockInstanceContainer.apiInstance.runtimeVersion = {} as RuntimeVersion;
@@ -1410,9 +1434,22 @@ export function createTxMock<
   });
 
   const transaction = jest.fn().mockReturnValue({
-    method: tx, // should be a `Call` object, but this is enough for testing
+    /*
+     * stands in for the `Call` object a real `SubmittableExtrinsic` exposes. `toHex` is the
+     *   SCALE encoding of the call, which the Ethereum signing path puts in the transaction's
+     *   `data` field; `toString` preserves the previous (tx name) behaviour for assertions
+     */
+    method: {
+      toHex: (): string => '0x02',
+      toString: (): string => String(tx),
+    },
     hash: tx,
     signAndSend: mockSignAndSend,
+    /*
+     * a real `SubmittableExtrinsic` can be broadcast with `send` as well as `signAndSend` — bare
+     *   (unsigned) extrinsics such as `revive.ethTransact` are submitted that way
+     */
+    send: mockSend,
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     paymentInfo: jest.fn().mockResolvedValue({ partialFee: gas }),
     toHex: jest.fn().mockReturnValue('0x02'),
@@ -3993,6 +4030,10 @@ export const createMockExtrinsics = (
     | {
         toHex: () => string;
         hash: Hash;
+        /* optional, used when a matcher inspects the call being made */
+        method?: { section: string; method: string };
+        /* optional, used by the `revive.ethTransact` keccak matcher */
+        args?: unknown[];
       }[]
 ): MockCodec<Vec<GenericExtrinsic>> => {
   const defaultExtrinsic = {
@@ -4001,16 +4042,21 @@ export const createMockExtrinsics = (
     addSignature: (): void => {},
   };
 
-  const extrinsicsArray = extrinsics ?? [defaultExtrinsic];
-  const { toHex, hash } = extrinsicsArray[0] ?? defaultExtrinsic;
+  const extrinsicsArray = (extrinsics ?? [defaultExtrinsic]) as {
+    toHex: () => string;
+    hash: Hash;
+    method?: { section: string; method: string };
+    args?: unknown[];
+  }[];
+
   return createMockCodec(
-    [
-      {
-        toHex,
-        hash,
-        addSignature: (): void => {},
-      },
-    ],
+    extrinsicsArray.map(({ toHex, hash, method, args }) => ({
+      toHex,
+      hash,
+      ...(method ? { method } : {}),
+      ...(args ? { args } : {}),
+      addSignature: (): void => {},
+    })),
     !extrinsics
   );
 };

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -19,6 +19,7 @@ import {
 import { ISubmittableResult, Signer as PolkadotSigner } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
+import { ExtrinsicMatcher } from '~/base/utils';
 import { Identity, Procedure } from '~/internal';
 import { CallIdEnum, ModuleIdEnum } from '~/middleware/types';
 import {
@@ -35,6 +36,7 @@ import {
   SignerValue,
   SimplePermissions,
   TxData,
+  UnsubCallback,
 } from '~/types';
 
 /**
@@ -262,6 +264,37 @@ export interface TransactionConstructionData {
    * options that specify details for MultiSig proposals
    */
   multiSigOpts?: MultiSigProcedureOpt | undefined;
+}
+
+/**
+ * How a transaction is delivered to the chain when the connection supports subscriptions.
+ *
+ * `PolymeshTransactionBase` owns all of the lifecycle bookkeeping (status transitions, block
+ *   data, on-chain failure handling); a submission only describes *how* the transaction reaches
+ *   the node
+ */
+export interface SubscriptionSubmission {
+  /**
+   * submit the transaction, invoking `callback` on every status update. Resolves to the
+   *   unsubscribe function once the transaction has been accepted
+   */
+  subscribe: (callback: (receipt: ISubmittableResult) => void) => Promise<UnsubCallback>;
+  /**
+   * the hash to report via `transaction.txHash` once the transaction has been accepted
+   */
+  getTxHash: () => string;
+}
+
+/**
+ * How a transaction is delivered to the chain when the connection does not support
+ *   subscriptions and the result has to be located by polling
+ */
+export interface PollingSubmission {
+  /**
+   * submit the transaction. Resolves once it has been accepted, yielding the hash to report via
+   *   `transaction.txHash` and a predicate that recognizes the extrinsic in a block's body
+   */
+  send: () => Promise<{ txHash: string; matcher: ExtrinsicMatcher }>;
 }
 
 export interface AuthTarget {

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -35,6 +35,7 @@ import {
   Role,
   SignerValue,
   SimplePermissions,
+  SubmissionOpts,
   TxData,
   UnsubCallback,
 } from '~/types';
@@ -264,6 +265,10 @@ export interface TransactionConstructionData {
    * options that specify details for MultiSig proposals
    */
   multiSigOpts?: MultiSigProcedureOpt | undefined;
+  /**
+   * bounds on how long to wait when submitting and tracking the transaction
+   */
+  submission?: SubmissionOpts | undefined;
 }
 
 /**

--- a/src/utils/__tests__/eth.ts
+++ b/src/utils/__tests__/eth.ts
@@ -1,0 +1,243 @@
+import { hexToU8a } from '@polkadot/util';
+import { encodeAddress, ethereumEncode } from '@polkadot/util-crypto';
+import { PalletRevivePrimitivesEthTransactError } from '@polymeshassociation/polymesh-types/polkadot/types-lookup';
+import BigNumber from 'bignumber.js';
+
+import { PolymeshError } from '~/base/PolymeshError';
+import { dsMockUtils } from '~/testUtils/mocks';
+import { ErrorCode } from '~/types';
+import {
+  ethAddressFromSs58,
+  isEthDerivedAddress,
+  parseEthTransactError,
+  ss58FromEthAddress,
+} from '~/utils/eth';
+
+describe('eth utils', () => {
+  const h160 = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+  const checksummedH160 = ethereumEncode(hexToU8a(h160));
+
+  const buildEthAccountId = (): Uint8Array => {
+    const accountId = new Uint8Array(32);
+    accountId.set(hexToU8a(h160), 0);
+    accountId.set(new Uint8Array(12).fill(0xee), 20);
+    return accountId;
+  };
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  describe('isEthDerivedAddress', () => {
+    it.each([new BigNumber(42), new BigNumber(12)])(
+      'should return true for an Ethereum-derived address (ss58Format %s)',
+      ss58Format => {
+        const accountId = buildEthAccountId();
+        const address = encodeAddress(accountId, ss58Format.toNumber());
+
+        expect(isEthDerivedAddress(address, ss58Format)).toBe(true);
+      }
+    );
+
+    it.each([new BigNumber(42), new BigNumber(12)])(
+      'should return false for a non Ethereum-derived address (ss58Format %s)',
+      ss58Format => {
+        const accountId = new Uint8Array(32).fill(1);
+        const address = encodeAddress(accountId, ss58Format.toNumber());
+
+        expect(isEthDerivedAddress(address, ss58Format)).toBe(false);
+      }
+    );
+
+    it('should return false rather than throw for a malformed address', () => {
+      expect(isEthDerivedAddress('not an address', new BigNumber(42))).toBe(false);
+      expect(isEthDerivedAddress('', new BigNumber(42))).toBe(false);
+    });
+
+    it('should return false for a validly encoded address that is not 32 bytes', () => {
+      // SS58 also encodes shorter keys, which can never carry the 12 byte 0xEE suffix
+      const shortAddress = encodeAddress(new Uint8Array(8).fill(0xee), 42);
+
+      expect(isEthDerivedAddress(shortAddress, new BigNumber(42))).toBe(false);
+    });
+  });
+
+  describe('ethAddressFromSs58', () => {
+    it.each([new BigNumber(42), new BigNumber(12)])(
+      'should convert the ss58 address of an Ethereum Account into its checksummed H160 (ss58Format %s)',
+      ss58Format => {
+        const accountId = buildEthAccountId();
+        const address = encodeAddress(accountId, ss58Format.toNumber());
+
+        expect(ethAddressFromSs58(address, ss58Format)).toBe(checksummedH160);
+      }
+    );
+
+    it('should throw a ValidationError if the address is not Ethereum-derived', () => {
+      const ss58Format = new BigNumber(42);
+      const accountId = new Uint8Array(32).fill(1);
+      const address = encodeAddress(accountId, ss58Format.toNumber());
+
+      expect(() => ethAddressFromSs58(address, ss58Format)).toThrow(
+        expect.objectContaining({ code: ErrorCode.ValidationError })
+      );
+    });
+  });
+
+  describe('ss58FromEthAddress', () => {
+    it.each([new BigNumber(42), new BigNumber(12)])(
+      'should convert an H160 address into the ss58 address of the Account it controls (ss58Format %s)',
+      ss58Format => {
+        const accountId = buildEthAccountId();
+        const expected = encodeAddress(accountId, ss58Format.toNumber());
+
+        expect(ss58FromEthAddress(h160, ss58Format)).toBe(expected);
+        expect(ss58FromEthAddress(checksummedH160, ss58Format)).toBe(expected);
+      }
+    );
+
+    it('should throw a ValidationError if the address is not valid hex', () => {
+      expect(() => ss58FromEthAddress('not hex', new BigNumber(42))).toThrow(
+        expect.objectContaining({ code: ErrorCode.ValidationError })
+      );
+    });
+
+    it('should throw a ValidationError if the address is not 20 bytes long', () => {
+      expect(() => ss58FromEthAddress('0x1234', new BigNumber(42))).toThrow(
+        expect.objectContaining({ code: ErrorCode.ValidationError })
+      );
+    });
+
+    it('should report malformed input as a hex problem rather than a length problem', () => {
+      /*
+       * `hexToU8a` decodes non-hex input to garbage bytes instead of throwing, so without an
+       *   up-front check this would surface as the (misleading) length error
+       */
+      expect(() => ss58FromEthAddress('not hex', new BigNumber(42))).toThrow(
+        expect.objectContaining({
+          code: ErrorCode.ValidationError,
+          message: 'The supplied Ethereum address is not valid hex',
+        })
+      );
+    });
+  });
+
+  describe('round trip', () => {
+    it.each([new BigNumber(42), new BigNumber(12)])(
+      'should round trip an Ethereum address through its ss58 form (ss58Format %s)',
+      ss58Format => {
+        const ss58 = ss58FromEthAddress(h160, ss58Format);
+
+        expect(isEthDerivedAddress(ss58, ss58Format)).toBe(true);
+        expect(ethAddressFromSs58(ss58, ss58Format)).toBe(checksummedH160);
+      }
+    );
+  });
+
+  describe('parseEthTransactError', () => {
+    it('should resolve a Module error through chain metadata, matching the exact verified string', () => {
+      const context = dsMockUtils.getContextInstance();
+
+      (context.polymeshApi.registry.findMetaError as jest.Mock).mockReturnValue({
+        section: 'identity',
+        name: 'AlreadyLinked',
+        docs: ['One secondary or primary key can only belong to one DID'],
+      });
+
+      const error = {
+        isData: false,
+        isMessage: true,
+        asMessage: {
+          toString: () =>
+            'Failed to dispatch call: Module(ModuleError { index: 7, error: [0, 0, 0, 0], message: Some("AlreadyLinked") })',
+        },
+      } as unknown as PalletRevivePrimitivesEthTransactError;
+
+      const result = parseEthTransactError(error, context);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          code: ErrorCode.TransactionReverted,
+          message:
+            'identity.AlreadyLinked: One secondary or primary key can only belong to one DID',
+        })
+      );
+      expect(context.polymeshApi.registry.findMetaError).toHaveBeenCalledWith({
+        index: expect.objectContaining({ words: [7] }),
+        error: Uint8Array.from([0, 0, 0, 0]),
+      });
+    });
+
+    it('should fall back to UnexpectedError carrying the raw message when it does not match the module error pattern', () => {
+      const context = dsMockUtils.getContextInstance();
+
+      const rawMessage = 'Failed to instantiate';
+      const error = {
+        isData: false,
+        isMessage: true,
+        asMessage: { toString: () => rawMessage },
+      } as unknown as PalletRevivePrimitivesEthTransactError;
+
+      const result = parseEthTransactError(error, context);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          code: ErrorCode.UnexpectedError,
+          message: rawMessage,
+        })
+      );
+    });
+
+    it('should fall back to UnexpectedError if metadata lookup throws for a matching message', () => {
+      const context = dsMockUtils.getContextInstance();
+
+      (context.polymeshApi.registry.findMetaError as jest.Mock).mockImplementation(() => {
+        throw new Error('not found');
+      });
+
+      const rawMessage =
+        'Failed to dispatch call: Module(ModuleError { index: 99, error: [9, 0, 0, 0], message: Some("Unknown") })';
+      const error = {
+        isData: false,
+        isMessage: true,
+        asMessage: { toString: () => rawMessage },
+      } as unknown as PalletRevivePrimitivesEthTransactError;
+
+      const result = parseEthTransactError(error, context);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          code: ErrorCode.UnexpectedError,
+          message: rawMessage,
+        })
+      );
+    });
+
+    it('should map a Data variant to UnexpectedError with the raw hex, without ABI decoding', () => {
+      const context = dsMockUtils.getContextInstance();
+
+      const error = {
+        isData: true,
+        asData: { toHex: () => '0xdeadbeef' },
+      } as unknown as PalletRevivePrimitivesEthTransactError;
+
+      const result = parseEthTransactError(error, context);
+
+      expect(result).toBeInstanceOf(PolymeshError);
+      expect(result).toEqual(
+        expect.objectContaining({
+          code: ErrorCode.UnexpectedError,
+          data: { data: '0xdeadbeef' },
+        })
+      );
+    });
+  });
+});

--- a/src/utils/__tests__/eth.ts
+++ b/src/utils/__tests__/eth.ts
@@ -217,6 +217,59 @@ describe('eth utils', () => {
     );
   });
 
+  describe('shared vectors', () => {
+    /*
+     * The five prefunded Moonbeam dev keys, mirroring `DEV_ACCOUNTS` in `eth-signing-manager`'s
+     *   `src/utils/__tests__/index.spec.ts`. Both repos derive these addresses separately, so one
+     *   shared table of fixed vectors is what catches drift — every other test here builds its
+     *   expectation from the same primitives as the code under test
+     */
+    const devAccounts: { h160: string; ss58Format42: string; ss58Format12: string }[] = [
+      {
+        h160: '0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac',
+        ss58Format42: '5HYRCKHYJN9z5xUtfFkyMj4JUhsAwWyvuU8vKB1FcnYTf9ZQ',
+        ss58Format12: '2HvdSZ3SmdvBQCLyVHNG2h5Z69aMJ26KFFWyrfiDj8hqDb1S',
+      },
+      {
+        h160: '0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0',
+        ss58Format42: '5DSSiJevXj8XQ6uKD5ZNQJEimLPWwxuW4MZE9YNcAtRsYgVG',
+        ss58Format12: '2DpexYQpzztiiLmQ37Af5GFyNn6hJU1tQ8wHh35aHEbF7FTi',
+      },
+      {
+        h160: '0x798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc',
+        ss58Format42: '5Ep5dBwRE7mhFsH69SLRTSHYJ7yugeTycZHeT8Ez4DPACvqz',
+        ss58Format12: '2FCHsRhKhPXta79AyTwi8QJnuZh639aMxLfhzcwxAZYXm6wf',
+      },
+      {
+        h160: '0x773539d4Ac0e786233D90A233654ccEE26a613D9',
+        ss58Format42: '5Em1NEHgVvpXYBEzWeNf9JzuLyvuyyn3ZLifywLQPGdqFVU2',
+        ss58Format12: '2F9DcU3ayCairR75LfywpH29xRe6LUtRu86jXS3NVcoCofey',
+      },
+      {
+        h160: '0xFf64d3F6efE2317EE2807d223a0Bdc4c0c49dfDB',
+        ss58Format42: '5Hqa27HwFuRr2YLJHXLwrP7Q4JMftxEF1kSdFwXvoeZ1PnkA',
+        ss58Format12: '2JDnGM3qjBC3LnCP7YxEXM8efk4rFTLdMXpgoSEtuziNx1WT',
+      },
+    ];
+
+    it.each(devAccounts)(
+      'should map $h160 to and from its Account in both ss58 formats',
+      ({ h160: address, ss58Format42, ss58Format12 }) => {
+        const format42 = new BigNumber(42);
+        const format12 = new BigNumber(12);
+
+        expect(ss58FromEthAddress(address, format42)).toBe(ss58Format42);
+        expect(ss58FromEthAddress(address, format12)).toBe(ss58Format12);
+
+        expect(ethAddressFromSs58(ss58Format42, format42)).toBe(address);
+        expect(ethAddressFromSs58(ss58Format12, format12)).toBe(address);
+
+        expect(isEthDerivedAddress(ss58Format42, format42)).toBe(true);
+        expect(isEthDerivedAddress(ss58Format12, format12)).toBe(true);
+      }
+    );
+  });
+
   describe('parseEthTransactError', () => {
     it('should resolve a Module error through chain metadata, matching the exact verified string', () => {
       const context = dsMockUtils.getContextInstance();

--- a/src/utils/__tests__/eth.ts
+++ b/src/utils/__tests__/eth.ts
@@ -1,5 +1,5 @@
 import { hexToU8a } from '@polkadot/util';
-import { encodeAddress, ethereumEncode } from '@polkadot/util-crypto';
+import { encodeAddress, ethereumEncode, keccakAsU8a } from '@polkadot/util-crypto';
 import { PalletRevivePrimitivesEthTransactError } from '@polymeshassociation/polymesh-types/polkadot/types-lookup';
 import BigNumber from 'bignumber.js';
 
@@ -8,6 +8,7 @@ import { dsMockUtils } from '~/testUtils/mocks';
 import { ErrorCode } from '~/types';
 import {
   ethAddressFromSs58,
+  evmAddressFromSs58,
   isEthDerivedAddress,
   parseEthTransactError,
   ss58FromEthAddress,
@@ -125,6 +126,80 @@ describe('eth utils', () => {
         expect.objectContaining({
           code: ErrorCode.ValidationError,
           message: 'The supplied Ethereum address is not valid hex',
+        })
+      );
+    });
+  });
+
+  describe('evmAddressFromSs58', () => {
+    it.each([new BigNumber(42), new BigNumber(12)])(
+      'should return the padded Ethereum key for an Ethereum-derived Account (ss58Format %s)',
+      ss58Format => {
+        const address = encodeAddress(buildEthAccountId(), ss58Format.toNumber());
+
+        expect(evmAddressFromSs58(address, ss58Format)).toBe(checksummedH160);
+        // for an Ethereum-derived Account this must agree with the dedicated getter
+        expect(evmAddressFromSs58(address, ss58Format)).toBe(
+          ethAddressFromSs58(address, ss58Format)
+        );
+      }
+    );
+
+    it.each([new BigNumber(42), new BigNumber(12)])(
+      'should hash a native Account, matching revive `keccak256(<account id>)[12..]` (ss58Format %s)',
+      ss58Format => {
+        const accountId = new Uint8Array(32).fill(1);
+        const address = encodeAddress(accountId, ss58Format.toNumber());
+
+        const expected = ethereumEncode(keccakAsU8a(accountId).subarray(12));
+
+        expect(evmAddressFromSs58(address, ss58Format)).toBe(expected);
+      }
+    );
+
+    it('should be independent of the ss58 format the address is encoded in', () => {
+      const accountId = new Uint8Array(32).fill(7);
+
+      expect(evmAddressFromSs58(encodeAddress(accountId, 42), new BigNumber(42))).toBe(
+        evmAddressFromSs58(encodeAddress(accountId, 12), new BigNumber(12))
+      );
+    });
+
+    it('should not collide with the Ethereum-derived branch for a lookalike Account', () => {
+      /*
+       * An Account whose last 12 bytes are `0xEE` except for one takes the hashing branch, so it
+       *   must not be read as the padded form of the leading 20 bytes
+       */
+      const accountId = new Uint8Array(32).fill(0xee);
+      accountId.set(hexToU8a(h160), 0);
+      accountId[31] = 0x01;
+
+      const ss58Format = new BigNumber(42);
+      const address = encodeAddress(accountId, ss58Format.toNumber());
+
+      expect(evmAddressFromSs58(address, ss58Format)).not.toBe(checksummedH160);
+      expect(evmAddressFromSs58(address, ss58Format)).toBe(
+        ethereumEncode(keccakAsU8a(accountId).subarray(12))
+      );
+    });
+
+    it('should throw a ValidationError if the address is not a valid ss58 address', () => {
+      expect(() => evmAddressFromSs58('not an address', new BigNumber(42))).toThrow(
+        expect.objectContaining({
+          code: ErrorCode.ValidationError,
+          message: 'The supplied address is not a valid SS58 address',
+        })
+      );
+    });
+
+    it('should throw a ValidationError if the address does not encode 32 bytes', () => {
+      // ss58 also encodes shorter keys, which the chain has no `AccountId32` to derive from
+      const shortKey = encodeAddress(new Uint8Array(8).fill(1), 42);
+
+      expect(() => evmAddressFromSs58(shortKey, new BigNumber(42))).toThrow(
+        expect.objectContaining({
+          code: ErrorCode.ValidationError,
+          message: 'The supplied address does not encode a 32 byte Account ID',
         })
       );
     });

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -11,6 +11,7 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 import crossFetch from 'cross-fetch';
 import { when } from 'jest-when';
+import { noop } from 'lodash';
 
 import {
   Account,
@@ -148,6 +149,7 @@ import {
   toHumanReadable,
   unserialize,
   warnUnexpectedSqVersion,
+  withTimeout,
   xor,
 } from '~/utils/internal';
 
@@ -195,6 +197,74 @@ describe('delay', () => {
     jest.advanceTimersByTime(5000);
 
     expect(await delayPromise).toBeUndefined();
+  });
+});
+
+describe('withTimeout', () => {
+  const buildError = (): PolymeshError =>
+    new PolymeshError({ code: ErrorCode.TransactionTimeout, message: 'gave up waiting' });
+
+  beforeAll(() => {
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return the promise untouched when no timeout is given', async () => {
+    const promise = Promise.resolve('resolved');
+
+    const result = withTimeout(promise, undefined, buildError);
+
+    expect(result).toBe(promise);
+    await expect(result).resolves.toBe('resolved');
+  });
+
+  it('should resolve with the value if it settles before the timeout', async () => {
+    const result = withTimeout(Promise.resolve('resolved'), 5000, buildError);
+
+    await expect(result).resolves.toBe('resolved');
+  });
+
+  it('should reject with the built error once the timeout elapses', async () => {
+    // never settles, standing in for a wallet prompt that is never answered
+    const result = withTimeout(new Promise<string>(noop), 5000, buildError);
+
+    jest.advanceTimersByTime(5000);
+
+    await expect(result).rejects.toThrow(
+      expect.objectContaining({ code: ErrorCode.TransactionTimeout, message: 'gave up waiting' })
+    );
+  });
+
+  it('should propagate a rejection that happens before the timeout', async () => {
+    const result = withTimeout(Promise.reject(new Error('failed')), 5000, buildError);
+
+    await expect(result).rejects.toThrow('failed');
+  });
+
+  it('should swallow a rejection arriving after the timeout, rather than leaving it unhandled', async () => {
+    let rejectLate: (err: Error) => void = noop;
+    const late = new Promise<string>((_resolve, reject) => {
+      rejectLate = reject;
+    });
+
+    const result = withTimeout(late, 5000, buildError);
+
+    jest.advanceTimersByTime(5000);
+
+    await expect(result).rejects.toThrow('gave up waiting');
+
+    /*
+     * the abandoned work is still running and may fail later. Were that rejection not handled, it
+     *   would take down a Node consumer
+     */
+    rejectLate(new Error('failed long after we stopped waiting'));
+
+    await expect(late).rejects.toThrow('failed long after we stopped waiting');
   });
 });
 

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -36,6 +36,12 @@ const KECCAK_ADDRESS_OFFSET = 12;
  * Return whether the given SS58 address was derived from an Ethereum key, i.e. whether the last
  *   12 bytes of the decoded `AccountId32` are `0xEE`
  *
+ * @note `@polymeshassociation/eth-signing-manager` implements this, {@link ethAddressFromSs58}
+ *   and {@link ss58FromEthAddress} separately in its `src/utils/index.ts`, since
+ *   `signing-manager-types` is a types-only devDependency here. Its `DEV_ACCOUNTS` vectors are
+ *   mirrored in `utils/__tests__/eth.ts`, so drift fails a test. Its `ss58Format` is
+ *   optional by design: a standalone manager does not know the chain's format, the SDK always does
+ *
  * @note tolerant of a malformed address: returns `false` rather than throwing, since this runs on
  *   every transaction submission
  */

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -58,7 +58,7 @@ export function isEthDerivedAddress(address: string, ss58Format: BigNumber): boo
     }
 
     return decoded.subarray(H160_LENGTH).every(byte => byte === ETH_SUFFIX_BYTE);
-  } catch (err) {
+  } catch {
     return false;
   }
 }
@@ -212,7 +212,7 @@ export function parseEthTransactError(
     const [, indexString, errorBytesString] = match as [string, string, string];
     const index = new BN(indexString);
     const errorBytes = Uint8Array.from(
-      errorBytesString.split(',').map(byte => parseInt(byte.trim(), 10))
+      errorBytesString.split(',').map(byte => Number.parseInt(byte.trim(), 10))
     );
 
     try {
@@ -222,7 +222,7 @@ export function parseEthTransactError(
         code: ErrorCode.TransactionReverted,
         message: `${meta.section}.${meta.name}: ${meta.docs.join(' ')}`,
       });
-    } catch (err) {
+    } catch {
       // fall through to the generic branch below if metadata lookup itself fails
     }
   }

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,6 +1,6 @@
 import { BN, hexToU8a, isHex } from '@polkadot/util';
 import { HexString } from '@polkadot/util/types';
-import { decodeAddress, encodeAddress, ethereumEncode } from '@polkadot/util-crypto';
+import { decodeAddress, encodeAddress, ethereumEncode, keccakAsU8a } from '@polkadot/util-crypto';
 import { PalletRevivePrimitivesEthTransactError } from '@polymeshassociation/polymesh-types/polkadot/types-lookup';
 import BigNumber from 'bignumber.js';
 
@@ -23,6 +23,14 @@ const ETH_SUFFIX_BYTE = 0xee;
  */
 const ACCOUNT_ID_LENGTH = 32;
 const H160_LENGTH = 20;
+
+/**
+ * @hidden
+ *
+ * Offset into a 32 byte Keccak-256 digest at which revive's derived address begins, i.e. the
+ *   digest's last 20 bytes
+ */
+const KECCAK_ADDRESS_OFFSET = 12;
 
 /**
  * Return whether the given SS58 address was derived from an Ethereum key, i.e. whether the last
@@ -104,6 +112,51 @@ export function ss58FromEthAddress(h160: string, ss58Format: BigNumber): string 
   accountId.set(new Uint8Array(ETH_SUFFIX_LENGTH).fill(ETH_SUFFIX_BYTE), H160_LENGTH);
 
   return encodeAddress(accountId, ss58Format.toNumber());
+}
+
+/**
+ * Compute the Ethereum (H160) address the chain associates with an Account, mirroring revive's
+ *   `AccountId32Mapper::to_address`:
+ *
+ * - an Ethereum-derived Account (`<h160> ++ [0xEE; 12]`) yields the Ethereum key it is padded
+ *   from. The chain can always invert this, so no on-chain mapping is involved
+ * - any other Account yields `keccak256(<32-byte AccountId32>)[12..]`. This direction is a one-way
+ *   hash, so the chain can only invert it if the Account has called `revive.mapAccount`
+ *
+ * @returns the checksummed (EIP-55) `0x`-prefixed address
+ *
+ * @throws if the address is not a validly encoded 32 byte `AccountId32`
+ */
+export function evmAddressFromSs58(address: string, ss58Format: BigNumber): HexString {
+  let decoded;
+
+  try {
+    decoded = decodeAddress(address, false, ss58Format.toNumber());
+  } catch (err) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The supplied address is not a valid SS58 address',
+      data: { address },
+    });
+  }
+
+  /*
+   * SS58 also encodes shorter keys (1, 2, 4, 8 and 33 bytes), which the chain has no `AccountId32`
+   *   to derive an address from
+   */
+  if (decoded.length !== ACCOUNT_ID_LENGTH) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The supplied address does not encode a 32 byte Account ID',
+      data: { address },
+    });
+  }
+
+  if (decoded.subarray(H160_LENGTH).every(byte => byte === ETH_SUFFIX_BYTE)) {
+    return ethereumEncode(decoded.subarray(0, H160_LENGTH)) as HexString;
+  }
+
+  return ethereumEncode(keccakAsU8a(decoded).subarray(KECCAK_ADDRESS_OFFSET)) as HexString;
 }
 
 /**

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,0 +1,175 @@
+import { BN, hexToU8a, isHex } from '@polkadot/util';
+import { HexString } from '@polkadot/util/types';
+import { decodeAddress, encodeAddress, ethereumEncode } from '@polkadot/util-crypto';
+import { PalletRevivePrimitivesEthTransactError } from '@polymeshassociation/polymesh-types/polkadot/types-lookup';
+import BigNumber from 'bignumber.js';
+
+import { Context, PolymeshError } from '~/internal';
+import { ErrorCode } from '~/types';
+
+/**
+ * @hidden
+ *
+ * The last 12 bytes of an `AccountId32` derived from an Ethereum key. Mirrors revive's
+ *   `is_eth_derived`/`to_fallback_account_id`: `AccountId32 = <20-byte H160> ++ [0xEE; 12]`
+ */
+const ETH_SUFFIX_LENGTH = 12;
+const ETH_SUFFIX_BYTE = 0xee;
+
+/**
+ * @hidden
+ *
+ * Length of an `AccountId32`, and the offset at which its Ethereum suffix begins
+ */
+const ACCOUNT_ID_LENGTH = 32;
+const H160_LENGTH = 20;
+
+/**
+ * Return whether the given SS58 address was derived from an Ethereum key, i.e. whether the last
+ *   12 bytes of the decoded `AccountId32` are `0xEE`
+ *
+ * @note tolerant of a malformed address: returns `false` rather than throwing, since this runs on
+ *   every transaction submission
+ */
+export function isEthDerivedAddress(address: string, ss58Format: BigNumber): boolean {
+  try {
+    const decoded = decodeAddress(address, false, ss58Format.toNumber());
+
+    /*
+     * SS58 also encodes shorter keys (1, 2, 4, 8 and 33 bytes), so the length must be checked
+     *   before the suffix — this guarantees the slice below is exactly `ETH_SUFFIX_LENGTH` long
+     */
+    if (decoded.length !== ACCOUNT_ID_LENGTH) {
+      return false;
+    }
+
+    return decoded.subarray(H160_LENGTH).every(byte => byte === ETH_SUFFIX_BYTE);
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
+ * Convert the SS58 address of an Ethereum-derived Account into its controlling, checksummed
+ *   (EIP-55) `0x`-prefixed Ethereum address
+ *
+ * @throws if the address is not a validly encoded, Ethereum-derived address
+ */
+export function ethAddressFromSs58(address: string, ss58Format: BigNumber): HexString {
+  if (!isEthDerivedAddress(address, ss58Format)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The supplied address is not an Ethereum-derived Account',
+      data: { address },
+    });
+  }
+
+  const decoded = decodeAddress(address, false, ss58Format.toNumber());
+
+  return ethereumEncode(decoded.subarray(0, H160_LENGTH)) as HexString;
+}
+
+/**
+ * Convert an Ethereum address into the SS58 address of the Account it controls:
+ *   `ss58(<h160> ++ [0xEE; 12])`
+ *
+ * @throws if `h160` is not a 20 byte hex encoded address
+ */
+export function ss58FromEthAddress(h160: string, ss58Format: BigNumber): string {
+  /*
+   * `hexToU8a` is lenient — it decodes non-hex input to garbage bytes rather than throwing — so
+   *   the input must be validated up front, otherwise malformed input is reported as a length
+   *   problem rather than as the hex problem it actually is
+   */
+  if (!isHex(h160)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The supplied Ethereum address is not valid hex',
+      data: { h160 },
+    });
+  }
+
+  const addressBytes = hexToU8a(h160);
+
+  if (addressBytes.length !== H160_LENGTH) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The supplied Ethereum address must be 20 bytes long',
+      data: { h160 },
+    });
+  }
+
+  const accountId = new Uint8Array(ACCOUNT_ID_LENGTH);
+  accountId.set(addressBytes, 0);
+  accountId.set(new Uint8Array(ETH_SUFFIX_LENGTH).fill(ETH_SUFFIX_BYTE), H160_LENGTH);
+
+  return encodeAddress(accountId, ss58Format.toNumber());
+}
+
+/**
+ * @hidden
+ *
+ * Format of the `Message` variant the chain produces for a failed runtime dispatch on the
+ *   `revive.ethTransact` dry-run path:
+ *
+ * ```text
+ * Failed to dispatch call: Module(ModuleError { index: 7, error: [0, 0, 0, 0], message: Some("AlreadyLinked") })
+ * ```
+ */
+const MODULE_ERROR_PATTERN = /Module\(ModuleError \{ index: (\d+), error: \[([\d,\s]+)\]/;
+
+/**
+ * @hidden
+ *
+ * Parse the `Err` variant returned by `reviveApi.ethTransactWithConfig`'s dry run into the same
+ *   `PolymeshError` shape a failed native dispatch would produce
+ *
+ * - `Message` matching the module error pattern is resolved through chain metadata, so the
+ *   message is identical to what `handleExtrinsicFailure` would produce for the same error
+ * - `Message` not matching the pattern (e.g. gas/balance related failures, "Failed to
+ *   instantiate") falls back to `ErrorCode.UnexpectedError`, carrying the raw string. It is never
+ *   swallowed
+ * - `Data` is EVM revert data. It is unreachable on the sentinel path (the sentinel is not a
+ *   contract), so it is mapped to `ErrorCode.UnexpectedError` with the raw hex attached. No ABI
+ *   decoding is attempted
+ */
+export function parseEthTransactError(
+  error: PalletRevivePrimitivesEthTransactError,
+  context: Context
+): PolymeshError {
+  if (error.isData) {
+    return new PolymeshError({
+      code: ErrorCode.UnexpectedError,
+      message: 'The Ethereum transaction dry run failed with EVM revert data',
+      data: { data: error.asData.toHex() },
+    });
+  }
+
+  const rawMessage = error.asMessage.toString();
+
+  const match = rawMessage.match(MODULE_ERROR_PATTERN);
+
+  if (match) {
+    const [, indexString, errorBytesString] = match as [string, string, string];
+    const index = new BN(indexString);
+    const errorBytes = Uint8Array.from(
+      errorBytesString.split(',').map(byte => parseInt(byte.trim(), 10))
+    );
+
+    try {
+      const meta = context.polymeshApi.registry.findMetaError({ index, error: errorBytes });
+
+      return new PolymeshError({
+        code: ErrorCode.TransactionReverted,
+        message: `${meta.section}.${meta.name}: ${meta.docs.join(' ')}`,
+      });
+    } catch (err) {
+      // fall through to the generic branch below if metadata lookup itself fails
+    }
+  }
+
+  return new PolymeshError({
+    code: ErrorCode.UnexpectedError,
+    message: rawMessage,
+  });
+}

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -163,6 +163,48 @@ export function delay(amount: number): Promise<void> {
 
 /**
  * @hidden
+ * Reject with `buildError()` if `promise` has not settled within `timeout` milliseconds. Passing
+ *   `undefined` as the timeout returns the promise untouched, so callers can hand a caller-supplied
+ *   optional value straight through without branching
+ *
+ * @note this only stops the *waiting*. The underlying work is not cancelled — there is no way to
+ *   recall a transaction handed to a wallet, or to abort an in-flight chain scan from here — so it
+ *   keeps running in the background until it settles or reaches its own internal cap. Its rejection
+ *   is swallowed for that reason: it may well reject long after this one has, and that must not
+ *   surface as an unhandled rejection
+ *
+ * @param promise - the work to bound
+ * @param timeout - milliseconds to wait, or `undefined` to wait indefinitely
+ * @param buildError - builds the error to reject with. A function rather than a value so the
+ *   message can describe state that is only known once the timeout has actually fired
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeout: number | undefined,
+  buildError: () => PolymeshError
+): Promise<T> {
+  if (timeout === undefined) {
+    return promise;
+  }
+
+  // the losing promise may reject long after this one settles; that must not go unhandled
+  promise.catch(noop);
+
+  let timer: ReturnType<typeof setTimeout>;
+
+  const timingOut = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(buildError());
+    }, timeout);
+  });
+
+  return Promise.race([promise, timingOut]).finally(() => {
+    clearTimeout(timer);
+  });
+}
+
+/**
+ * @hidden
  * Convert an entity type and its unique Identifiers to a base64 string
  */
 export function serialize<UniqueIdentifiers>(

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -1,5 +1,8 @@
 /* istanbul ignore file */
 
+import { SigningManager } from '@polymeshassociation/signing-manager-types';
+
+import { EthSigningManager } from '~/base/types';
 import {
   Account,
   AuthorizationRequest,
@@ -459,3 +462,13 @@ export const isPortfolioAssetHolder = (
 ): holder is DefaultPortfolio | NumberedPortfolio => {
   return !(holder instanceof Account);
 };
+
+/**
+ * Return whether a Signing Manager is capable of signing Ethereum transactions, i.e. whether it
+ *   exposes a `getEthSigner` method
+ */
+export function isEthSigningManager(
+  manager: SigningManager | null | undefined
+): manager is EthSigningManager {
+  return !!manager && typeof (manager as Partial<EthSigningManager>).getEthSigner === 'function';
+}

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -466,6 +466,9 @@ export const isPortfolioAssetHolder = (
 /**
  * Return whether a Signing Manager is capable of signing Ethereum transactions, i.e. whether it
  *   exposes a `getEthSigner` method
+ *
+ * TODO: re-export from @polymeshassociation/signing-manager-types once >=3.8.0 is published, which
+ *   carries this same implementation
  */
 export function isEthSigningManager(
   manager: SigningManager | null | undefined

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -467,8 +467,8 @@ export const isPortfolioAssetHolder = (
  * Return whether a Signing Manager is capable of signing Ethereum transactions, i.e. whether it
  *   exposes a `getEthSigner` method
  *
- * TODO: re-export from @polymeshassociation/signing-manager-types once >=3.8.0 is published, which
- *   carries this same implementation
+ * @note deliberately implemented here rather than re-exported from
+ *   `@polymeshassociation/signing-manager-types` to avoid dependency
  */
 export function isEthSigningManager(
   manager: SigningManager | null | undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -3658,7 +3658,7 @@ __metadata:
     "@polkadot/util-crypto": "npm:13.5.9"
     "@polymeshassociation/local-signing-manager": "npm:^4.1.1"
     "@polymeshassociation/polymesh-types": "npm:^7.5.0"
-    "@polymeshassociation/signing-manager-types": "npm:3.8.0-beta.1"
+    "@polymeshassociation/signing-manager-types": "npm:3.8.0"
     "@semantic-release/changelog": "npm:^6.0.3"
     "@types/jest": "npm:^29.5.14"
     "@types/jest-when": "npm:^3.5.2"
@@ -3746,12 +3746,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymeshassociation/signing-manager-types@npm:3.8.0-beta.1":
-  version: 3.8.0-beta.1
-  resolution: "@polymeshassociation/signing-manager-types@npm:3.8.0-beta.1"
+"@polymeshassociation/signing-manager-types@npm:3.8.0":
+  version: 3.8.0
+  resolution: "@polymeshassociation/signing-manager-types@npm:3.8.0"
   dependencies:
     "@polkadot/api": "npm:16.5.2"
-  checksum: 10c0/8f912d05f87a6db142391c671f061d0afb06f8f7316f68f67e444106c45426eb7455eaddf1483d18eda7da2aabc0464187aa3cf88893862b5c40f285072343c7
+  checksum: 10c0/cd936649bd3f47096056afe432a2a5251b6d3a192d08df5c35b355eb771b7e9f5db88be6e06852b141e014890b8e71c44a4771c4626340ee73a9ad1d8c06d5d9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3658,7 +3658,7 @@ __metadata:
     "@polkadot/util-crypto": "npm:13.5.9"
     "@polymeshassociation/local-signing-manager": "npm:^4.1.1"
     "@polymeshassociation/polymesh-types": "npm:^7.5.0"
-    "@polymeshassociation/signing-manager-types": "npm:^3.7.1"
+    "@polymeshassociation/signing-manager-types": "npm:3.8.0-beta.1"
     "@semantic-release/changelog": "npm:^6.0.3"
     "@types/jest": "npm:^29.5.14"
     "@types/jest-when": "npm:^3.5.2"
@@ -3737,12 +3737,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymeshassociation/signing-manager-types@npm:3.7.1, @polymeshassociation/signing-manager-types@npm:^3.7.1":
+"@polymeshassociation/signing-manager-types@npm:3.7.1":
   version: 3.7.1
   resolution: "@polymeshassociation/signing-manager-types@npm:3.7.1"
   dependencies:
     "@polkadot/api": "npm:16.5.2"
   checksum: 10c0/a6e29495be2547852be80923c1aabffe5ec545a3acb6d85333f3577625ceb836a818ae8cd735a1dc89504b60e98a87f05e39bb66ff6d77bdeea57542a7a255f2
+  languageName: node
+  linkType: hard
+
+"@polymeshassociation/signing-manager-types@npm:3.8.0-beta.1":
+  version: 3.8.0-beta.1
+  resolution: "@polymeshassociation/signing-manager-types@npm:3.8.0-beta.1"
+  dependencies:
+    "@polkadot/api": "npm:16.5.2"
+  checksum: 10c0/8f912d05f87a6db142391c671f061d0afb06f8f7316f68f67e444106c45426eb7455eaddf1483d18eda7da2aabc0464187aa3cf88893862b5c40f285072343c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Sign any Polymesh transaction with an Ethereum key (MetaMask, viem/ethers, Ledger, Fireblocks).

The chain's `revive` pallet dispatches on behalf of `AccountId32 = <20-byte H160> ++ [0xEE; 12]`, so each Ethereum address controls exactly one Polymesh Account.

```ts
const sdk = await Polymesh.connect({ nodeUrl, signingManager: ethSigningManager });
sdk.setSigningAccount(ethDerivedSs58Address);

await sdk.assets.createAsset({ ... });   // unchanged
```

Routing is automatic and per-Account. **No procedure, argument or `ProcedureOpts` changes.** A manager holding both native and Ethereum keys just works.

Two submission modes, picked from what the signer implements:

| Signer implements | Who broadcasts | Nonce owner |
| --- | --- | --- |
| `signTransaction` | SDK | SDK |
| `sendTransaction` | wallet | wallet |

A dry run over the Substrate connection runs **before** the wallet opens, so errors like a missing Identity surface as structured errors, not wallet reverts.

**New API (all additive)**

- `Account.ethAddress` / `.evmAddress` / `.getEvmAddressDetails()`
- `AccountManagement.mapEvmAccount()` / `.unmapEvmAccount()` / `.getAccountByEvmAddress()`
- `PolymeshTransactionBase.broadcast()` — submit without waiting; returns a handle with `watch()`
- `PolymeshTransactionBase.toEthSignablePayload()` + `Network.submitEthTransaction()` — detached/custody signing
- `Network.watchTransaction()` — resume tracking from a hash
- `Network.decodeCall()` — decode SCALE to a readable call
- `SubmissionOpts` (`broadcastTimeout`, `watchTimeout`), `ErrorCode.TransactionTimeout`, `AccountKeyType.Ethereum`

Also fixes a bug affecting **all** transactions: failed dispatches that weren't module errors were reported as `Unknown error`, discarding the reason.

**Limitations** (these throw, not fail silently)

- **No off-chain signatures** — the chain only verifies sr25519/ed25519. Hits bulk secondary-key addition and off-chain receipts. Onboarding an Ethereum key is unaffected.
- **No MultiSig signing** with an Ethereum key.
- **No transaction history** — middleware can't attribute a `revive` extrinsic to the Ethereum Account yet.
- `mortality` and `paidForBy` rejected; explicit `nonce` rejected when the wallet owns it.
- Subsidies ignored on this path — fee is over-reported, never under-reported, so balance checks stay safe.

**Testing**

- Full suite green: 207 suites, 2572 tests
- 100% line coverage on new code (1237/1237 vs `develop`)
- **Not** run against a live chain or real wallet — the reason this is a draft

**Before merging**

1. Live validation against a dev-env chain + MetaMask
2. `@polymeshassociation/signing-manager-types` promoted from `3.8.0-beta.1` to a stable release, and the exact pin relaxed to a range

**Related repos**

- `signing-manager-types` — the `EthSigner` interfaces ([PR #14](https://github.com/PolymeshAssociation/signing-manager-types/pull/14), published as `3.8.0-beta.1`)
- `eth-signing-manager` — the reference MetaMask/viem implementation (not yet published)

### Breaking Changes

None. Everything above is additive. Two things to be aware of even so:

- **`AccountKeyType.Ethereum`** is a new enum variant. Consumers switching exhaustively over `AccountKeyType` will need to handle it. Where an Account is both Ethereum-derived and a MultiSig signer, `MultiSig` still takes priority.
- **`TransactionStatus.InBlock` is now emitted** for transactions tracked by block scanning (offline-signed, HTTP connections, wallet-broadcast). These previously stayed in `Running` until finalization. Progress signal only — the resolved result still comes from a finalized block.

### JIRA Link

<!-- TODO: no ticket referenced in the branch or commits — please add -->

### Checklist

- [ ] Updated the Readme.md (if required) ?

<!--
Not done: the README has no Ethereum signing section, and it does list signing manager
implementations. Probably wants a short section once `eth-signing-manager` is published,
so there is something to link to.
-->
