### PR TITLE
feat: 🎸 support issuing NFTs to the signing Account, not just portfolios

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0, to be included in the next release. Adds support for signing Polymesh transactions with an Ethereum wallet, mapping an Account to its Ethereum address, broadcasting a transaction without waiting for it, and reports on-chain failure reasons that previously surfaced as Unknown error.
+description: Pending changes since Polymesh SDK v31.0.0, to be included in the next release. Adds support for signing Polymesh transactions with an Ethereum wallet, mapping an Account to its Ethereum address, broadcasting a transaction without waiting for it, issuing NFTs directly to an Account, and reports on-chain failure reasons that previously surfaced as Unknown error.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -102,6 +102,19 @@ const { free } = await fallbackAccount.getBalance();
 - `Account.getEvmAddressDetails()` — the address together with its `EvmAddressType` (`Native` for an Ethereum-derived Account, `Derived` otherwise), whether it `isMapped`, and the `fallbackAccount` credited whenever the chain cannot resolve the address. For a `Derived` address the fallback Account is reported **even once the Account is mapped**, because mapping does not move funds that arrived beforehand — so it stays the pointer to anything stranded there. `Native` has no fallback Account, since that Account already _is_ the one the Ethereum key controls.
 - `AccountManagement.mapEvmAccount()` / `unmapEvmAccount()` — register or unregister the signing Account against its derived address. Mapping takes a deposit, released by unmapping. Mapping throws for an Ethereum-derived Account (the chain rejects an `Address20` origin — there is nothing to map) and for an Account that is already mapped; unmapping throws for one that is not.
 - `AccountManagement.getAccountByEvmAddress({ evmAddress })` — the reverse direction, mirroring the chain: the Account that mapped the address, or the `0xEE`-padded fallback Account if none has. It always resolves to an Account, so use `getEvmAddressDetails()` on the Account you expect if you need to know whether a mapping actually exists.
+
+### Issue NFTs directly to an Account
+
+`NftCollection.issue` and `NftCollection.batchIssue` accept an optional `account`, matching the `account` option `FungibleAsset.issue` already offers. The NFT is minted to that Account's asset holdings rather than to a portfolio of the issuing Identity:
+
+```ts
+await collection.issue({
+  metadata: [...],
+  account: sdk.getSigningAccount().address,
+});
+```
+
+`portfolioId` and `account` are mutually exclusive — passing both throws a `ValidationError`. As with fungible issuance, `account` must be the signing Account; any other address throws an `UnmetPrerequisite` error. Omitting both is unchanged: the NFT is issued to the signing Identity's default portfolio.
 
 ### Transaction inclusion is reported before finalization
 

