### PR TITLE
feat: allow connecting from runtimes that disallow WASM compilation

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0, to be included in the next release. Adds support for signing Polymesh transactions with an Ethereum wallet, mapping an Account to its Ethereum address, broadcasting a transaction without waiting for it, issuing NFTs directly to an Account, and reports on-chain failure reasons that previously surfaced as Unknown error.
+description: Pending changes since Polymesh SDK v31.0.0, to be included in the next release. Adds support for signing Polymesh transactions with an Ethereum wallet, mapping an Account to its Ethereum address, broadcasting a transaction without waiting for it, issuing NFTs directly to an Account, connecting from runtimes that disallow WASM compilation, and reports on-chain failure reasons that previously surfaced as Unknown error.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -14,7 +14,7 @@ This guide describes **unreleased** changes since **v31.0.0** of `@polymeshassoc
 
 ## Overview
 
-This release adds support for **signing Polymesh transactions with an Ethereum wallet** such as MetaMask, on chains running the `revive` pallet, adds **Ethereum address mapping** so an Account can safely receive funds at its Ethereum address, and reports on-chain failure reasons that previously surfaced as `Unknown error`. These changes are additive — note the new `AccountKeyType.Ethereum` variant described below.
+This release adds support for **signing Polymesh transactions with an Ethereum wallet** such as MetaMask, on chains running the `revive` pallet, adds **Ethereum address mapping** so an Account can safely receive funds at its Ethereum address, lets a read-only client connect from runtimes that disallow WASM compilation, and reports on-chain failure reasons that previously surfaced as `Unknown error`. These changes are additive — note the new `AccountKeyType.Ethereum` variant described below.
 
 ---
 
@@ -174,6 +174,31 @@ Because it needs nothing but a hash and a block height, tracking can resume in a
 - `ErrorCode.TransactionTimeout`.
 
 Note that `broadcast()` always submits without an extrinsic status subscription, since that channel cannot report a hash without also waiting for the result. The trade-off is that `Future` status reporting and in-pool `Aborted` detection are unavailable on that path — those come from the node's status stream, which only `run()` attaches to.
+
+---
+
+### Connect from runtimes that disallow WASM compilation
+
+`Polymesh.connect` now accepts `polkadot.initWasm`, and the SDK no longer depends on `cross-fetch`. Together these let a read-only client run in sandboxed server runtimes such as Cloudflare Workers (`workerd`), where each was a hard blocker.
+
+Polkadot's `ApiPromise` waits on `cryptoWaitReady()` before emitting `ready`. Where WASM compilation is forbidden that call resolves to `false` rather than rejecting, so `ready` is never emitted and `connect` hangs indefinitely, with no error to trace. Passing `initWasm: false` skips that wait:
+
+```typescript
+const polymesh = await Polymesh.connect({
+  nodeUrl: 'https://some.node.url',
+  polkadot: { initWasm: false },
+});
+```
+
+Read-only use needs no WASM. The SDK never calls `cryptoWaitReady()` itself, and blake2, keccak and the SS58 address codec all fall back to pure JS implementations. Signing is the exception: `cryptoWaitReady()` is what initializes the WASM backend, so with `initWasm: false` it stays uninitialized, and `sr25519` has no JS fallback. A signing manager relying on `sr25519` must call `cryptoWaitReady()` itself — `LocalSigningManager` already does, so the usual setup is unaffected.
+
+`initWasm` defaults to polkadot's behaviour of waiting, so existing callers see no change.
+
+#### `cross-fetch` removed
+
+The SDK requires node >= 20, where `fetch` is a global, so the ponyfill was redundant. It was also actively harmful in restricted runtimes: under the `node` export condition it resolves to a `node:http` build, which Cloudflare's `nodejs_compat` claims and then crashes inside, and under the `browser` condition to an `XMLHttpRequest` build, which `workerd` lacks, so requests never settle. Calls now use the runtime's global `fetch`.
+
+This drops `cross-fetch`, `node-fetch`, `whatwg-url`, `tr46` and `webidl-conversions` from the dependency tree. There are no API changes.
 
 ---
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -190,7 +190,9 @@ const polymesh = await Polymesh.connect({
 });
 ```
 
