### PR TITLE
fix: 🐛 read withdrawal slashing spans from the stash, not the controller

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0, to be included in the next release. Adds support for signing Polymesh transactions with an Ethereum wallet, mapping an Account to its Ethereum address, broadcasting a transaction without waiting for it, issuing NFTs directly to an Account, connecting from runtimes that disallow WASM compilation, and reports on-chain failure reasons that previously surfaced as Unknown error.
+description: Pending changes since Polymesh SDK v31.0.0, to be included in the next release. Adds support for signing Polymesh transactions with an Ethereum wallet, mapping an Account to its Ethereum address, broadcasting a transaction without waiting for it, issuing NFTs directly to an Account, connecting from runtimes that disallow WASM compilation, reports on-chain failure reasons that previously surfaced as Unknown error, and fixes withdrawing unbonded POLYX where the controller is not the stash.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -211,6 +211,12 @@ This drops `cross-fetch`, `node-fetch`, `whatwg-url`, `tr46` and `webidl-convers
 A failed transaction whose dispatch error was not a module error was reported as `Unknown error`, discarding the reason. `SpRuntimeDispatchError` has fifteen variants, of which only three were handled.
 
 `Token`, `Arithmetic` and `Transactional` errors are now reported by name — an Account that cannot cover a transfer produces `Token error: FundsUnavailable` instead of `Unknown error` — and any other variant falls back to its own name rather than being discarded. This affects all transactions, not only those signed with an Ethereum key.
+
+### Withdraw unbonded POLYX where the controller is not the stash
+
+`staking.withdraw` read the slashing span count from the acting Account, but `staking.slashingSpans` is keyed by the stash — and `withdrawUnbonded` is signed by the controller. Where `staking.setController` had bonded a stash to a separate controller, the lookup missed and the SDK sent `0`, so the chain rejected the call with `IncorrectSlashingSpans` whenever a slashed stash withdrew the last of its bond.
+
+The count is now taken from the stash named in the controller's ledger. An Account that is its own controller is unaffected.
 
 ---
 

--- a/src/api/procedures/__tests__/withdrawUnbondedPolyx.ts
+++ b/src/api/procedures/__tests__/withdrawUnbondedPolyx.ts
@@ -28,6 +28,7 @@ describe('withdrawUnbondedPolyx procedure', () => {
 
   let bigNumberToU32Spy: jest.SpyInstance;
   let rawSpanCount: u32;
+  let stashAddress: string;
 
   let storage: Storage;
 
@@ -40,11 +41,13 @@ describe('withdrawUnbondedPolyx procedure', () => {
     bigNumberToU32Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU32');
     bigNumberToU32Spy.mockReturnValue(rawSpanCount);
 
+    stashAddress = 'someStashAddress';
+
     storage = {
       actingAccount,
       optSpans: dsMockUtils.createMockOption(),
       controllerEntry: {
-        stash: entityMockUtils.getAccountInstance(),
+        stash: entityMockUtils.getAccountInstance({ address: stashAddress }),
         total: new BigNumber(100),
         active: new BigNumber(100),
         unlocking: [],
@@ -84,6 +87,22 @@ describe('withdrawUnbondedPolyx procedure', () => {
 
       const result = await prepareWithdrawUnbondedPolyx.call(proc);
 
+      expect(result).toEqual({
+        transaction: withdrawUnbondedTx,
+        args: [rawSpanCount],
+        resolver: undefined,
+      });
+    });
+
+    it('should count no spans when the slashing spans were not fetched', async () => {
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext, {
+        ...storage,
+        optSpans: null,
+      });
+
+      const result = await prepareWithdrawUnbondedPolyx.call(proc);
+
+      expect(bigNumberToU32Spy).toHaveBeenCalledWith(new BigNumber(0), mockContext);
       expect(result).toEqual({
         transaction: withdrawUnbondedTx,
         args: [rawSpanCount],
@@ -144,6 +163,56 @@ describe('withdrawUnbondedPolyx procedure', () => {
           controllerEntry: null,
         })
       );
+    });
+
+    it('should not fetch slashing spans if the acting account is not a controller', async () => {
+      const slashingSpansMock = dsMockUtils.createQueryMock('staking', 'slashingSpans', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+      mockContext.getActingAccount.mockResolvedValue(actingAccount);
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext);
+      const boundFunc = prepareStorage.bind(proc);
+
+      const result = await boundFunc();
+
+      expect(slashingSpansMock).not.toHaveBeenCalled();
+      expect(result.optSpans).toBeNull();
+    });
+
+    it('should fetch the slashing spans of the stash, not of the signing controller', async () => {
+      const rawStashAddress = dsMockUtils.createMockAccountId(stashAddress);
+      const optSpans = dsMockUtils.createMockOption(
+        dsMockUtils.createMockSlashingSpans({
+          spanIndex: dsMockUtils.createMockU32(),
+          prior: dsMockUtils.createMockVec<u32>([dsMockUtils.createMockU32(new BigNumber(3))]),
+          lastStart: dsMockUtils.createMockU32(),
+          lastNonzeroSlash: dsMockUtils.createMockU32(),
+        })
+      );
+
+      const slashingSpansMock = dsMockUtils.createQueryMock('staking', 'slashingSpans', {
+        returnValue: optSpans,
+      });
+
+      jest
+        .spyOn(utilsConversionModule, 'stringToAccountId')
+        .mockImplementation(address =>
+          address === stashAddress ? rawStashAddress : dsMockUtils.createMockAccountId(address)
+        );
+
+      actingAccount = entityMockUtils.getAccountInstance({
+        address: DUMMY_ACCOUNT_ID,
+        stakingGetLedger: storage.controllerEntry,
+      });
+      mockContext.getActingAccount.mockResolvedValue(actingAccount);
+
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext);
+      const boundFunc = prepareStorage.bind(proc);
+
+      const result = await boundFunc();
+
+      expect(slashingSpansMock).toHaveBeenCalledWith(rawStashAddress);
+      expect(result.optSpans).toBe(optSpans);
     });
   });
 });

--- a/src/api/procedures/withdrawUnbondedPolyx.ts
+++ b/src/api/procedures/withdrawUnbondedPolyx.ts
@@ -13,7 +13,8 @@ import { bigNumberToU32, stringToAccountId } from '~/utils/conversion';
 export interface Storage {
   actingAccount: Account;
   controllerEntry: StakingLedger | null;
-  optSpans: Option<PalletStakingSlashingSlashingSpans>;
+  /** `null` if there is no `controllerEntry`, since the query is keyed by its stash */
+  optSpans: Option<PalletStakingSlashingSlashingSpans> | null;
 }
 
 /**
@@ -42,9 +43,9 @@ export function prepareWithdrawUnbondedPolyx(
     });
   }
 
-  const spanCount = optSpans.isNone
-    ? new BigNumber(0)
-    : new BigNumber(optSpans.unwrap().prior.length + 1);
+  const spanCount = optSpans?.isSome
+    ? new BigNumber(optSpans.unwrap().prior.length + 1)
+    : new BigNumber(0);
   const rawSpanCount = bigNumberToU32(spanCount, context);
 
   return Promise.resolve({
@@ -84,17 +85,18 @@ export async function prepareStorage(this: Procedure<void, void, Storage>): Prom
   } = this;
 
   const actingAccount = await context.getActingAccount();
-  const rawActingAddress = stringToAccountId(actingAccount.address, context);
 
-  const [controllerEntry, spans] = await Promise.all([
-    actingAccount.staking.getLedger(),
-    slashingSpans(rawActingAddress),
-  ]);
+  const controllerEntry = await actingAccount.staking.getLedger();
+
+  // `slashingSpans` is keyed by the stash, which can differ from the signing controller
+  const optSpans = controllerEntry
+    ? await slashingSpans(stringToAccountId(controllerEntry.stash.address, context))
+    : null;
 
   return {
     actingAccount,
     controllerEntry,
-    optSpans: spans,
+    optSpans,
   };
 }
 


### PR DESCRIPTION
### Description

`sdk.staking.withdraw` sent the wrong `numSlashingSpans`.

`staking.slashingSpans` is keyed by the **stash**, but `prepareStorage` queried it
with the acting Account — which for `withdrawUnbonded` is the **controller**. Where
`setStakingController` has bonded a stash to a separate controller, the lookup misses
and the SDK sends `0`. The chain rejects the call with `IncorrectSlashingSpans` when a
slashed stash withdraws the last of its bond.

Fix: read the ledger first to learn the stash, then key the query by
`controllerEntry.stash.address`. This costs a serialised round trip in place of the
previous `Promise.all`, since the stash is only known from the ledger. Where the acting
Account is not a controller, the query is skipped and `optSpans` is `null` — that path
already throws before the count is used.

The existing suite only covered the self-controller case, which is why this passed.
Test storage now gives the stash a distinct address, and the new
`should fetch the slashing spans of the stash, not of the signing controller` case
fails against the old keying.

### Breaking Changes

None. `Storage` is `@hidden`, so widening `optSpans` to
`Option<PalletStakingSlashingSlashingSpans> | null` is not part of the public API.

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [x] Updated the Readme.md (if required) ?