--- a/src/api/entities/Asset/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/NonFungible/NftCollection.ts
@@ -111,9 +111,9 @@ export class NftCollection extends BaseAsset {
 
     this.issue = createProcedureMethod(
       {
-        getProcedureAndArgs: ({ metadata, portfolioId }) => [
+        getProcedureAndArgs: ({ metadata, portfolioId, account }) => [
           issueNft,
-          { collection: this, metadataList: [metadata], portfolioId },
+          { collection: this, metadataList: [metadata], portfolioId, account },
         ],
         transformer: issueNftTransformer,
       },

--- a/src/api/entities/Asset/__tests__/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/__tests__/NonFungible/NftCollection.ts
@@ -516,7 +516,46 @@ describe('NftCollection class', () => {
       when(procedureMockUtils.getPrepareMock())
         .calledWith(
           {
-            args: { collection, metadataList: [args.metadata], portfolioId: args.portfolioId },
+            args: {
+              collection,
+              metadataList: [args.metadata],
+              portfolioId: args.portfolioId,
+              account: undefined,
+            },
+            transformer: issueNftTransformer,
+          },
+          context,
+          {}
+        )
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await collection.issue(args);
+
+      expect(tx).toBe(expectedTransaction);
+    });
+
+    it('should prepare the procedure with the account argument when it is provided', async () => {
+      const assetId = '12341234-1234-1234-1234-123412341234';
+      const context = dsMockUtils.getContextInstance();
+      const collection = new NftCollection({ assetId }, context);
+
+      const args = {
+        metadata: [],
+        account: 'someAddress',
+      };
+
+      const expectedTransaction =
+        'someTransaction' as unknown as PolymeshTransaction<NftCollection>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith(
+          {
+            args: {
+              collection,
+              metadataList: [args.metadata],
+              portfolioId: undefined,
+              account: args.account,
+            },
             transformer: issueNftTransformer,
           },
           context,

--- a/src/api/procedures/__tests__/issueNft.ts
+++ b/src/api/procedures/__tests__/issueNft.ts
@@ -36,6 +36,7 @@ describe('issueNft procedure', () => {
   let rawAssetId: PolymeshPrimitivesAssetAssetId;
   let assetHolderToAssetHolderKindSpy: jest.SpyInstance;
   let nftInputToMetadataValueSpy: jest.SpyInstance;
+  let asAccountSpy: jest.SpyInstance;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -47,6 +48,7 @@ describe('issueNft procedure', () => {
       utilsConversionModule,
       'assetHolderToAssetHolderKind'
     );
+    asAccountSpy = jest.spyOn(utilsInternalModule, 'asAccount');
     assetId = '12341234-1234-1234-1234-123412341234';
     collection = entityMockUtils.getNftCollectionInstance({ assetId });
     rawAssetId = dsMockUtils.createMockAssetId(uuidToHex(assetId));
@@ -77,14 +79,20 @@ describe('issueNft procedure', () => {
       UserPortfolio: dsMockUtils.createMockU64(numberedPortfolioId),
     });
 
+    const signingAddress = '0xdummy';
+    const accountHolderKind = dsMockUtils.createMockAssetHolderKind('Account');
+
     const getPortfolio: EntityGetter<Portfolio> = jest.fn();
     const mockDefaultPortfolio = entityMockUtils.getDefaultPortfolioInstance();
     const mockNumberedPortfolio = entityMockUtils.getNumberedPortfolioInstance({
       did: 'did',
       id: numberedPortfolioId,
     });
+    const mockAccount = entityMockUtils.getAccountInstance({ address: signingAddress });
 
     beforeEach(() => {
+      when(asAccountSpy).calledWith(signingAddress, mockContext).mockReturnValue(mockAccount);
+
       when(getPortfolio)
         .calledWith()
         .mockResolvedValue(mockDefaultPortfolio)
@@ -97,7 +105,9 @@ describe('issueNft procedure', () => {
         .calledWith(mockDefaultPortfolio, mockContext)
         .mockReturnValue(defaultPortfolioHolderKind)
         .calledWith(mockNumberedPortfolio, mockContext)
-        .mockReturnValue(numberedPortfolioHolderKind);
+        .mockReturnValue(numberedPortfolioHolderKind)
+        .calledWith(mockAccount, mockContext)
+        .mockReturnValue(accountHolderKind);
     });
 
     it('should return an issueNft transaction spec', async () => {
@@ -198,6 +208,68 @@ describe('issueNft procedure', () => {
           {
             transaction,
             args: [rawAssetId, [], numberedPortfolioHolderKind],
+          },
+        ],
+        resolver: expect.any(Function),
+      });
+    });
+
+    it('should throw an error if both portfolioId and account are provided', () => {
+      const args = {
+        metadataList: [[]],
+        collection,
+        portfolioId: numberedPortfolioId,
+        account: signingAddress,
+      };
+
+      const proc = procedureMockUtils.getInstance<Params, Nft[]>(mockContext);
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message: 'Only one of portfolioId or account can be provided to issue NFTs',
+      });
+
+      return expect(prepareIssueNft.call(proc, args)).rejects.toThrow(expectedError);
+    });
+
+    it('should throw an error if account is provided but does not match the signing account', () => {
+      const args = {
+        metadataList: [[]],
+        collection,
+        account: 'someOtherAddress',
+      };
+
+      const proc = procedureMockUtils.getInstance<Params, Nft[]>(mockContext);
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'Account should be same as the signing account',
+      });
+
+      return expect(prepareIssueNft.call(proc, args)).rejects.toThrow(expectedError);
+    });
+
+    it('should issue the Nft to the signing Account when account is provided', async () => {
+      const args = {
+        metadataList: [[]],
+        collection,
+        account: signingAddress,
+      };
+
+      nftInputToMetadataValueSpy.mockReturnValue([]);
+
+      const transaction = dsMockUtils.createTxMock('nft', 'issueNft');
+      const proc = procedureMockUtils.getInstance<Params, Nft[]>(mockContext);
+
+      const result = await prepareIssueNft.call(proc, args);
+
+      expect(asAccountSpy).toHaveBeenCalledWith(signingAddress, mockContext);
+      expect(mockContext.getSigningIdentity).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        transactions: [
+          {
+            transaction,
+            args: [rawAssetId, [], accountHolderKind],
           },
         ],
         resolver: expect.any(Function),

--- a/src/api/procedures/issueNft.ts
+++ b/src/api/procedures/issueNft.ts
@@ -12,11 +12,12 @@ import {
   meshNftToNftId,
   nftInputToNftMetadataVec,
 } from '~/utils/conversion';
-import { checkTxType, filterEventRecords } from '~/utils/internal';
+import { asAccount, checkTxType, filterEventRecords } from '~/utils/internal';
 
 export type Params = {
   metadataList: NftMetadataInput[][];
   portfolioId?: BigNumber | undefined;
+  account?: string | undefined;
   collection: NftCollection;
 };
 
@@ -85,7 +86,21 @@ export async function prepareIssueNft(
     },
     context,
   } = this;
-  const { portfolioId, metadataList: nftParams, collection } = args;
+  const { portfolioId, account, metadataList: nftParams, collection } = args;
+
+  if (portfolioId && account) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Only one of portfolioId or account can be provided to issue NFTs',
+    });
+  }
+
+  if (account && context.getSigningAccount().address !== account) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Account should be same as the signing account',
+    });
+  }
 
   const rawMetadataValues = nftParams.map(metadata => nftInputToNftMetadataVec(metadata, context));
 
@@ -93,14 +108,20 @@ export async function prepareIssueNft(
 
   nftParams.forEach(metadata => validateNftParams(metadata, [...neededMetadata], collection.id));
 
-  const signingIdentity = await context.getSigningIdentity();
+  let rawAssetHolder;
+  if (account) {
+    rawAssetHolder = assetHolderToAssetHolderKind(asAccount(account, context), context);
+  } else {
+    const signingIdentity = await context.getSigningIdentity();
 
-  const portfolio = portfolioId
-    ? await signingIdentity.portfolios.getPortfolio({ portfolioId })
-    : await signingIdentity.portfolios.getPortfolio();
+    const portfolio = portfolioId
+      ? await signingIdentity.portfolios.getPortfolio({ portfolioId })
+      : await signingIdentity.portfolios.getPortfolio();
+
+    rawAssetHolder = assetHolderToAssetHolderKind(portfolio, context);
+  }
 
   const rawAssetId = assetToMeshAssetId(collection, context);
-  const rawAssetHolder = assetHolderToAssetHolderKind(portfolio, context);
 
   const transactions = rawMetadataValues.map(metadata =>
     checkTxType({

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1356,6 +1356,13 @@ export type IssueNftParams = {
    * portfolio to which the NFTCollection will be issued (optional, default is the default portfolio)
    */
   portfolioId?: BigNumber;
+
+  /**
+   * (optional) Account to which the NFT will be issued
+   *
+   * @note only one of `portfolioId` or `account` can be provided. If both are not provided, the NFT is issued in the default portfolio
+   */
+  account?: string;
 };
 
 export type BatchIssueNftParams = {
@@ -1367,6 +1374,13 @@ export type BatchIssueNftParams = {
    * portfolio to which the NFTCollection will be issued (optional, default is the default portfolio)
    */
   portfolioId?: BigNumber;
+
+  /**
+   * (optional) Account to which the NFTs will be issued
+   *
+   * @note only one of `portfolioId` or `account` can be provided. If both are not provided, the NFTs are issued in the default portfolio
+   */
+  account?: string;
 };
 
 export interface RedeemTokensParams {


### PR DESCRIPTION
### Description

`NftCollection.issue` and `NftCollection.batchIssue` accept an optional `account`, so an NFT can be minted directly into an Account's asset holdings instead of a portfolio of the issuing Identity. This mirrors the `account` option `FungibleAsset.issue` already offers, using the same param name, guards and error messages:

- `portfolioId` and `account` are mutually exclusive — passing both throws a `ValidationError`.
- `account` must be the signing Account; any other address throws an `UnmetPrerequisite` error.
- Omitting both is unchanged — the NFT goes to the signing Identity's default portfolio.

Changelog entry added to `changelogs/v31.0.0-next.md`. `issueNft.ts` is at 100% statement, branch, function and line coverage.

### Breaking Changes

None — `account` is optional and the existing portfolio paths are untouched.

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