-Read-only use needs no WASM. The SDK never calls `cryptoWaitReady()` itself, and blake2, keccak and the SS58 address codec all fall back to pure JS implementations. Signing is the exception: `cryptoWaitReady()` is what initializes the WASM backend, so with `initWasm: false` it stays uninitialized, and `sr25519` has no JS fallback. A signing manager relying on `sr25519` must call `cryptoWaitReady()` itself — `LocalSigningManager` already does, so the usual setup is unaffected.
+Read-only use needs no WASM: blake2, keccak and the SS58 address codec all fall back to pure JS implementations. Signing is the exception, since `sr25519` has no JS fallback.
+
+Attaching a Signing Manager now awaits `cryptoWaitReady()`, whether it is passed to `connect` or set later via `setSigningManager`. That call is what initializes the WASM backend, so signing keeps working even with `initWasm: false`, and there is no ordering trap where a Manager attached after connecting would fail at its first signature. It is memoized, costing roughly 8 ms once and nothing thereafter. Where WASM is unavailable a warning is logged at attach time rather than throwing, since `ed25519` and `ecdsa` keys, and remote signers, work without it.
 
 `initWasm` defaults to polkadot's behaviour of waiting, so existing callers see no change.
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "@polkadot/util-crypto": "13.5.9",
     "@polymeshassociation/polymesh-types": "^7.5.0",
     "bignumber.js": "9.0.1",
-    "cross-fetch": "^4.0.0",
     "dayjs": "1.11.9",
     "graphql": "^16.8.0",
     "graphql-tag": "2.12.6",

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -8,7 +8,6 @@ import { ApiPromise, HttpProvider, WsProvider } from '@polkadot/api';
 import { DefinitionsCall } from '@polkadot/types/types';
 import schema from '@polymeshassociation/polymesh-types/polkadot/schema';
 import { SigningManager } from '@polymeshassociation/signing-manager-types';
-import fetch from 'cross-fetch';
 
 import { AccountManagement } from '~/api/client/AccountManagement';
 import { Assets } from '~/api/client/Assets';
@@ -156,7 +155,7 @@ export class Polymesh {
     let context: Context;
     let polymeshApi: ApiPromise;
 
-    const { metadata, noInitWarn, typesBundle } = polkadot ?? {};
+    const { metadata, noInitWarn, typesBundle, initWasm } = polkadot ?? {};
 
     await assertExpectedChainVersion(nodeUrl);
     try {
@@ -178,6 +177,8 @@ export class Polymesh {
         ...(metadata ? { metadata } : {}),
         ...(noInitWarn ? { noInitWarn } : {}),
         ...(typesBundle ? { typesBundle } : {}),
+        /* `false` is the meaningful value, so this cannot be a truthiness check */
+        ...(initWasm !== undefined ? { initWasm } : {}),
       });
       context = await Context.create({
         polymeshApi,

--- a/src/api/client/__tests__/Polymesh.ts
+++ b/src/api/client/__tests__/Polymesh.ts
@@ -134,6 +134,39 @@ describe('Polymesh Class', () => {
       });
     });
 
+    it('should forward `initWasm: false` so that connecting does not wait on the WASM backend', async () => {
+      const apiPromiseCreateSpy = jest.spyOn(polkadotRef.ApiPromise, 'create');
+      dsMockUtils.getContextCreateMock();
+
+      await Polymesh.connect({
+        nodeUrl: 'wss://some.url',
+        polkadot: {
+          initWasm: false,
+        },
+      });
+
+      expect(apiPromiseCreateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initWasm: false,
+        })
+      );
+    });
+
+    it('should not pass `initWasm` when it is not supplied, leaving the polkadot default in place', async () => {
+      const apiPromiseCreateSpy = jest.spyOn(polkadotRef.ApiPromise, 'create');
+      dsMockUtils.getContextCreateMock();
+
+      await Polymesh.connect({
+        nodeUrl: 'wss://some.url',
+      });
+
+      expect(apiPromiseCreateSpy).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          initWasm: expect.anything(),
+        })
+      );
+    });
+
     it('should instantiate Context with middleware V2 URL and return a Polymesh instance', async () => {
       const createMock = dsMockUtils.getContextCreateMock();
 

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -175,6 +175,18 @@ export interface PolkadotConfig {
   noInitWarn?: boolean;
 
   /**
+   * set to `false` to stop `ApiPromise` waiting on the WASM crypto backend before becoming ready
+   *
+   * @note runtimes that forbid WASM compilation (e.g. Cloudflare Workers) otherwise hang on
+   *   connect, since `cryptoWaitReady()` resolves to `false` instead of rejecting
+   *
+   * @note this also leaves the backend uninitialized, since `cryptoWaitReady()` is what
+   *   initializes it. Read only usage is unaffected, but `sr25519` has no JS fallback, so a
+   *   signing manager using it must call `cryptoWaitReady()` itself (`LocalSigningManager` does)
+   */
+  initWasm?: boolean;
+
+  /**
    * allows for types to be provided for multiple chain specs at once
    *
    * @note shouldn't be needed for most use cases

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -17,6 +17,7 @@ import {
   PolymeshPrimitivesProtocolFeeProtocolOp,
 } from '@polkadot/types/lookup';
 import { CallFunction, Codec, DetectCodec, Signer as PolkadotSigner } from '@polkadot/types/types';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { SigningManager } from '@polymeshassociation/signing-manager-types';
 import BigNumber from 'bignumber.js';
 import { chunk, clone, flattenDeep } from 'lodash';
@@ -241,6 +242,8 @@ export class Context {
    *
    * @note the signing Account will be set to the Signing Manager's first Account. If the Signing Manager has
    *   no Accounts yet, the signing Account will be left empty
+   *
+   * @note this initializes the WASM crypto backend, which is a no-op once it is up
    */
   public async setSigningManager(signingManager: SigningManager | null): Promise<void> {
     if (signingManager === null) {
@@ -249,6 +252,13 @@ export class Context {
       this.polymeshApi.setSigner(undefined);
 
       return;
+    }
+
+    // polkadot initializes the WASM backend lazily via this call, and `sr25519` has no JS fallback
+    if (!(await cryptoWaitReady())) {
+      console.warn(
+        'The WASM crypto backend could not be initialized in this environment. Signing with an sr25519 key will not work'
+      );
     }
 
     this._signingManager = signingManager;

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -1,6 +1,7 @@
 import { QueryOptions } from '@apollo/client/core';
 import { ApiPromise } from '@polkadot/api';
 import { Signer as PolkadotSigner } from '@polkadot/types/types';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
 // eslint-disable-next-line import/order
 import BigNumber from 'bignumber.js';
 // eslint-disable-next-line import/order
@@ -36,6 +37,10 @@ jest.mock(
   '@polkadot/api',
   require('~/testUtils/mocks/dataSources').mockPolkadotModule('@polkadot/api')
 );
+jest.mock('@polkadot/util-crypto', () => ({
+  ...jest.requireActual('@polkadot/util-crypto'),
+  cryptoWaitReady: jest.fn(),
+}));
 jest.mock(
   '~/api/entities/Identity',
   require('~/testUtils/mocks/entities').mockIdentityModule('~/api/entities/Identity')
@@ -270,12 +275,58 @@ describe('Context class', () => {
   });
 
   describe('method: setSigningManager', () => {
+    const cryptoWaitReadyMock = cryptoWaitReady as jest.Mock;
+
     beforeAll(() => {
       jest.spyOn(utilsInternalModule, 'assertAddressValid').mockImplementation();
     });
 
+    beforeEach(() => {
+      cryptoWaitReadyMock.mockReset().mockResolvedValue(true);
+    });
+
     afterAll(() => {
       jest.restoreAllMocks();
+    });
+
+    it('should initialize the WASM crypto backend', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      await context.setSigningManager(dsMockUtils.getSigningManagerInstance());
+
+      expect(cryptoWaitReadyMock).toHaveBeenCalled();
+    });
+
+    it('should warn if the WASM crypto backend is unavailable', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      cryptoWaitReadyMock.mockResolvedValue(false);
+
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      await context.setSigningManager(dsMockUtils.getSigningManagerInstance());
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('sr25519'));
+
+      warnSpy.mockRestore();
+    });
+
+    it('should not initialize the WASM crypto backend when unsetting the Signing Manager', async () => {
+      const context = await Context.create({
+        polymeshApi,
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+      });
+
+      cryptoWaitReadyMock.mockClear();
+
+      await context.setSigningManager(null);
+
+      expect(cryptoWaitReadyMock).not.toHaveBeenCalled();
     });
 
     it('should set the passed value as Signing Manager', async () => {

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -9,7 +9,6 @@ import {
 } from '@polkadot/types/lookup';
 import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
-import crossFetch from 'cross-fetch';
 import { when } from 'jest-when';
 import { noop } from 'lodash';
 
@@ -171,14 +170,6 @@ jest.mock(
   require('~/testUtils/mocks/entities').mockAccountModule('~/api/entities/Account')
 );
 jest.mock('ws', require('~/testUtils/mocks/dataSources').mockWebSocketModule());
-
-jest.mock('cross-fetch', () => {
-  return {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    __esModule: true,
-    default: jest.fn(),
-  };
-});
 
 describe('delay', () => {
   beforeAll(() => {
@@ -1371,8 +1362,11 @@ describe('assertExpectedChainVersion', () => {
 
   describe('with http:// connection', () => {
     const originalFetch = global.fetch;
+    let fetchMock: jest.Mock;
+
     beforeAll(() => {
-      global.fetch = jest.fn();
+      fetchMock = jest.fn();
+      global.fetch = fetchMock;
     });
 
     afterAll(() => {
@@ -1384,7 +1378,7 @@ describe('assertExpectedChainVersion', () => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       const requestBase = { headers: { 'Content-Type': 'application/json' }, method: 'POST' };
 
-      when(crossFetch)
+      when(fetchMock)
         .calledWith(url, {
           ...requestBase,
           body: JSON.stringify(CONFIDENTIAL_ASSETS_SUPPORTED_CALL),
@@ -1396,7 +1390,7 @@ describe('assertExpectedChainVersion', () => {
           }),
         } as unknown as Response);
 
-      when(crossFetch)
+      when(fetchMock)
         .calledWith(url, {
           ...requestBase,
           body: JSON.stringify(STATE_RUNTIME_VERSION_CALL),
@@ -1418,7 +1412,7 @@ describe('assertExpectedChainVersion', () => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       const requestBase = { headers: { 'Content-Type': 'application/json' }, method: 'POST' };
 
-      when(crossFetch)
+      when(fetchMock)
         .calledWith(url, {
           ...requestBase,
           body: JSON.stringify(CONFIDENTIAL_ASSETS_SUPPORTED_CALL),
@@ -1437,7 +1431,7 @@ describe('assertExpectedChainVersion', () => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       const requestBase = { headers: { 'Content-Type': 'application/json' }, method: 'POST' };
 
-      when(crossFetch)
+      when(fetchMock)
         .calledWith(url, {
           ...requestBase,
           body: JSON.stringify(STATE_RUNTIME_VERSION_CALL),

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -23,7 +23,6 @@ import { AnyFunction, AnyTuple, IEvent, ISubmittableResult } from '@polkadot/typ
 import { stringUpperFirst } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import BigNumber from 'bignumber.js';
-import fetch from 'cross-fetch';
 import stringify from 'json-stable-stringify';
 import { differenceWith, flatMap, isEqual, mapValues, noop, padEnd, uniq } from 'lodash';
 import { coerce, lt, major, satisfies } from 'semver';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,7 +3673,6 @@ __metadata:
     bignumber.js: "npm:9.0.1"
     case-sensitive-paths-webpack-plugin: "npm:^2.4.0"
     cross-env: "npm:^7.0.3"
-    cross-fetch: "npm:^4.0.0"
     crypto-browserify: "npm:^3.12.0"
     dayjs: "npm:1.11.9"
     eslint: "npm:^8.48.0"
@@ -6944,15 +6943,6 @@ __metadata:
     cross-env: src/bin/cross-env.js
     cross-env-shell: src/bin/cross-env-shell.js
   checksum: 10c0/f3765c25746c69fcca369655c442c6c886e54ccf3ab8c16847d5ad0e91e2f337d36eedc6599c1227904bf2a228d721e690324446876115bc8e7b32a866735ecf
-  languageName: node
-  linkType: hard
-
-"cross-fetch@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "cross-fetch@npm:4.1.0"
-  dependencies:
-    node-fetch: "npm:^2.7.0"
-  checksum: 10c0/628b134ea27cfcada67025afe6ef1419813fffc5d63d175553efa75a2334522d450300a0f3f0719029700da80e96327930709d5551cf6deb39bb62f1d536642e
   languageName: node
   linkType: hard
 
@@ -12224,20 +12214,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0"
-  dependencies:
-    whatwg-url: "npm:^5.0.0"
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:^3.3.2":
   version: 3.3.2
   resolution: "node-fetch@npm:3.3.2"
@@ -15519,13 +15495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
-  languageName: node
-  linkType: hard
-
 "traverse@npm:0.6.8":
   version: 0.6.8
   resolution: "traverse@npm:0.6.8"
@@ -16407,13 +16376,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
-  languageName: node
-  linkType: hard
-
 "webpack-cli@npm:^5.1.4":
   version: 5.1.4
   resolution: "webpack-cli@npm:5.1.4"
@@ -16588,16 +16550,6 @@ __metadata:
   version: 4.0.0
   resolution: "whatwg-mimetype@npm:4.0.0"
   checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: "npm:~0.0.3"
-    webidl-conversions: "npm:^3.0.0"
-  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Adds `polkadot.initWasm` to `Polymesh.connect`, initializes the WASM crypto backend when a Signing Manager is attached, and removes the `cross-fetch` dependency. Together these let a read-only client run in sandboxed server runtimes such as Cloudflare Workers, where each was a hard blocker.

**`initWasm`** — `ApiPromise` gates its `ready` event on `cryptoWaitReady()`. Where WASM compilation is forbidden that call resolves to `false` rather than rejecting, so `ready` is never emitted and `Polymesh.connect` hangs indefinitely with no error to trace. `initWasm: false` skips the gate. It defaults to polkadot's behaviour of waiting, so existing callers are unaffected.

Read-only use needs no WASM — blake2, keccak and the SS58 codec fall back to pure JS. Signing is the exception, since `sr25519` has no JS fallback.

**Signing Manager attachment** — `cryptoWaitReady()` is what lazily initializes the backend, so `initWasm: false` would otherwise leave it down and `sr25519` signing would fail at the first signature, far from the cause. `Context.setSigningManager` now awaits it, covering both attachment paths (`connect` and a later `setSigningManager`), so there is no ordering trap. It is memoized: ~8 ms on the first call, ~0.01 ms after.

It warns rather than throws where WASM is unavailable. `SigningManager` exposes only `getAccounts`, `getExternalSigner` and `setSs58Format`, so the SDK cannot tell whether a given Manager needs `sr25519`, and throwing would break `ed25519`/`ecdsa` keys and remote signers that work fine without it.

**`cross-fetch`** — redundant on node >= 20, and it breaks restricted runtimes: the `node` build uses `node:http`, which Cloudflare's `nodejs_compat` claims and then crashes inside; the `browser` build uses `XMLHttpRequest`, which `workerd` lacks, so requests never settle. Calls now use the global `fetch`. Drops `cross-fetch`, `node-fetch`, `whatwg-url`, `tr46` and `webidl-conversions` from the dependency tree — `@apollo/client` lists `cross-fetch` only as a devDependency, so it leaves consumers entirely.

Notes for reviewers:

- The neighbouring option spreads use truthiness checks, which would silently swallow `initWasm: false` — the only value anyone passes. This uses `!== undefined`.
- Test mocking changed from `jest.mock('cross-fetch')` to stubbing `global.fetch`, which the affected describe block already did. The assertions now exercise the real path.
- Follow-up, not in this PR: with the attachment guard in place, `initWasm` could default to `false`, so restricted runtimes work without the caller knowing to opt in. That is the one genuinely behaviour-changing piece, so it is left for its own review.

### Breaking Changes

None. `initWasm` is optional and defaults to polkadot's existing behaviour of waiting for WASM, so existing callers are unaffected. Attaching a Signing Manager now awaits `cryptoWaitReady()`, which polkadot previously did during `connect` — same work, moved to the point of need. The `cross-fetch` removal is internal, with no API surface changes.

### JIRA Link

<!-- TODO: add ticket -->

### Checklist

- [x] Updated the Readme.md (if required) ? — not required; the new option is documented on `PolkadotConfig` and in `changelogs/v31.0.0-next.md`
