### PR TITLE
Feat/staking

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0, to be included in the next release. Adds support for signing Polymesh transactions with an Ethereum wallet, mapping an Account to its Ethereum address, broadcasting a transaction without waiting for it, issuing NFTs directly to an Account, connecting from runtimes that disallow WASM compilation, reports on-chain failure reasons that previously surfaced as Unknown error, and fixes withdrawing unbonded POLYX where the controller is not the stash.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -14,7 +14,7 @@ This guide describes **unreleased** changes since **v31.0.0** of `@polymeshassoc
 
 ## Overview
 
-This release adds support for **signing Polymesh transactions with an Ethereum wallet** such as MetaMask, on chains running the `revive` pallet, adds **Ethereum address mapping** so an Account can safely receive funds at its Ethereum address, lets a read-only client connect from runtimes that disallow WASM compilation, and reports on-chain failure reasons that previously surfaced as `Unknown error`. These changes are additive — note the new `AccountKeyType.Ethereum` variant described below.
+This release adds **signing Polymesh transactions with an Ethereum wallet** such as MetaMask on chains running the `revive` pallet, **Ethereum address mapping** so an Account can safely receive funds at its Ethereum address, read-only connection from runtimes that disallow WASM compilation, broadcast without waiting, and much wider staking coverage. Changes are additive — note the new `AccountKeyType.Ethereum` variant below.
 
 ---
 
@@ -38,11 +38,11 @@ sdk.setSigningAccount(ethDerivedSs58Address);
 await sdk.assets.createAsset({ ... });
 ```
 
-Routing is automatic and per-Account: the SDK detects an Ethereum-derived address and switches transports for that transaction only. A signing manager holding both native and Ethereum keys is supported without extra configuration, and no procedure, argument or `ProcedureOpts` changes are required.
+Routing is automatic and per-Account: the SDK detects an Ethereum-derived address and switches transports for that transaction only. A signing manager holding both native and Ethereum keys needs no extra configuration, and no procedure, argument or `ProcedureOpts` changes are required.
 
 **Two submission modes**, chosen from the signer's advertised capabilities:
 
-- **Signers that can return raw signed bytes** (viem/ethers local accounts, Ledger, Fireblocks, KMS/HSM) — the SDK broadcasts and tracks the transaction itself, so the nonce is SDK-controlled and the transaction lifecycle is identical to the native path. The request is hex encoded throughout (EIP-1193 wire format), so a viem or ethers account needs it converted first — `EthSigningManager`'s `fromViemAccount` / `fromEthersWallet` do that.
+- **Signers returning raw signed bytes** (viem/ethers local accounts, Ledger, Fireblocks, KMS/HSM) — the SDK broadcasts and tracks the transaction, so the nonce is SDK-controlled and the lifecycle matches the native path. The request is hex encoded throughout (EIP-1193 wire format), so viem and ethers accounts need conversion first — `EthSigningManager`'s `fromViemAccount` / `fromEthersWallet` do that.
 - **Wallets that sign and broadcast themselves** (MetaMask and other injected EIP-1193 providers) — the wallet owns the nonce, and the SDK correlates the result back to the Substrate extrinsic by matching `keccak256` of the `revive.ethTransact` payload against the Ethereum transaction hash.
 
 **Before the wallet is opened**, the SDK performs a dry run over the Substrate connection. Failures such as a missing Identity are reported as structured errors up front rather than as a wallet-level revert.
@@ -55,21 +55,21 @@ Routing is automatic and per-Account: the SDK detects an Ethereum-derived addres
 - `PolymeshTransactionBase.toEthSignablePayload()` and `Network.submitEthTransaction()` — detached/custody signing, for Fireblocks, KMS/HSM and air-gapped flows. No signing manager is required to build the payload; pass `{ eip1559: false }` for a signer that can only encode legacy transactions. The returned `transaction` is hex encoded the same way — `EthSigningManager` exports `toEthersTransaction` / `toViemTransaction` to convert it, without requiring the manager itself.
 - `Network.decodeCall(hex)` — decodes a SCALE-encoded call into its `TxTag`, argument metadata and a human-readable form, so a dapp can display what is being signed alongside the wallet prompt.
 
-**Fees.** `getTotalFees()` remains the single entry point and is correct on both paths. On the Ethereum path the `gas` component is derived from the dry run (`ethGas × gasPrice ÷ nativeToEthRatio`) rather than from `payment_queryInfo`, so it may differ slightly from the equivalent native call — measured at 1.008–1.011× the fee the chain actually charges, erring on the safe side. Protocol fees are charged separately and are still summed into the total, so balance checks continue to protect against a transaction that would be included, fail, and charge anyway.
+**Fees.** `getTotalFees()` remains the single entry point and is correct on both paths. On the Ethereum path the `gas` component comes from the dry run (`ethGas × gasPrice ÷ nativeToEthRatio`) rather than `payment_queryInfo`, so it may differ slightly from the native equivalent — measured at 1.008–1.011× what the chain charges, erring high. Protocol fees are still summed into the total, so balance checks continue to protect against a transaction that would be included, fail, and charge anyway.
 
-Note that an Ethereum-signed transaction costs somewhat more than the same call signed natively, because the outer extrinsic carries the entire signed Ethereum transaction as its payload.
+An Ethereum-signed transaction costs more than the same call signed natively, because the outer extrinsic carries the entire signed Ethereum transaction as its payload.
 
 **Limitations.** These throw rather than failing silently:
 
-- **Off-chain signatures are not supported.** The chain's `verify_any_signature` accepts only sr25519 and ed25519, so an Ethereum key cannot produce one. This affects bulk secondary-key addition (`addSecondaryAccountsWithAuth`) and off-chain settlement/investment receipts. Onboarding an Ethereum key into an existing Identity still works — that flow uses two ordinary signed dispatches (`inviteAccount`, then accepting the authorization) — but the joining key must hold POLYX to pay its own fee, as described above.
+- **Off-chain signatures are not supported.** The chain's `verify_any_signature` accepts only sr25519 and ed25519, so an Ethereum key cannot produce one. This affects bulk secondary-key addition (`addSecondaryAccountsWithAuth`) and off-chain settlement/investment receipts. Onboarding an Ethereum key into an existing Identity still works — two ordinary signed dispatches (`inviteAccount`, then accepting) — but the joining key must hold POLYX for its own fee, as below.
 - **MultiSig signing with an Ethereum key is out of scope** for this release and throws `NotSupported`.
-- **Transaction history is not yet available** for Ethereum-derived Accounts. The middleware cannot currently attribute a `revive` extrinsic to the Ethereum Account, so `getTransactionHistory()` throws `NotSupported` rather than returning a misleadingly empty list. Balance activity driven by chain events (e.g. `getPolyxTransactions`) is unaffected.
+- **Transaction history is not yet available** for Ethereum-derived Accounts. The middleware cannot attribute a `revive` extrinsic to the Ethereum Account, so `getTransactionHistory()` throws `NotSupported` rather than returning a misleadingly empty list. Event-driven balance activity (e.g. `getPolyxTransactions`) is unaffected.
 - **`toSignablePayload()` throws** for an Ethereum-derived Account; use `toEthSignablePayload()` instead.
 - **`mortality` is rejected**, as is an explicit `nonce` when the wallet owns nonce management. Ethereum transactions have no era — replay protection comes from the nonce and chain ID. `paidForBy` is accepted but has no effect, since the signing Account pays regardless.
 
-**An Ethereum-derived Account always pays its own fees.** `revive.ethTransact` is a bare extrinsic, so neither a subsidy nor a third-party payer reaches the chain's fee pipeline — gas is charged to the signing Account. `getTotalFees()` reports this accurately, attributing the fee to the caller in both cases.
+**An Ethereum-derived Account always pays its own fees.** `revive.ethTransact` is a bare extrinsic, so neither a subsidy nor a third-party payer reaches the chain's fee pipeline; `getTotalFees()` attributes the fee to the caller accordingly.
 
-The practical consequence is that **an Ethereum key must hold POLYX before it can join an Identity**, where a native key does not: accepting a `JoinIdentity` authorization is normally paid for by the inviting Identity, and that does not apply here. Fund the Account first, or the transaction fails on chain for insufficient balance.
+So **an Ethereum key must hold POLYX before it can join an Identity**, where a native key need not — accepting a `JoinIdentity` authorization is normally paid by the inviting Identity. Fund the Account first, or the transaction fails on chain for insufficient balance.
 
 ### Map an Account to its Ethereum address
 
@@ -78,7 +78,7 @@ Polymesh Accounts are 32 bytes (`AccountId32`); Ethereum addresses are 20 (`H160
 - **Ethereum key → Account.** The key is padded, `AccountId32 = <20-byte H160> ++ [0xEE; 12]`. The chain inverts this by stripping the padding, so it always works and needs no setup. This is the Account an Ethereum wallet signs for.
 - **Account → Ethereum address.** The address is `keccak256(<32-byte AccountId32>)[12..]`. Hashing is lossy, so **the chain cannot invert it**. Until the Account calls `revive.mapAccount`, the chain resolves that address to its `0xEE`-padded fallback Account instead — and anything sent there is credited to the fallback Account, not to yours.
 
-The practical consequence: **map the Account before advertising its Ethereum address or receiving funds at it.** Funds already sent to an unmapped address are not lost — the chain's `revive.dispatchAsFallbackAccount` can dispatch on the fallback Account's behalf — but recovering them is manual and is not wrapped by the SDK in this release.
+So **map the Account before advertising its Ethereum address or receiving funds at it.** Funds already sent to an unmapped address are not lost — `revive.dispatchAsFallbackAccount` can dispatch on the fallback Account's behalf — but recovery is manual and not wrapped by the SDK in this release.
 
 ```ts
 const account = await sdk.accountManagement.getSigningAccount();
@@ -99,7 +99,7 @@ const { free } = await fallbackAccount.getBalance();
 **New API surface** (all additive):
 
 - `Account.evmAddress` — the Ethereum address the chain associates with the Account, mirroring revive's address mapper. Synchronous, and defined for every Account: the padded Ethereum key for an Ethereum-derived Account, the `keccak256` derivation otherwise. It reports what the address _would_ be, not whether the chain can resolve it.
-- `Account.getEvmAddressDetails()` — the address together with its `EvmAddressType` (`Native` for an Ethereum-derived Account, `Derived` otherwise), whether it `isMapped`, and the `fallbackAccount` credited whenever the chain cannot resolve the address. For a `Derived` address the fallback Account is reported **even once the Account is mapped**, because mapping does not move funds that arrived beforehand — so it stays the pointer to anything stranded there. `Native` has no fallback Account, since that Account already _is_ the one the Ethereum key controls.
+- `Account.getEvmAddressDetails()` — the address with its `EvmAddressType` (`Native` for an Ethereum-derived Account, `Derived` otherwise), whether it `isMapped`, and the `fallbackAccount`. A `Derived` address reports its fallback Account **even once mapped**, since it remains the pointer to anything stranded there beforehand; `Native` has none, that Account already _being_ the one the Ethereum key controls.
 - `AccountManagement.mapEvmAccount()` / `unmapEvmAccount()` — register or unregister the signing Account against its derived address. Mapping takes a deposit, released by unmapping. Mapping throws for an Ethereum-derived Account (the chain rejects an `Address20` origin — there is nothing to map) and for an Account that is already mapped; unmapping throws for one that is not.
 - `AccountManagement.getAccountByEvmAddress({ evmAddress })` — the reverse direction, mirroring the chain: the Account that mapped the address, or the `0xEE`-padded fallback Account if none has. It always resolves to an Account, so use `getEvmAddressDetails()` on the Account you expect if you need to know whether a mapping actually exists.
 
@@ -114,21 +114,119 @@ await collection.issue({
 });
 ```
 
-`portfolioId` and `account` are mutually exclusive — passing both throws a `ValidationError`. As with fungible issuance, `account` must be the signing Account; any other address throws an `UnmetPrerequisite` error. Omitting both is unchanged: the NFT is issued to the signing Identity's default portfolio.
+`portfolioId` and `account` are mutually exclusive — passing both throws `ValidationError`. As with fungible issuance, `account` must be the signing Account; any other address throws `UnmetPrerequisite`. Omitting both is unchanged: the NFT goes to the signing Identity's default portfolio.
+
+### Read era progress, historical eras and the staking constants
+
+`staking.eraProgress()` reports which era and session are in force and how far through each the chain has got — previously derivable only from BABE slots and session indices via `_polkadotApi`.
+
+Progress is counted in **slots**, so it advances every block and `progress` is exact. `remaining` and `end` are projections from `expectedBlockTime` and drift with block production.
+
+```typescript
+const { era, session } = await sdk.staking.eraProgress();
+
+era.index; // the active era
+era.planned; // the latest planned era; ahead of `index` during an election
+era.progress.progress; // 0–1, exact — drive a bar from this
+era.progress.remaining; // projected ms left — drive a countdown from this
+session.inEra; // which session of the era, 1-based
+session.progress.progress; // the epoch bar
+```
+
+Pass a callback and it fires every block, so a progress bar needs no polling:
+
+```typescript
+const unsub = await sdk.staking.eraProgress(({ era, session }) => {
+  setEraBar(era.progress.progress.toNumber());
+  setSessionBar(session.progress.progress.toNumber());
+});
+```
+
+`era.start` is `null` in the brief window between the chain creating the era at session rotation and recording its start on the next block. Progress is unaffected, since slots are always available.
+
+`staking.getConstants()` returns the constants the staking maths is defined against, with two derived values every consumer otherwise recomputes:
+
+- `eraDuration` — `expectedBlockTime × slotsPerSession × sessionsPerEra`
+- `erasPerYear` — counted against the **Julian year of 365.25 days**, which the chain's reward calculation uses. Annualising against 365 days overstates it by 0.0685%.
+
+It also surfaces `bondingDuration`; `historyDepth`, how many past eras the chain keeps and so what the per-era reads return `null` beyond; and `fixedYearlyReward` / `maxVariableInflationTotalIssuance`, the inputs to Polymesh's fixed-reward cap. `fixedYearlyReward` moved from the `staking` pallet to `validators` between runtimes. No query is made; these come from chain metadata.
+
+`staking.getEraRewardPoints()`, `getEraValidatorReward()`, `getEraStartSession()`, `getEraExposure()` and `getEraNominators()` read historical era data that previously required `_polkadotApi`. Each takes an optional `era`, defaulting to the active one, and returns `null` where the chain holds nothing — an era outside the history depth, or an Account absent from that era's validator set.
+
+Exposure is split in two because the chain pages nominators so a payout fits in a block: `getEraExposure` returns the totals and a `pageCount`, `getEraNominators` one page.
+
+```typescript
+const { total, own, pageCount } = await sdk.staking.getEraExposure({ validator });
+const { nominators } = await sdk.staking.getEraNominators({ validator, page: new BigNumber(0) });
+```
+
+`getEraRewardPoints()` is also subscribable — points accrue block by block as validators author, so for the active era this is a live leaderboard:
+
+```typescript
+const unsub = await sdk.staking.getEraRewardPoints(({ total, individual }) => { ... });
+```
+
+Only the active era changes; subscribing to a past era calls back once and stops.
+
+`staking.getElectionPhase()` returns the election's phase as an `ElectionPhase` enum, and is subscribable too. Staking transactions behave differently while an election is open, so a UI should say when this is anything other than `Off` — and a warning that waits for the next poll arrives after the user has acted.
+
+### Read the validator set, historical commission and total issuance
+
+Three reads a staking dashboard needs that previously meant dropping to `_polkadotApi`.
+
+`staking.getActiveValidators()` returns the set actually **in force** for the active era, and `staking.getValidatorCount()` how many the chain aims to elect. Both differ from `staking.getValidators()`, which lists every Account _declaring intent_ — the waiting set is the difference.
+
+```typescript
+const [active, intending] = await Promise.all([
+  sdk.staking.getActiveValidators(),
+  sdk.staking.getValidators(),
+]);
+```
+
+`account.staking.getCommission()` now takes an optional `era`, reading what the Account was **elected on** rather than what it advertises now:
+
+```typescript
+const now = await account.staking.getCommission();
+const then = await account.staking.getCommission({ era: new BigNumber(7131) });
+```
+
+A validator can change its advertised commission at any time, but the elected value is fixed for the era and is what that era's rewards were calculated against — so charting commission over time needs the second. Returns `null` for an era the Account was not in the set for.
+
+`network.getTotalIssuance()` returns every POLYX the chain has issued — the denominator for a staking ratio, and an input to Polymesh's inflation curve alongside `getConstants().maxVariableInflationTotalIssuance`. Subscribable, like `getTreasuryBalance()`.
+
+**Corrected documentation.** `StakingEraInfo` now explains that the chain tracks **two** era numbers, which are not interchangeable. `currentEra` is the latest era the chain has _planned_ — elected, but perhaps not yet brought into force by the Session pallet. `activeEra` is the era whose validator set is in force and whose rewards and slashes are being processed. `currentEra` runs ahead between an election and the rotation that follows, and equals `activeEra` otherwise. Code describing what the chain is doing now wants `activeEra` — but `currentEra` was documented only as "The current era", which invites the opposite reading.
+
+`StakingEraInfo.activeEraStart` and `ActiveEraInfo.start` were documented as a block number. They are a **millisecond Unix timestamp**, the field the chain uses when computing each era's payout. Code reading them as block numbers was computing nonsense.
+
+### Stop nominating, and rebond without waiting
+
+`staking.chill()` and `staking.rebond()` complete the SDK's coverage of the chain's staking actions. Both must be signed by a controller.
+
+`chill` stops nominating **without unbonding** — previously the only way out of a validator set was to `unbond` and wait the full bonding duration. The POLYX stays bonded and can be re-nominated at any time.
+
+```typescript
+await sdk.staking.chill();
+```
+
+`rebond` returns POLYX that is currently unbonding to the active bond, without waiting for the lockup to elapse. It throws `InsufficientBalance` if the amount exceeds the total across all unlocking chunks.
+
+```typescript
+await sdk.staking.rebond({ amount: new BigNumber(100) });
+```
 
 ### Transaction inclusion is reported before finalization
 
-Transactions tracked by scanning blocks — offline-signed submissions, HTTP connections, and Ethereum transactions broadcast by a wallet — previously stayed in `Running` until the block containing them was finalized, with no intermediate feedback for roughly 15–25 seconds.
+Transactions tracked by scanning blocks — offline-signed submissions, HTTP connections, and Ethereum transactions broadcast by a wallet — previously stayed in `Running` until the containing block was finalized, with no feedback for roughly 15–25 seconds.
 
-The scan now reports inclusion as soon as the transaction appears in a block, emitting `TransactionStatus.InBlock` after roughly one block. The resolved result still comes from a finalized block, so this is a progress signal only and cannot report a transaction that is later reorganised away as complete.
+The scan now emits `TransactionStatus.InBlock` as soon as the transaction appears in a block, after roughly one block. The resolved result still comes from a finalized block, so this is a progress signal only and cannot report a transaction later reorganised away as complete.
 
-Where the node connection supports subscriptions, blocks are now followed by subscription rather than polled, which removes a repeating poll cycle per in-flight transaction.
+Where the connection supports subscriptions, blocks are now followed by subscription rather than polled, removing a repeating poll cycle per in-flight transaction.
 
 ### Broadcast without waiting, and bound how long waiting lasts
 
-Transactions tracked by scanning blocks previously had no upper bound on how long they would wait, and no way to stop waiting. A wallet prompt the user never answers — MetaMask dismissed, the extension backgrounded — left `run()` pending indefinitely, and there was no path anywhere that submitted a transaction without also tracking it to finalization.
+Transactions tracked by scanning blocks previously had no upper bound on how long they would wait, and no way to stop. A wallet prompt the user never answers — MetaMask dismissed, the extension backgrounded — left `run()` pending indefinitely, and nothing submitted a transaction without also tracking it to finalization.
 
-`transaction.broadcast()` splits `run()` at its natural seam. It returns once the transaction has been accepted for broadcast, handing back the hash and a `watch` that performs the second half:
+`transaction.broadcast()` splits `run()` at its natural seam, returning once the transaction is accepted for broadcast and handing back the hash plus a `watch` for the second half:
 
 ```ts
 const tx = await sdk.assets.createAsset({ ... });
@@ -139,7 +237,7 @@ const { txHash, startingBlock, watch } = await tx.broadcast();
 const asset = await watch({ timeout: 60000 }); // same value `run()` would have returned
 ```
 
-`watch()` runs the same resolver `run()` does, so nothing is lost by broadcasting first. It can be retried if it times out — nothing is resubmitted, the block scan simply starts again.
+`watch()` runs the same resolver `run()` does, so nothing is lost by broadcasting first, and it can be retried if it times out — nothing is resubmitted, the block scan simply restarts.
 
 To bound `run()` itself, pass `submission` in the Procedure options:
 
@@ -152,7 +250,7 @@ const tx = await sdk.assets.createAsset(
 
 `broadcastTimeout` covers the wallet confirmation prompt; `watchTimeout` covers the wait for a finalized block. Both default to waiting indefinitely, so existing behavior is unchanged. The same options are accepted by `Network.submitTransaction()` and `Network.submitEthTransaction()`.
 
-**A timeout never cancels a transaction** — it only stops the SDK waiting. Both raise the new `ErrorCode.TransactionTimeout`, distinct from `TransactionAborted` and `TransactionReverted` precisely because the transaction may still be included afterwards. For the same reason a `watchTimeout` leaves the transaction's status at `Running` or `InBlock` rather than moving it to `Failed`. Nothing is automatically resubmitted or gas-bumped: on the wallet-broadcast path the SDK does not own the nonce, so an automatic retry risks submitting the same transaction twice.
+**A timeout never cancels a transaction** — it only stops the SDK waiting. Both raise the new `ErrorCode.TransactionTimeout`, distinct from `TransactionAborted` and `TransactionReverted` precisely because the transaction may still be included afterwards; for the same reason a `watchTimeout` leaves the status at `Running` or `InBlock` rather than `Failed`. Nothing is resubmitted or gas-bumped automatically: on the wallet-broadcast path the SDK does not own the nonce, so a retry risks submitting twice.
 
 `Network.watchTransaction()` picks tracking back up from a hash alone, for a transaction that was broadcast but never watched, or whose watch timed out:
 
@@ -164,7 +262,7 @@ const details = await sdk.network.watchTransaction({
 });
 ```
 
-Because it needs nothing but a hash and a block height, tracking can resume in a later session — after a page reload, where the original `watch` no longer exists.
+Needing nothing but a hash and a block height, tracking can resume in a later session — after a page reload, where the original `watch` no longer exists.
 
 **New API surface** (all additive):
 
@@ -173,7 +271,7 @@ Because it needs nothing but a hash and a block height, tracking can resume in a
 - `Network.watchTransaction()` — resume tracking a broadcast transaction by hash.
 - `ErrorCode.TransactionTimeout`.
 
-Note that `broadcast()` always submits without an extrinsic status subscription, since that channel cannot report a hash without also waiting for the result. The trade-off is that `Future` status reporting and in-pool `Aborted` detection are unavailable on that path — those come from the node's status stream, which only `run()` attaches to.
+`broadcast()` always submits without an extrinsic status subscription, since that channel cannot report a hash without also waiting for the result. The trade-off is that `Future` status reporting and in-pool `Aborted` detection are unavailable there — both come from the node's status stream, which only `run()` attaches to.
 
 ---
 
@@ -181,7 +279,7 @@ Note that `broadcast()` always submits without an extrinsic status subscription,
 
 `Polymesh.connect` now accepts `polkadot.initWasm`, and the SDK no longer depends on `cross-fetch`. Together these let a read-only client run in sandboxed server runtimes such as Cloudflare Workers (`workerd`), where each was a hard blocker.
 
-Polkadot's `ApiPromise` waits on `cryptoWaitReady()` before emitting `ready`. Where WASM compilation is forbidden that call resolves to `false` rather than rejecting, so `ready` is never emitted and `connect` hangs indefinitely, with no error to trace. Passing `initWasm: false` skips that wait:
+Polkadot's `ApiPromise` waits on `cryptoWaitReady()` before emitting `ready`. Where WASM compilation is forbidden that call resolves to `false` rather than rejecting, so `ready` never fires and `connect` hangs indefinitely with no error to trace. Passing `initWasm: false` skips the wait:
 
 ```typescript
 const polymesh = await Polymesh.connect({
@@ -192,13 +290,13 @@ const polymesh = await Polymesh.connect({
 
 Read-only use needs no WASM: blake2, keccak and the SS58 address codec all fall back to pure JS implementations. Signing is the exception, since `sr25519` has no JS fallback.
 
-Attaching a Signing Manager now awaits `cryptoWaitReady()`, whether it is passed to `connect` or set later via `setSigningManager`. That call is what initializes the WASM backend, so signing keeps working even with `initWasm: false`, and there is no ordering trap where a Manager attached after connecting would fail at its first signature. It is memoized, costing roughly 8 ms once and nothing thereafter. Where WASM is unavailable a warning is logged at attach time rather than throwing, since `ed25519` and `ecdsa` keys, and remote signers, work without it.
+Attaching a Signing Manager now awaits `cryptoWaitReady()`, whether passed to `connect` or set later via `setSigningManager`. That call initializes the WASM backend, so signing keeps working with `initWasm: false` and there is no ordering trap where a Manager attached after connecting fails at its first signature. It is memoized — roughly 8 ms once, nothing thereafter. Where WASM is unavailable a warning is logged rather than thrown, since `ed25519` and `ecdsa` keys and remote signers work without it.
 
 `initWasm` defaults to polkadot's behaviour of waiting, so existing callers see no change.
 
 #### `cross-fetch` removed
 
-The SDK requires node >= 20, where `fetch` is a global, so the ponyfill was redundant. It was also actively harmful in restricted runtimes: under the `node` export condition it resolves to a `node:http` build, which Cloudflare's `nodejs_compat` claims and then crashes inside, and under the `browser` condition to an `XMLHttpRequest` build, which `workerd` lacks, so requests never settle. Calls now use the runtime's global `fetch`.
+The SDK requires node >= 20, where `fetch` is a global, so the ponyfill was redundant — and harmful in restricted runtimes: the `node` export condition resolves to a `node:http` build, which Cloudflare's `nodejs_compat` claims and then crashes inside, and the `browser` condition to an `XMLHttpRequest` build, which `workerd` lacks, so requests never settle. Calls now use the runtime's global `fetch`.
 
 This drops `cross-fetch`, `node-fetch`, `whatwg-url`, `tr46` and `webidl-conversions` from the dependency tree. There are no API changes.
 
@@ -208,15 +306,31 @@ This drops `cross-fetch`, `node-fetch`, `whatwg-url`, `tr46` and `webidl-convers
 
 ### Report the actual reason an on-chain transaction failed
 
-A failed transaction whose dispatch error was not a module error was reported as `Unknown error`, discarding the reason. `SpRuntimeDispatchError` has fifteen variants, of which only three were handled.
+A failed transaction whose dispatch error was not a module error was reported as `Unknown error`, discarding the reason: `SpRuntimeDispatchError` has fifteen variants and only three were handled.
 
-`Token`, `Arithmetic` and `Transactional` errors are now reported by name — an Account that cannot cover a transfer produces `Token error: FundsUnavailable` instead of `Unknown error` — and any other variant falls back to its own name rather than being discarded. This affects all transactions, not only those signed with an Ethereum key.
+`Token`, `Arithmetic` and `Transactional` errors are now reported by name — an Account that cannot cover a transfer gives `Token error: FundsUnavailable` — and any other variant falls back to its own name. This affects all transactions, not only Ethereum-signed ones.
+
+### The total staked amount was reported in the chain's smallest unit
+
+`staking.eraInfo()` documented `totalStaked` as POLYX but returned `erasTotalStake` unshifted, so the value was 1,000,000× too large. It is now converted as a balance, like every other POLYX amount the SDK returns.
+
+This is a **behaviour change on an existing method** — code dividing by `1e6` to compensate must stop. All staking amounts now agree on units.
+
+### Staking actions applied permission checks the chain does not
+
+`pallet_staking` never consults a signer's `ExtrinsicPermissions` — no Substrate pallet in the Polymesh runtime does — so no staking action requires a permission. The SDK disagreed in three ways:
+
+- **`unbond()`, `bondExtra()` and `rebond()` declared real transaction tags**, so a secondary key lacking the tag was **refused** — a client-side rejection of a call the chain accepts.
+- **`bond()`, `chill()`, `withdraw()`, `setController()` and `setPayee()` declared empty permission arrays.** These pass, but an empty `SimplePermissions` still routes through `Account.checkPermissions`, which reads the key's permissions from chain and **throws `DataUnavailable` for an Account with no Identity** — failing the call with a message about a missing Identity rather than anything to do with staking, and costing a query either way.
+- **`nominate()` declared `signerPermissions: true`.** Correct in effect, but that overrides only the secondary-key branch, reading as though external agents were restricted.
+
+All seven now return `permissions: true`: it short-circuits both checks, makes no query, and cannot fail for a keyless Account.
 
 ### Withdraw unbonded POLYX where the controller is not the stash
 
-`staking.withdraw` read the slashing span count from the acting Account, but `staking.slashingSpans` is keyed by the stash — and `withdrawUnbonded` is signed by the controller. Where `staking.setController` had bonded a stash to a separate controller, the lookup missed and the SDK sent `0`, so the chain rejected the call with `IncorrectSlashingSpans` whenever a slashed stash withdrew the last of its bond.
+`staking.withdraw` read the slashing span count from the acting Account, but `staking.slashingSpans` is keyed by the stash while `withdrawUnbonded` is signed by the controller. Where `setController` had bonded a stash to a separate controller the lookup missed and the SDK sent `0`, so the chain rejected the call with `IncorrectSlashingSpans` whenever a slashed stash withdrew the last of its bond.
 
-The count is now taken from the stash named in the controller's ledger. An Account that is its own controller is unaffected.
+The count now comes from the stash named in the controller's ledger. An Account that is its own controller is unaffected.
 
 ---
 

--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -169,6 +169,53 @@ export class Network {
   }
 
   /**
+   * Get the total POLYX in existence
+   *
+   * @returns Promise that resolves to the current total issuance
+   *
+   * @note this is every POLYX the chain has issued, not the circulating or staked amount. It is
+   *   the denominator for a staking ratio, and one of the inputs to Polymesh's inflation curve —
+   *   see {@link api/client/Staking!Staking.getConstants | staking.getConstants}
+   */
+  public getTotalIssuance(): Promise<BigNumber>;
+
+  /**
+   * Get the total POLYX in existence (with subscription support)
+   *
+   * @param callback - Callback function that receives issuance updates
+   *
+   * @returns Promise that resolves to an unsubscribe function
+   *
+   * @note can be subscribed to, if connected to node using a web socket
+   */
+  public getTotalIssuance(callback: SubCallback<BigNumber>): Promise<UnsubCallback>;
+
+  // eslint-disable-next-line require-jsdoc
+  public async getTotalIssuance(
+    callback?: SubCallback<BigNumber>
+  ): Promise<BigNumber | UnsubCallback> {
+    const {
+      context,
+      context: {
+        polymeshApi: {
+          query: { balances },
+        },
+      },
+    } = this;
+
+    if (callback) {
+      context.assertSupportsSubscription();
+
+      return balances.totalIssuance(rawIssuance => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- callback errors should be handled by the caller
+        callback(balanceToBigNumber(rawIssuance));
+      });
+    }
+
+    return balanceToBigNumber(await balances.totalIssuance());
+  }
+
+  /**
    * Transfer an amount of POLYX to a specified Account
    */
   public transferPolyx: ProcedureMethod<TransferPolyxParams, void>;

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -1,5 +1,5 @@
-import { Option, u32, u128 } from '@polkadot/types';
-import { PalletStakingActiveEraInfo } from '@polkadot/types/lookup';
+import { Option, u32, u64, u128 } from '@polkadot/types';
+import { PalletStakingActiveEraInfo, PalletStakingEraRewardPoints } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 
 import {
@@ -8,6 +8,7 @@ import {
   chillStaking,
   Context,
   nominateValidators,
+  PolymeshError,
   setStakingController,
   setStakingPayee,
   updateBondedPolyx,
@@ -16,26 +17,69 @@ import {
 import {
   ActiveEraInfo,
   BondPolyxParams,
+  ElectionPhase,
+  EraExposure,
+  EraNominators,
+  EraProgress,
+  EraRewardPoints,
+  ErrorCode,
   NoArgsProcedureMethod,
   NominateValidatorsParams,
   PaginationOptions,
+  PeriodProgress,
   ProcedureMethod,
   ResultSet,
   SetStakingPayeeParams,
   StakingCommission,
+  StakingConstants,
   StakingEraInfo,
   SubCallback,
   UnsubCallback,
   UpdatePolyxBondParams,
 } from '~/types';
+import { MILLISECONDS_PER_YEAR } from '~/utils/constants';
 import {
   accountIdToString,
   activeEraStakingToActiveEraInfo,
+  balanceToBigNumber,
+  bigNumberToU32,
   rawValidatorPrefToCommission,
+  stringToAccountId,
   u32ToBigNumber,
+  u64ToBigNumber,
   u128ToBigNumber,
 } from '~/utils/conversion';
-import { createProcedureMethod, requestPaginated } from '~/utils/internal';
+import {
+  asAccount,
+  createProcedureMethod,
+  QueryMultiParam,
+  requestMulti,
+  requestPaginated,
+} from '~/utils/internal';
+
+/**
+ * @hidden
+ *
+ * Assemble the exact slot-counted progress through a period, plus the time projection a countdown
+ *   needs. Both are clamped: a period that has run long has not ended, and a progress above 1 or a
+ *   negative countdown reads as broken
+ */
+function toPeriodProgress(
+  elapsed: BigNumber,
+  total: BigNumber,
+  expectedBlockTime: BigNumber
+): PeriodProgress {
+  const capped = BigNumber.min(elapsed, total);
+  const remaining = total.minus(capped).multipliedBy(expectedBlockTime);
+
+  return {
+    elapsed,
+    total,
+    progress: capped.dividedBy(total),
+    remaining,
+    end: new Date(new BigNumber(Date.now()).plus(remaining).toNumber()),
+  };
+}
 
 /**
  * Handles Staking related functionality
@@ -227,9 +271,16 @@ export class Staking {
   }
 
   /**
-   * Retrieve the current staking era information
+   * Retrieve information about the staking eras the chain is tracking
    *
-   * @returns Promise that resolves to the current era information
+   * @returns Promise that resolves to the era information
+   *
+   * @note the chain tracks **two** era numbers and they are not interchangeable. `currentEra` is
+   *   the latest era the chain has *planned* — a validator set has been elected for it, but the
+   *   Session pallet may not have brought it into force. `activeEra` is the era whose validator set
+   *   is in force and whose rewards and slashes are being processed. `currentEra` runs ahead of
+   *   `activeEra` between an election and the session rotation that follows it, and the two are
+   *   equal the rest of the time. Anything describing what the chain is doing now wants `activeEra`
    */
   public async eraInfo(): Promise<StakingEraInfo>;
 
@@ -355,5 +406,477 @@ export class Staking {
     const rawTotalStaked = await query.staking.erasTotalStake(rawCurrentEra.unwrapOr(0));
 
     return assembleResult(rawActiveEra, rawCurrentEra, rawPlannedSession, rawTotalStaked);
+  }
+
+  /**
+   * Retrieve the chain constants that govern staking
+   *
+   * @note these come from the chain's metadata, so this makes no query
+   */
+  public getConstants(): StakingConstants {
+    const {
+      context: {
+        polymeshApi: { consts },
+      },
+    } = this;
+
+    const sessionsPerEra = u32ToBigNumber(consts.staking.sessionsPerEra);
+    const slotsPerSession = u64ToBigNumber(consts.babe.epochDuration);
+    const expectedBlockTime = u64ToBigNumber(consts.babe.expectedBlockTime);
+
+    const eraDuration = expectedBlockTime
+      .multipliedBy(slotsPerSession)
+      .multipliedBy(sessionsPerEra);
+
+    return {
+      sessionsPerEra,
+      slotsPerSession,
+      expectedBlockTime,
+      eraDuration,
+      erasPerYear: MILLISECONDS_PER_YEAR.dividedBy(eraDuration),
+      bondingDuration: u32ToBigNumber(consts.staking.bondingDuration),
+      historyDepth: u32ToBigNumber(consts.staking.historyDepth),
+      fixedYearlyReward: balanceToBigNumber(consts.validators.fixedYearlyReward),
+      maxVariableInflationTotalIssuance: balanceToBigNumber(
+        consts.validators.maxVariableInflationTotalIssuance
+      ),
+    };
+  }
+
+  /**
+   * Retrieve how far through the staking cycle the chain is — which era and session are in force,
+   *   and how far through each of them the chain has got
+   *
+   * @throws if there is no active era
+   *
+   * @note progress is counted in **slots**, which is how the chain measures a period, so
+   *   `progress` is exact. The `remaining` and `end` projections come from `expectedBlockTime` and
+   *   move as block production drifts
+   */
+  public async eraProgress(): Promise<EraProgress>;
+
+  /**
+   * Retrieve how far through the staking cycle the chain is, and subscribe to its advance
+   *
+   * @param callback - called on every block, since the slot the progress is counted in advances
+   *   with each one. This is what drives a progress bar without polling
+   *
+   * @returns Promise that resolves to an unsubscribe function
+   *
+   * @note can be subscribed to, if connected to node using a web socket
+   */
+  public async eraProgress(callback: SubCallback<EraProgress>): Promise<UnsubCallback>;
+
+  // eslint-disable-next-line require-jsdoc
+  public async eraProgress(
+    callback?: SubCallback<EraProgress>
+  ): Promise<EraProgress | UnsubCallback> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    const { slotsPerSession, sessionsPerEra, expectedBlockTime } = this.getConstants();
+
+    type ProgressQueries = [
+      typeof query.staking.activeEra,
+      typeof query.staking.currentEra,
+      typeof query.session.currentIndex,
+      typeof query.babe.epochIndex,
+      typeof query.babe.currentSlot,
+      typeof query.babe.genesisSlot
+    ];
+
+    /* `babe.currentSlot` alone changes every block; the rest ride along on the same notification */
+    const queries: QueryMultiParam<ProgressQueries> = [
+      [query.staking.activeEra, undefined],
+      [query.staking.currentEra, undefined],
+      [query.session.currentIndex, undefined],
+      [query.babe.epochIndex, undefined],
+      [query.babe.currentSlot, undefined],
+      [query.babe.genesisSlot, undefined],
+    ];
+
+    type RawProgress = [Option<PalletStakingActiveEraInfo>, Option<u32>, u32, u64, u64, u64];
+
+    /*
+     * `erasStartSessionIndex` is keyed by the active era, so it cannot join the multi query that
+     *   reads the era itself. It changes once per era rather than once per block, so it is re-read
+     *   only when the era does
+     */
+    let cachedFor: string | null = null;
+    let startSession = new BigNumber(0);
+
+    const readStartSession = async (era: BigNumber): Promise<BigNumber> => {
+      if (cachedFor !== era.toString()) {
+        const rawStartSession = await query.staking.erasStartSessionIndex(
+          bigNumberToU32(era, context)
+        );
+
+        /* an era whose start the chain has pruned cannot anchor a count, so treat it as session 0 */
+        startSession = rawStartSession.isSome
+          ? u32ToBigNumber(rawStartSession.unwrap())
+          : new BigNumber(0);
+        cachedFor = era.toString();
+      }
+
+      return startSession;
+    };
+
+    const assembleResult = (
+      [rawActiveEra, rawCurrentEra, rawSession, rawEpoch, rawSlot, rawGenesisSlot]: RawProgress,
+      eraStartSession: BigNumber
+    ): EraProgress => {
+      const { index: rawEraIndex, start: rawStart } = rawActiveEra.unwrap();
+
+      const era = u32ToBigNumber(rawEraIndex);
+      const session = u32ToBigNumber(rawSession);
+
+      /*
+       * the chain does not store where a session began, so it is derived the way the runtime lays
+       *   epochs out: the Nth epoch starts `N * slotsPerSession` slots after genesis
+       */
+      const sessionStartSlot = u64ToBigNumber(rawEpoch)
+        .multipliedBy(slotsPerSession)
+        .plus(u64ToBigNumber(rawGenesisSlot));
+
+      const sessionElapsed = BigNumber.max(u64ToBigNumber(rawSlot).minus(sessionStartSlot), 0);
+
+      /* sessions of this era that are already behind the chain */
+      const sessionsDone = BigNumber.max(session.minus(eraStartSession), 0);
+
+      const eraElapsed = sessionsDone.multipliedBy(slotsPerSession).plus(sessionElapsed);
+
+      return {
+        era: {
+          index: era,
+          planned: rawCurrentEra.isSome ? u32ToBigNumber(rawCurrentEra.unwrap()) : era,
+          start: rawStart.isSome ? new Date(u64ToBigNumber(rawStart.unwrap()).toNumber()) : null,
+          progress: toPeriodProgress(
+            eraElapsed,
+            slotsPerSession.multipliedBy(sessionsPerEra),
+            expectedBlockTime
+          ),
+        },
+        session: {
+          index: session,
+          inEra: BigNumber.min(sessionsDone.plus(1), sessionsPerEra),
+          perEra: sessionsPerEra,
+          progress: toPeriodProgress(sessionElapsed, slotsPerSession, expectedBlockTime),
+        },
+      };
+    };
+
+    const assertActiveEra = (raw: RawProgress): void => {
+      if (raw[0].isNone) {
+        throw new PolymeshError({
+          code: ErrorCode.DataUnavailable,
+          message: 'There is no active staking era',
+        });
+      }
+    };
+
+    if (callback) {
+      context.assertSupportsSubscription();
+
+      return requestMulti<ProgressQueries>(context, queries, async raw => {
+        assertActiveEra(raw);
+
+        const eraStartSession = await readStartSession(u32ToBigNumber(raw[0].unwrap().index));
+
+        await callback(assembleResult(raw, eraStartSession));
+      });
+    }
+
+    const raw = await requestMulti<ProgressQueries>(context, queries);
+
+    assertActiveEra(raw);
+
+    return assembleResult(raw, await readStartSession(u32ToBigNumber(raw[0].unwrap().index)));
+  }
+
+  /**
+   * Retrieve the reward points earned by each validator in an era
+   *
+   * @param era - defaults to the active era
+   *
+   * @note points are how the era's reward is split between validators. A validator that authored no
+   *   blocks in the era is absent rather than present with zero
+   */
+  public async getEraRewardPoints(era?: BigNumber): Promise<EraRewardPoints>;
+
+  /**
+   * Retrieve the reward points earned by each validator in an era, and subscribe to them
+   *
+   * @param callback - called as points are credited. Points accrue block by block as validators
+   *   author, so for the active era this is a live leaderboard
+   *
+   * @returns Promise that resolves to an unsubscribe function
+   *
+   * @note only the active era changes. Subscribing to a past era is allowed and simply calls back
+   *   once, since the chain has finished writing it
+   * @note can be subscribed to, if connected to node using a web socket
+   */
+  public async getEraRewardPoints(callback: SubCallback<EraRewardPoints>): Promise<UnsubCallback>;
+
+  /**
+   * Retrieve the reward points earned by each validator in a specific era, and subscribe to them
+   *
+   * @returns Promise that resolves to an unsubscribe function
+   *
+   * @note can be subscribed to, if connected to node using a web socket
+   */
+  public async getEraRewardPoints(
+    era: BigNumber,
+    callback: SubCallback<EraRewardPoints>
+  ): Promise<UnsubCallback>;
+
+  // eslint-disable-next-line require-jsdoc
+  public async getEraRewardPoints(
+    eraOrCallback?: BigNumber | SubCallback<EraRewardPoints>,
+    maybeCallback?: SubCallback<EraRewardPoints>
+  ): Promise<EraRewardPoints | UnsubCallback> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    const era = BigNumber.isBigNumber(eraOrCallback) ? eraOrCallback : undefined;
+    const callback = BigNumber.isBigNumber(eraOrCallback) ? maybeCallback : eraOrCallback;
+
+    const rawEra = await this.asRawEra(era);
+
+    const assembleResult = (rawPoints: PalletStakingEraRewardPoints): EraRewardPoints => {
+      const { total, individual } = rawPoints;
+
+      return {
+        total: u32ToBigNumber(total),
+        individual: [...individual.entries()].map(([rawAccountId, rawIndividualPoints]) => ({
+          account: new Account({ address: accountIdToString(rawAccountId) }, context),
+          points: u32ToBigNumber(rawIndividualPoints),
+        })),
+      };
+    };
+
+    if (callback) {
+      context.assertSupportsSubscription();
+
+      return query.staking.erasRewardPoints(rawEra, rawPoints => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- callback errors should be handled by the caller
+        callback(assembleResult(rawPoints));
+      });
+    }
+
+    return assembleResult(await query.staking.erasRewardPoints(rawEra));
+  }
+
+  /**
+   * Retrieve the total POLYX paid out to validators and their nominators for an era
+   *
+   * @param era - defaults to the active era
+   *
+   * @returns `null` for an era the chain has not paid out, i.e. one still running or older than the
+   *   history depth
+   */
+  public async getEraValidatorReward(era?: BigNumber): Promise<BigNumber | null> {
+    const {
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    const rawEra = await this.asRawEra(era);
+
+    const rawReward = await query.staking.erasValidatorReward(rawEra);
+
+    return rawReward.isNone ? null : balanceToBigNumber(rawReward.unwrap());
+  }
+
+  /**
+   * Retrieve the session an era started at
+   *
+   * @param era - defaults to the active era
+   *
+   * @returns `null` for an era outside the chain's history depth
+   */
+  public async getEraStartSession(era?: BigNumber): Promise<BigNumber | null> {
+    const {
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    const rawEra = await this.asRawEra(era);
+
+    const rawIndex = await query.staking.erasStartSessionIndex(rawEra);
+
+    return rawIndex.isNone ? null : u32ToBigNumber(rawIndex.unwrap());
+  }
+
+  /**
+   * Retrieve how much POLYX was backing a validator in an era, and how it was split
+   *
+   * @param args.validator - the validator's Account or address
+   * @param args.era - defaults to the active era
+   *
+   * @returns `null` if the Account was not in the era's validator set
+   */
+  public async getEraExposure(args: {
+    validator: Account | string;
+    era?: BigNumber;
+  }): Promise<EraExposure | null> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    const { validator, era } = args;
+
+    const rawEra = await this.asRawEra(era);
+    const rawAddress = stringToAccountId(asAccount(validator, context).address, context);
+
+    const rawOverview = await query.staking.erasStakersOverview(rawEra, rawAddress);
+
+    if (rawOverview.isNone) {
+      return null;
+    }
+
+    const { total, own, nominatorCount, pageCount } = rawOverview.unwrap();
+
+    return {
+      total: balanceToBigNumber(total.unwrap()),
+      own: balanceToBigNumber(own.unwrap()),
+      nominatorCount: u32ToBigNumber(nominatorCount),
+      pageCount: u32ToBigNumber(pageCount),
+    };
+  }
+
+  /**
+   * Retrieve one page of the nominators backing a validator in an era
+   *
+   * @param args.validator - the validator's Account or address
+   * @param args.page - defaults to the first page. Read `pageCount` from
+   *   {@link api/client/Staking!Staking.getEraExposure | getEraExposure} for how many there are
+   * @param args.era - defaults to the active era
+   *
+   * @returns `null` if the page does not exist
+   *
+   * @note nominators are paged by the chain so that a payout fits in a block, which is why this is
+   *   not returned as part of the exposure
+   */
+  public async getEraNominators(args: {
+    validator: Account | string;
+    page?: BigNumber;
+    era?: BigNumber;
+  }): Promise<EraNominators | null> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    const { validator, page = new BigNumber(0), era } = args;
+
+    const rawEra = await this.asRawEra(era);
+    const rawAddress = stringToAccountId(asAccount(validator, context).address, context);
+    const rawPage = bigNumberToU32(page, context);
+
+    const rawExposure = await query.staking.erasStakersPaged(rawEra, rawAddress, rawPage);
+
+    if (rawExposure.isNone) {
+      return null;
+    }
+
+    const { pageTotal, others } = rawExposure.unwrap();
+
+    return {
+      pageTotal: balanceToBigNumber(pageTotal.unwrap()),
+      nominators: others.map(({ who, value }) => ({
+        account: new Account({ address: accountIdToString(who) }, context),
+        value: balanceToBigNumber(value.unwrap()),
+      })),
+    };
+  }
+
+  /**
+   * Retrieve the current phase of the validator election
+   *
+   * @note staking transactions behave differently while an election is open, so a UI should say
+   *   when the phase is anything other than `Off`
+   */
+  public async getElectionPhase(): Promise<ElectionPhase>;
+
+  /**
+   * Retrieve the current phase of the validator election, and subscribe to it
+   *
+   * @param callback - called whenever the phase changes, which happens several times an era
+   *
+   * @returns Promise that resolves to an unsubscribe function
+   *
+   * @note this is the read that most benefits from a subscription — a warning that only appears on
+   *   the next poll appears after the user has already acted
+   * @note can be subscribed to, if connected to node using a web socket
+   */
+  public async getElectionPhase(callback: SubCallback<ElectionPhase>): Promise<UnsubCallback>;
+
+  // eslint-disable-next-line require-jsdoc
+  public async getElectionPhase(
+    callback?: SubCallback<ElectionPhase>
+  ): Promise<ElectionPhase | UnsubCallback> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    if (callback) {
+      context.assertSupportsSubscription();
+
+      return query.electionProviderMultiPhase.currentPhase(rawPhase => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- callback errors should be handled by the caller
+        callback(ElectionPhase[rawPhase.type]);
+      });
+    }
+
+    const rawPhase = await query.electionProviderMultiPhase.currentPhase();
+
+    return ElectionPhase[rawPhase.type];
+  }
+
+  /**
+   * @hidden
+   *
+   * Resolve an optional era argument to the era to query, defaulting to the active one
+   */
+  private async asRawEra(era?: BigNumber): Promise<u32> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    if (era) {
+      return bigNumberToU32(era, context);
+    }
+
+    const rawActiveEra = await query.staking.activeEra();
+
+    if (rawActiveEra.isNone) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'There is no active staking era',
+      });
+    }
+
+    return rawActiveEra.unwrap().index;
   }
 }

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -5,6 +5,7 @@ import BigNumber from 'bignumber.js';
 import {
   Account,
   bondPolyx,
+  chillStaking,
   Context,
   nominateValidators,
   setStakingController,
@@ -69,6 +70,21 @@ export class Staking {
       context
     );
 
+    this.rebond = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [updateBondedPolyx, { ...args, type: 'rebond' } as const],
+      },
+      context
+    );
+
+    this.chill = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [chillStaking, undefined],
+        voidArgs: true,
+      },
+      context
+    );
+
     this.withdraw = createProcedureMethod(
       {
         getProcedureAndArgs: () => [withdrawUnbondedPolyx, undefined],
@@ -118,6 +134,21 @@ export class Staking {
    * Unbond POLYX for staking. The unbonded amount can be withdrawn after the lockup period
    */
   public unbond: ProcedureMethod<UpdatePolyxBondParams, void>;
+
+  /**
+   * Rebond POLYX that is currently unbonding, without waiting for the lockup period to elapse
+   *
+   * @note this transaction must be signed by a controller
+   */
+  public rebond: ProcedureMethod<UpdatePolyxBondParams, void>;
+
+  /**
+   * Stop nominating validators, without unbonding any POLYX
+   *
+   * @note the bonded POLYX stays bonded. Use `unbond` to begin withdrawing it
+   * @note this transaction must be signed by a controller
+   */
+  public chill: NoArgsProcedureMethod<void>;
 
   /**
    * Withdraw unbonded POLYX to free it for the stash account

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -47,7 +47,6 @@ import {
   stringToAccountId,
   u32ToBigNumber,
   u64ToBigNumber,
-  u128ToBigNumber,
 } from '~/utils/conversion';
 import {
   asAccount,
@@ -371,7 +370,8 @@ export class Staking {
       }
 
       const plannedSession = u32ToBigNumber(rawPlannedSession);
-      const totalStaked = u128ToBigNumber(rawTotalStaked);
+      // `erasTotalStake` is a `Balance`, so it needs the POLYX shift rather than a plain u128 read
+      const totalStaked = balanceToBigNumber(rawTotalStaked);
 
       return {
         activeEra: activeEra.index,

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -271,6 +271,50 @@ export class Staking {
   }
 
   /**
+   * Retrieve the validators whose set is actually in force for the active era
+   *
+   * @returns the elected validators, in the chain's own order
+   *
+   * @note this is a different question from
+   *   {@link api/client/Staking!Staking.getValidators | getValidators}, which lists every Account
+   *   *declaring intent* to validate. Those declaring intent but not elected are the waiting set —
+   *   subtract this result from `getValidators` to get it
+   * @note bounded by {@link api/client/Staking!Staking.getValidatorCount | getValidatorCount}, so
+   *   unlike the intent list this needs no pagination
+   */
+  public async getActiveValidators(): Promise<Account[]> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    const rawValidators = await query.session.validators();
+
+    return rawValidators.map(
+      rawAddress => new Account({ address: accountIdToString(rawAddress) }, context)
+    );
+  }
+
+  /**
+   * Retrieve how many validators the chain aims to elect each era
+   *
+   * @note this is the target the election is run against, not how many are currently in force —
+   *   read {@link api/client/Staking!Staking.getActiveValidators | getActiveValidators} for that.
+   *   The two differ when fewer Accounts declare intent than there are slots
+   */
+  public async getValidatorCount(): Promise<BigNumber> {
+    const {
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    return u32ToBigNumber(await query.staking.validatorCount());
+  }
+
+  /**
    * Retrieve information about the staking eras the chain is tracking
    *
    * @returns Promise that resolves to the era information

--- a/src/api/client/__tests__/Network.ts
+++ b/src/api/client/__tests__/Network.ts
@@ -190,6 +190,37 @@ describe('Network Class', () => {
     });
   });
 
+  describe('method: getTotalIssuance', () => {
+    it('should return the total POLYX in existence', async () => {
+      dsMockUtils.createQueryMock('balances', 'totalIssuance', {
+        returnValue: dsMockUtils.createMockBalance(new BigNumber(1_000_000_000)),
+      });
+
+      const result = await network.getTotalIssuance();
+
+      // shifted from the chain's smallest unit into POLYX
+      expect(result).toEqual(new BigNumber(1000));
+    });
+
+    it('should allow subscription', async () => {
+      const unsubCallback = 'unsubCallback';
+      const callback = jest.fn();
+
+      dsMockUtils
+        .createQueryMock('balances', 'totalIssuance')
+        .mockImplementation((cb: (issuance: unknown) => void) => {
+          cb(dsMockUtils.createMockBalance(new BigNumber(2_000_000_000)));
+
+          return unsubCallback;
+        });
+
+      const result = await network.getTotalIssuance(callback);
+
+      expect(result).toEqual(unsubCallback);
+      expect(callback).toBeCalledWith(new BigNumber(2000));
+    });
+  });
+
   describe('method: transferPolyx', () => {
     it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
       const args = {

--- a/src/api/client/__tests__/Staking.ts
+++ b/src/api/client/__tests__/Staking.ts
@@ -124,6 +124,544 @@ describe('Staking Class', () => {
     });
   });
 
+  describe('method: getConstants', () => {
+    const setConsts = (): void => {
+      dsMockUtils.setConstMock('staking', 'sessionsPerEra', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(3)),
+      });
+      dsMockUtils.setConstMock('staking', 'bondingDuration', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(7)),
+      });
+      dsMockUtils.setConstMock('staking', 'historyDepth', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(84)),
+      });
+      dsMockUtils.setConstMock('babe', 'epochDuration', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(300)),
+      });
+      dsMockUtils.setConstMock('babe', 'expectedBlockTime', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(6000)),
+      });
+      dsMockUtils.setConstMock('validators', 'fixedYearlyReward', {
+        returnValue: dsMockUtils.createMockBalance(new BigNumber(140000000000000)),
+      });
+      dsMockUtils.setConstMock('validators', 'maxVariableInflationTotalIssuance', {
+        returnValue: dsMockUtils.createMockBalance(new BigNumber(1000000000000000)),
+      });
+    };
+
+    it('should return the staking constants', () => {
+      setConsts();
+
+      const result = staking.getConstants();
+
+      expect(result.sessionsPerEra).toEqual(new BigNumber(3));
+      expect(result.historyDepth).toEqual(new BigNumber(84));
+      expect(result.slotsPerSession).toEqual(new BigNumber(300));
+      expect(result.expectedBlockTime).toEqual(new BigNumber(6000));
+      expect(result.bondingDuration).toEqual(new BigNumber(7));
+      // returned as POLYX, not base units — mainnet's 140M POLYX yearly cap
+      expect(result.fixedYearlyReward).toEqual(new BigNumber(140000000));
+      expect(result.maxVariableInflationTotalIssuance).toEqual(new BigNumber(1000000000));
+    });
+
+    it('should derive the era duration from the block time, session and era constants', () => {
+      setConsts();
+
+      // 6000ms * 300 slots * 3 sessions = 90 minutes
+      expect(staking.getConstants().eraDuration).toEqual(new BigNumber(5400000));
+    });
+
+    it('should count eras per year against the Julian year the chain uses', () => {
+      setConsts();
+
+      const { erasPerYear } = staking.getConstants();
+
+      // 365.25 days of 90 minute eras, not 365
+      expect(erasPerYear).toEqual(new BigNumber(31557600000).dividedBy(5400000));
+      expect(erasPerYear.toNumber()).toBeCloseTo(5844, 0);
+    });
+  });
+
+  describe('method: eraProgress', () => {
+    /*
+     * 300 slots per session, 3 sessions per era, so 900 slots per era. Genesis at slot 1000, and
+     *   the active era anchored to session 30 — so the era opened at epoch 40, slot 13000
+     */
+    const genesisSlot = 1000;
+    const slotsPerSession = 300;
+    const eraStartSession = 30;
+    const eraStartEpoch = 40;
+    const eraStartSlot = genesisSlot + eraStartEpoch * slotsPerSession;
+    const eraStartedAt = 1_700_000_000_000;
+
+    let queryMultiMock: jest.Mock;
+
+    beforeEach(() => {
+      dsMockUtils.setConstMock('staking', 'sessionsPerEra', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(3)),
+      });
+      dsMockUtils.setConstMock('staking', 'bondingDuration', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(7)),
+      });
+      dsMockUtils.setConstMock('staking', 'historyDepth', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(84)),
+      });
+      dsMockUtils.setConstMock('babe', 'epochDuration', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(slotsPerSession)),
+      });
+      dsMockUtils.setConstMock('babe', 'expectedBlockTime', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(6000)),
+      });
+      dsMockUtils.setConstMock('validators', 'fixedYearlyReward', {
+        returnValue: dsMockUtils.createMockBalance(new BigNumber(140000000000000)),
+      });
+      dsMockUtils.setConstMock('validators', 'maxVariableInflationTotalIssuance', {
+        returnValue: dsMockUtils.createMockBalance(new BigNumber(1000000000000000)),
+      });
+
+      dsMockUtils.createQueryMock('staking', 'erasStartSessionIndex', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockU32(new BigNumber(eraStartSession))
+        ),
+      });
+
+      /* the values come back through `queryMulti`, but the entries must exist to be passed to it */
+      dsMockUtils.createQueryMock('staking', 'activeEra');
+      dsMockUtils.createQueryMock('staking', 'currentEra');
+      dsMockUtils.createQueryMock('session', 'currentIndex');
+      dsMockUtils.createQueryMock('babe', 'epochIndex');
+      dsMockUtils.createQueryMock('babe', 'currentSlot');
+      dsMockUtils.createQueryMock('babe', 'genesisSlot');
+
+      queryMultiMock = dsMockUtils.getQueryMultiMock();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    /**
+     * @param sessionsIn - how many sessions of the era are already behind the chain
+     * @param slotsIntoSession - how far into the current session the chain is
+     */
+    const mockProgress = (
+      sessionsIn: number,
+      slotsIntoSession: number,
+      opts: { start?: number | null; activeEra?: number; plannedEra?: number } = {}
+    ): void => {
+      const { start = eraStartedAt, activeEra = 7131, plannedEra = activeEra } = opts;
+
+      queryMultiMock.mockResolvedValue([
+        dsMockUtils.createMockOption(
+          dsMockUtils.createMockActiveEraInfo({
+            index: dsMockUtils.createMockU32(new BigNumber(activeEra)),
+            start:
+              start === null
+                ? dsMockUtils.createMockOption()
+                : dsMockUtils.createMockOption(dsMockUtils.createMockU64(new BigNumber(start))),
+          })
+        ),
+        dsMockUtils.createMockOption(dsMockUtils.createMockU32(new BigNumber(plannedEra))),
+        dsMockUtils.createMockU32(new BigNumber(eraStartSession + sessionsIn)),
+        dsMockUtils.createMockU64(new BigNumber(eraStartEpoch + sessionsIn)),
+        dsMockUtils.createMockU64(
+          new BigNumber(eraStartSlot + sessionsIn * slotsPerSession + slotsIntoSession)
+        ),
+        dsMockUtils.createMockU64(new BigNumber(genesisSlot)),
+      ]);
+    };
+
+    it('should count era and session progress in slots', async () => {
+      // one full session done, plus 150 slots into the second: 450 of 900 slots
+      mockProgress(1, 150);
+
+      const result = await staking.eraProgress();
+
+      expect(result.era.index).toEqual(new BigNumber(7131));
+      expect(result.era.start).toEqual(new Date(eraStartedAt));
+      expect(result.era.progress.elapsed).toEqual(new BigNumber(450));
+      expect(result.era.progress.total).toEqual(new BigNumber(900));
+      expect(result.era.progress.progress).toEqual(new BigNumber(0.5));
+      expect(result.era.progress.remaining).toEqual(new BigNumber(450 * 6000));
+
+      expect(result.session.index).toEqual(new BigNumber(eraStartSession + 1));
+      expect(result.session.inEra).toEqual(new BigNumber(2));
+      expect(result.session.perEra).toEqual(new BigNumber(3));
+      expect(result.session.progress.elapsed).toEqual(new BigNumber(150));
+      expect(result.session.progress.total).toEqual(new BigNumber(300));
+      expect(result.session.progress.progress).toEqual(new BigNumber(0.5));
+      expect(result.session.progress.remaining).toEqual(new BigNumber(150 * 6000));
+    });
+
+    it('should report zero progress at the very start of an era', async () => {
+      mockProgress(0, 0);
+
+      const result = await staking.eraProgress();
+
+      expect(result.era.progress.progress).toEqual(new BigNumber(0));
+      expect(result.era.progress.remaining).toEqual(new BigNumber(900 * 6000));
+      expect(result.session.inEra).toEqual(new BigNumber(1));
+    });
+
+    it('should clamp an overdue era rather than reporting past the end', async () => {
+      // a fourth session in a three session era, which happens when the rotation is late
+      mockProgress(3, 200);
+
+      const result = await staking.eraProgress();
+
+      expect(result.era.progress.elapsed).toEqual(new BigNumber(1100));
+      expect(result.era.progress.progress).toEqual(new BigNumber(1));
+      expect(result.era.progress.remaining).toEqual(new BigNumber(0));
+      expect(result.session.inEra).toEqual(new BigNumber(3));
+    });
+
+    it('should report progress for an era whose start the chain has not recorded', async () => {
+      mockProgress(1, 150, { start: null });
+
+      const result = await staking.eraProgress();
+
+      expect(result.era.start).toBeNull();
+      expect(result.era.progress.progress).toEqual(new BigNumber(0.5));
+    });
+
+    it('should report the planned era separately from the active one', async () => {
+      mockProgress(2, 0, { activeEra: 7131, plannedEra: 7132 });
+
+      const result = await staking.eraProgress();
+
+      expect(result.era.index).toEqual(new BigNumber(7131));
+      expect(result.era.planned).toEqual(new BigNumber(7132));
+    });
+
+    it('should anchor to session 0 where the chain has pruned the era start', async () => {
+      dsMockUtils.createQueryMock('staking', 'erasStartSessionIndex', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+      mockProgress(1, 150);
+
+      const result = await staking.eraProgress();
+
+      // without an anchor every session since genesis counts, so the era reads as overdue
+      expect(result.era.progress.progress).toEqual(new BigNumber(1));
+    });
+
+    it('should throw if there is no active era', () => {
+      queryMultiMock.mockResolvedValue([
+        dsMockUtils.createMockOption(),
+        dsMockUtils.createMockOption(),
+        dsMockUtils.createMockU32(new BigNumber(0)),
+        dsMockUtils.createMockU64(new BigNumber(0)),
+        dsMockUtils.createMockU64(new BigNumber(0)),
+        dsMockUtils.createMockU64(new BigNumber(0)),
+      ]);
+
+      return expect(staking.eraProgress()).rejects.toThrow('There is no active staking era');
+    });
+
+    it('should allow subscription', async () => {
+      const unsubCallback = 'unsubCallback';
+      const callback = jest.fn();
+
+      queryMultiMock.mockImplementation(async (_, cb) => {
+        await cb([
+          dsMockUtils.createMockOption(
+            dsMockUtils.createMockActiveEraInfo({
+              index: dsMockUtils.createMockU32(new BigNumber(7131)),
+              start: dsMockUtils.createMockOption(
+                dsMockUtils.createMockU64(new BigNumber(eraStartedAt))
+              ),
+            })
+          ),
+          dsMockUtils.createMockOption(dsMockUtils.createMockU32(new BigNumber(7131))),
+          dsMockUtils.createMockU32(new BigNumber(eraStartSession + 1)),
+          dsMockUtils.createMockU64(new BigNumber(eraStartEpoch + 1)),
+          dsMockUtils.createMockU64(new BigNumber(eraStartSlot + slotsPerSession + 150)),
+          dsMockUtils.createMockU64(new BigNumber(genesisSlot)),
+        ]);
+
+        return unsubCallback;
+      });
+
+      const result = await staking.eraProgress(callback);
+
+      expect(result).toEqual(unsubCallback);
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          era: expect.objectContaining({ index: new BigNumber(7131) }),
+          session: expect.objectContaining({ inEra: new BigNumber(2) }),
+        })
+      );
+    });
+  });
+
+  describe('per-era reads', () => {
+    const era = new BigNumber(7131);
+
+    beforeEach(() => {
+      // the entity mock's address is not a real SS58 string, so the codec conversion is stubbed
+      when(jest.spyOn(utilsConversionModule, 'stringToAccountId'))
+        .calledWith(account.address, mockContext)
+        .mockReturnValue(rawAddress);
+    });
+
+    const mockActiveEraIndex = (index: number): void => {
+      dsMockUtils.createQueryMock('staking', 'activeEra', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockActiveEraInfo({
+            index: dsMockUtils.createMockU32(new BigNumber(index)),
+            start: dsMockUtils.createMockOption(dsMockUtils.createMockU64(new BigNumber(1))),
+          })
+        ),
+      });
+    };
+
+    describe('method: getEraRewardPoints', () => {
+      it('should return the total and each validator that authored a block', async () => {
+        const individual = new Map([[rawAddress, dsMockUtils.createMockU32(new BigNumber(120))]]);
+
+        dsMockUtils.createQueryMock('staking', 'erasRewardPoints', {
+          returnValue: dsMockUtils.createMockEraRewardPoints({
+            total: dsMockUtils.createMockU32(new BigNumber(500)),
+            individual: individual as never,
+          }),
+        });
+
+        const result = await staking.getEraRewardPoints(era);
+
+        expect(result.total).toEqual(new BigNumber(500));
+        expect(result.individual).toHaveLength(1);
+        expect(result.individual[0]?.points).toEqual(new BigNumber(120));
+        expect(result.individual[0]?.account.address).toBe(account.address);
+      });
+
+      it('should allow subscription to the active era', async () => {
+        const unsubCallback = 'unsubCallback';
+        const callback = jest.fn();
+
+        mockActiveEraIndex(era.toNumber());
+
+        dsMockUtils
+          .createQueryMock('staking', 'erasRewardPoints')
+          .mockImplementation((_rawEra: unknown, cb: (points: unknown) => void) => {
+            cb(
+              dsMockUtils.createMockEraRewardPoints({
+                total: dsMockUtils.createMockU32(new BigNumber(500)),
+                individual: new Map([
+                  [rawAddress, dsMockUtils.createMockU32(new BigNumber(120))],
+                ]) as never,
+              })
+            );
+
+            return unsubCallback;
+          });
+
+        const result = await staking.getEraRewardPoints(callback);
+
+        expect(result).toEqual(unsubCallback);
+        expect(callback).toHaveBeenCalledWith(
+          expect.objectContaining({ total: new BigNumber(500) })
+        );
+      });
+
+      it('should allow subscription to a specific era', async () => {
+        const unsubCallback = 'unsubCallback';
+        const callback = jest.fn();
+
+        dsMockUtils
+          .createQueryMock('staking', 'erasRewardPoints')
+          .mockImplementation((_rawEra: unknown, cb: (points: unknown) => void) => {
+            cb(
+              dsMockUtils.createMockEraRewardPoints({
+                total: dsMockUtils.createMockU32(new BigNumber(42)),
+                individual: new Map() as never,
+              })
+            );
+
+            return unsubCallback;
+          });
+
+        const result = await staking.getEraRewardPoints(era, callback);
+
+        expect(result).toEqual(unsubCallback);
+        expect(callback).toHaveBeenCalledWith(
+          expect.objectContaining({ total: new BigNumber(42) })
+        );
+      });
+
+      it('should default to the active era', async () => {
+        mockActiveEraIndex(42);
+
+        const pointsMock = dsMockUtils.createQueryMock('staking', 'erasRewardPoints', {
+          returnValue: dsMockUtils.createMockEraRewardPoints({
+            total: dsMockUtils.createMockU32(new BigNumber(1)),
+            individual: new Map() as never,
+          }),
+        });
+
+        await staking.getEraRewardPoints();
+
+        expect(pointsMock).toHaveBeenCalledWith(
+          expect.objectContaining({ toString: expect.anything() })
+        );
+      });
+
+      it('should throw if defaulting to the active era when there is none', () => {
+        dsMockUtils.createQueryMock('staking', 'activeEra', {
+          returnValue: dsMockUtils.createMockOption(),
+        });
+
+        return expect(staking.getEraRewardPoints()).rejects.toThrow(
+          'There is no active staking era'
+        );
+      });
+    });
+
+    describe('method: getEraValidatorReward', () => {
+      it('should return the payout for the era', async () => {
+        dsMockUtils.createQueryMock('staking', 'erasValidatorReward', {
+          returnValue: dsMockUtils.createMockOption(
+            dsMockUtils.createMockBalance(new BigNumber(3000000))
+          ),
+        });
+
+        // returned as POLYX, not base units
+        await expect(staking.getEraValidatorReward(era)).resolves.toEqual(new BigNumber(3));
+      });
+
+      it('should return null for an era with no recorded payout', async () => {
+        dsMockUtils.createQueryMock('staking', 'erasValidatorReward', {
+          returnValue: dsMockUtils.createMockOption(),
+        });
+
+        await expect(staking.getEraValidatorReward(era)).resolves.toBeNull();
+      });
+    });
+
+    describe('method: getEraStartSession', () => {
+      it('should return the session the era began at', async () => {
+        dsMockUtils.createQueryMock('staking', 'erasStartSessionIndex', {
+          returnValue: dsMockUtils.createMockOption(dsMockUtils.createMockU32(new BigNumber(900))),
+        });
+
+        await expect(staking.getEraStartSession(era)).resolves.toEqual(new BigNumber(900));
+      });
+
+      it('should return null outside the history depth', async () => {
+        dsMockUtils.createQueryMock('staking', 'erasStartSessionIndex', {
+          returnValue: dsMockUtils.createMockOption(),
+        });
+
+        await expect(staking.getEraStartSession(era)).resolves.toBeNull();
+      });
+    });
+
+    describe('method: getEraExposure', () => {
+      it('should return the exposure split', async () => {
+        dsMockUtils.createQueryMock('staking', 'erasStakersOverview', {
+          returnValue: dsMockUtils.createMockOption(
+            dsMockUtils.createMockPagedExposureMetadata({
+              total: dsMockUtils.createMockCompact(
+                dsMockUtils.createMockU128(new BigNumber(5000000))
+              ),
+              own: dsMockUtils.createMockCompact(
+                dsMockUtils.createMockU128(new BigNumber(1000000))
+              ),
+              nominatorCount: dsMockUtils.createMockU32(new BigNumber(12)),
+              pageCount: dsMockUtils.createMockU32(new BigNumber(2)),
+            })
+          ),
+        });
+
+        const result = await staking.getEraExposure({ validator: account, era });
+
+        expect(result).toEqual({
+          total: new BigNumber(5),
+          own: new BigNumber(1),
+          nominatorCount: new BigNumber(12),
+          pageCount: new BigNumber(2),
+        });
+      });
+
+      it('should return null if the account was not in the validator set', async () => {
+        dsMockUtils.createQueryMock('staking', 'erasStakersOverview', {
+          returnValue: dsMockUtils.createMockOption(),
+        });
+
+        await expect(staking.getEraExposure({ validator: account, era })).resolves.toBeNull();
+      });
+    });
+
+    describe('method: getEraNominators', () => {
+      it('should return one page of nominators', async () => {
+        dsMockUtils.createQueryMock('staking', 'erasStakersPaged', {
+          returnValue: dsMockUtils.createMockOption(
+            dsMockUtils.createMockExposurePage({
+              pageTotal: dsMockUtils.createMockCompact(
+                dsMockUtils.createMockU128(new BigNumber(4000000))
+              ),
+              others: [
+                dsMockUtils.createMockIndividualExposure({
+                  who: rawAddress,
+                  value: dsMockUtils.createMockCompact(
+                    dsMockUtils.createMockU128(new BigNumber(4000000))
+                  ),
+                }),
+              ],
+            })
+          ),
+        });
+
+        const result = await staking.getEraNominators({ validator: account, era });
+
+        expect(result?.pageTotal).toEqual(new BigNumber(4));
+        expect(result?.nominators).toHaveLength(1);
+        expect(result?.nominators[0]?.value).toEqual(new BigNumber(4));
+        expect(result?.nominators[0]?.account.address).toBe(account.address);
+      });
+
+      it('should return null for a page that does not exist', async () => {
+        dsMockUtils.createQueryMock('staking', 'erasStakersPaged', {
+          returnValue: dsMockUtils.createMockOption(),
+        });
+
+        await expect(
+          staking.getEraNominators({ validator: account, era, page: new BigNumber(9) })
+        ).resolves.toBeNull();
+      });
+    });
+  });
+
+  describe('method: getElectionPhase', () => {
+    it.each(['Off', 'Signed', 'Unsigned', 'Emergency'] as const)(
+      'should return the %s phase',
+      async phase => {
+        dsMockUtils.createQueryMock('electionProviderMultiPhase', 'currentPhase', {
+          returnValue: dsMockUtils.createMockElectionPhase(phase),
+        });
+
+        await expect(staking.getElectionPhase()).resolves.toBe(phase);
+      }
+    );
+
+    it('should allow subscription', async () => {
+      const unsubCallback = 'unsubCallback';
+      const callback = jest.fn();
+
+      dsMockUtils
+        .createQueryMock('electionProviderMultiPhase', 'currentPhase')
+        .mockImplementation((cb: (phase: unknown) => void) => {
+          cb(dsMockUtils.createMockElectionPhase('Signed'));
+
+          return unsubCallback;
+        });
+
+      const result = await staking.getElectionPhase(callback);
+
+      expect(result).toEqual(unsubCallback);
+      expect(callback).toHaveBeenCalledWith('Signed');
+    });
+  });
+
   describe('method: rebond', () => {
     it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
       const amount = new BigNumber(3);

--- a/src/api/client/__tests__/Staking.ts
+++ b/src/api/client/__tests__/Staking.ts
@@ -124,6 +124,41 @@ describe('Staking Class', () => {
     });
   });
 
+  describe('method: rebond', () => {
+    it('should prepare the procedure with the correct arguments and context, and return the resulting transaction', async () => {
+      const amount = new BigNumber(3);
+
+      const args = {
+        amount,
+        type: 'rebond',
+      };
+
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.rebond({ amount });
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
+  describe('method: chill', () => {
+    it('should prepare the procedure with the correct context, and return the resulting transaction', async () => {
+      const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;
+
+      when(procedureMockUtils.getPrepareMock())
+        .calledWith({ args: undefined, transformer: undefined }, mockContext, {})
+        .mockResolvedValue(expectedTransaction);
+
+      const tx = await staking.chill();
+
+      expect(tx).toBe(expectedTransaction);
+    });
+  });
+
   describe('method: withdraw', () => {
     it('should prepare the procedure with the correct context, and return the resulting transaction', async () => {
       const expectedTransaction = 'someTransaction' as unknown as PolymeshTransaction<void>;

--- a/src/api/client/__tests__/Staking.ts
+++ b/src/api/client/__tests__/Staking.ts
@@ -631,6 +631,39 @@ describe('Staking Class', () => {
     });
   });
 
+  describe('method: getActiveValidators', () => {
+    it('should return the validators in force for the active era', async () => {
+      dsMockUtils.createQueryMock('session', 'validators', {
+        returnValue: [
+          dsMockUtils.createMockAccountId('5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY'),
+          dsMockUtils.createMockAccountId('5FCPTnjevGqAuTttetBy4a24Ej3pH9fiQ8fmvP1ZkrVsLUoT'),
+        ],
+      });
+
+      const result = await staking.getActiveValidators();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.address).toBe('5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY');
+      expect(result[1]?.address).toBe('5FCPTnjevGqAuTttetBy4a24Ej3pH9fiQ8fmvP1ZkrVsLUoT');
+    });
+
+    it('should return an empty array where no set is in force', async () => {
+      dsMockUtils.createQueryMock('session', 'validators', { returnValue: [] });
+
+      await expect(staking.getActiveValidators()).resolves.toEqual([]);
+    });
+  });
+
+  describe('method: getValidatorCount', () => {
+    it('should return how many validators the chain aims to elect', async () => {
+      dsMockUtils.createQueryMock('staking', 'validatorCount', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(20)),
+      });
+
+      await expect(staking.getValidatorCount()).resolves.toEqual(new BigNumber(20));
+    });
+  });
+
   describe('method: getElectionPhase', () => {
     it.each(['Off', 'Signed', 'Unsigned', 'Emergency'] as const)(
       'should return the %s phase',

--- a/src/api/client/__tests__/Staking.ts
+++ b/src/api/client/__tests__/Staking.ts
@@ -847,7 +847,8 @@ describe('Staking Class', () => {
       );
       rawCurrentEra = dsMockUtils.createMockOption(dsMockUtils.createMockU32(new BigNumber(2)));
       rawPlannedSession = dsMockUtils.createMockU32(new BigNumber(3));
-      rawTotal = dsMockUtils.createMockU128(new BigNumber(1000));
+      // the chain returns a Balance in the smallest unit; 1e9 base units is 1,000 POLYX
+      rawTotal = dsMockUtils.createMockU128(new BigNumber(1_000_000_000));
 
       activeEraQueryMock = dsMockUtils.createQueryMock('staking', 'activeEra', {
         returnValue: rawActiveEra,

--- a/src/api/client/__tests__/Staking.ts
+++ b/src/api/client/__tests__/Staking.ts
@@ -247,7 +247,7 @@ describe('Staking Class', () => {
     const mockProgress = (
       sessionsIn: number,
       slotsIntoSession: number,
-      opts: { start?: number | null; activeEra?: number; plannedEra?: number } = {}
+      opts: { start?: number | null; activeEra?: number; plannedEra?: number | null } = {}
     ): void => {
       const { start = eraStartedAt, activeEra = 7131, plannedEra = activeEra } = opts;
 
@@ -261,7 +261,9 @@ describe('Staking Class', () => {
                 : dsMockUtils.createMockOption(dsMockUtils.createMockU64(new BigNumber(start))),
           })
         ),
-        dsMockUtils.createMockOption(dsMockUtils.createMockU32(new BigNumber(plannedEra))),
+        plannedEra === null
+          ? dsMockUtils.createMockOption()
+          : dsMockUtils.createMockOption(dsMockUtils.createMockU32(new BigNumber(plannedEra))),
         dsMockUtils.createMockU32(new BigNumber(eraStartSession + sessionsIn)),
         dsMockUtils.createMockU64(new BigNumber(eraStartEpoch + sessionsIn)),
         dsMockUtils.createMockU64(
@@ -331,6 +333,15 @@ describe('Staking Class', () => {
 
       expect(result.era.index).toEqual(new BigNumber(7131));
       expect(result.era.planned).toEqual(new BigNumber(7132));
+    });
+
+    it('should fall back to the active era where the chain has planned none', async () => {
+      mockProgress(1, 150, { activeEra: 7131, plannedEra: null });
+
+      const result = await staking.eraProgress();
+
+      expect(result.era.index).toEqual(new BigNumber(7131));
+      expect(result.era.planned).toEqual(new BigNumber(7131));
     });
 
     it('should anchor to session 0 where the chain has pruned the era start', async () => {

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -2,7 +2,7 @@ import { ApiOptions } from '@polkadot/api/types';
 import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
-import { Asset, Identity, InstructionStatusEnum, TxTag } from '~/types';
+import { Account, Asset, Identity, InstructionStatusEnum, TxTag } from '~/types';
 
 export { InstructionStatusEnum };
 
@@ -283,15 +283,28 @@ export interface HistoricalInstructionFilters {
  */
 export interface StakingEraInfo {
   /**
-   * The active era. This is the era whose rewards and slashes are being processed and may lag the current era
+   * The era whose validator set is in force, and whose rewards and slashes are being processed
+   *
+   * @note this is the era to use for anything describing what the chain is doing *now*. It lags
+   *   {@link StakingEraInfo.currentEra | currentEra} between an election and the session rotation
+   *   that brings the newly elected set into force
    */
   activeEra: BigNumber;
   /**
-   * The block in which the active era began
+   * The moment the active era began, as milliseconds since the Unix epoch
+   *
+   * @note this is `0` where the chain holds no start for the active era. The chain creates the
+   *   active era at session rotation and records its start on the following block, so the gap is
+   *   brief — but it recurs at every era change, not only before the first era
    */
   activeEraStart: BigNumber;
   /**
-   * The current era
+   * The latest era the chain has *planned*
+   *
+   * @note a validator set has been elected for this era, but the Session pallet may not have
+   *   brought it into force yet, so this runs ahead of
+   *   {@link StakingEraInfo.activeEra | activeEra} between the election and the rotation. The two
+   *   are equal the rest of the time, and `currentEra` is never behind
    */
   currentEra: BigNumber;
   /**
@@ -302,4 +315,241 @@ export interface StakingEraInfo {
    * The total amount of POLYX staked
    */
   totalStaked: BigNumber;
+}
+
+export interface StakingConstants {
+  /**
+   * The number of sessions in an era
+   */
+  sessionsPerEra: BigNumber;
+
+  /**
+   * The number of slots in a session
+   */
+  slotsPerSession: BigNumber;
+
+  /**
+   * The average time the chain is expected to take to produce a block, in milliseconds
+   */
+  expectedBlockTime: BigNumber;
+
+  /**
+   * How long an era is expected to last, in milliseconds
+   *
+   * @note this is `expectedBlockTime * slotsPerSession * sessionsPerEra`. It is what an era is
+   *   expected to take, not what any particular era took — the chain pays rewards against the
+   *   duration an era actually ran for
+   */
+  eraDuration: BigNumber;
+
+  /**
+   * How many eras are expected in a year
+   *
+   * @note the year here is the Julian year of 365.25 days, which is what the chain's reward
+   *   calculation uses
+   */
+  erasPerYear: BigNumber;
+
+  /**
+   * The number of eras that must pass before unbonded POLYX can be withdrawn
+   */
+  bondingDuration: BigNumber;
+
+  /**
+   * How many past eras the chain keeps data for
+   *
+   * @note the per-era reads return `null` for anything older than this many eras before the active
+   *   one, because the chain has pruned it
+   */
+  historyDepth: BigNumber;
+
+  /**
+   * The amount of POLYX issued per year once total issuance reaches
+   *   {@link StakingConstants.maxVariableInflationTotalIssuance}
+   */
+  fixedYearlyReward: BigNumber;
+
+  /**
+   * The total issuance at which rewards stop following the inflation curve and become
+   *   {@link StakingConstants.fixedYearlyReward}
+   */
+  maxVariableInflationTotalIssuance: BigNumber;
+}
+
+/**
+ * The phase of the validator election
+ */
+export enum ElectionPhase {
+  /**
+   * No election is in progress
+   */
+  Off = 'Off',
+  /**
+   * Signed solutions are being accepted
+   */
+  Signed = 'Signed',
+  /**
+   * Unsigned solutions are being accepted
+   */
+  Unsigned = 'Unsigned',
+  /**
+   * The election failed and is being resolved by governance
+   */
+  Emergency = 'Emergency',
+}
+
+export interface EraRewardPoints {
+  /**
+   * The total points awarded across all validators in the era
+   */
+  total: BigNumber;
+
+  /**
+   * The points awarded to each validator that authored at least one block in the era
+   */
+  individual: {
+    account: Account;
+    points: BigNumber;
+  }[];
+}
+
+export interface EraExposure {
+  /**
+   * The total POLYX backing the validator, its own stake included
+   */
+  total: BigNumber;
+
+  /**
+   * The POLYX the validator bonded itself
+   */
+  own: BigNumber;
+
+  /**
+   * How many Accounts nominated the validator in this era
+   */
+  nominatorCount: BigNumber;
+
+  /**
+   * How many pages the nominators are split across
+   *
+   * @note nominators are paged so a payout fits in a block. Use
+   *   {@link api/client/Staking!Staking.getEraNominators | getEraNominators} to read one page
+   */
+  pageCount: BigNumber;
+}
+
+export interface EraNominators {
+  /**
+   * The total POLYX nominated on this page
+   */
+  pageTotal: BigNumber;
+
+  /**
+   * The nominators on this page and what each of them staked
+   */
+  nominators: {
+    account: Account;
+    value: BigNumber;
+  }[];
+}
+
+/**
+ * How far through a period the chain is
+ *
+ * @note `elapsed`, `total` and `progress` are **exact** — they are counted in slots, which is how
+ *   the chain itself measures a period. `remaining` and `end` are **projections** from
+ *   {@link StakingConstants.expectedBlockTime}, so they move as block production drifts. Render a
+ *   bar from `progress` and a countdown from `remaining`
+ */
+export interface PeriodProgress {
+  /**
+   * Slots elapsed so far
+   */
+  elapsed: BigNumber;
+
+  /**
+   * Slots in the whole period
+   */
+  total: BigNumber;
+
+  /**
+   * How far through the period the chain is, from 0 to 1
+   *
+   * @note clamped to 1. A period that has run past its expected length has not ended — the chain
+   *   rolls it over when it rolls over
+   */
+  progress: BigNumber;
+
+  /**
+   * Projected milliseconds until the period ends
+   *
+   * @note `0` once the period has run past its expected length
+   */
+  remaining: BigNumber;
+
+  /**
+   * Projected moment the period ends
+   */
+  end: Date;
+}
+
+/**
+ * A live view of where the chain is in the staking cycle
+ *
+ * @note an era is divided into sessions (BABE calls them epochs), and both advance every block.
+ *   Subscribe with {@link api/client/Staking!Staking.eraProgress | eraProgress} to drive a progress
+ *   bar without polling
+ */
+export interface EraProgress {
+  era: {
+    /**
+     * The active era — the one whose validator set is in force and whose rewards are being
+     *   processed
+     */
+    index: BigNumber;
+
+    /**
+     * The latest era the chain has *planned*
+     *
+     * @note runs ahead of `index` between an election and the session rotation that brings the
+     *   newly elected set into force, and equals it the rest of the time
+     */
+    planned: BigNumber;
+
+    /**
+     * When the active era began
+     *
+     * @note `null` in the brief window between the chain creating the era at session rotation and
+     *   recording its start on the following block. Progress is unaffected — it is counted in
+     *   slots, which are always available
+     */
+    start: Date | null;
+
+    /**
+     * How far through the active era the chain is
+     */
+    progress: PeriodProgress;
+  };
+
+  session: {
+    /**
+     * The absolute session index, counting from genesis
+     */
+    index: BigNumber;
+
+    /**
+     * Which session of the active era this is, counting from 1
+     */
+    inEra: BigNumber;
+
+    /**
+     * How many sessions there are in an era
+     */
+    perEra: BigNumber;
+
+    /**
+     * How far through the current session the chain is
+     */
+    progress: PeriodProgress;
+  };
 }

--- a/src/api/entities/Account/Staking/index.ts
+++ b/src/api/entities/Account/Staking/index.ts
@@ -1,6 +1,7 @@
 import { Option } from '@polkadot/types';
 import { AccountId, RewardDestination } from '@polkadot/types/interfaces';
 import { PalletStakingNominations } from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
 
 import { Account, Namespace } from '~/internal';
 import {
@@ -13,6 +14,7 @@ import {
 } from '~/types';
 import {
   accountIdToString,
+  bigNumberToU32,
   rawNominationToStakingNomination,
   rawStakingLedgerToStakingLedgerEntry,
   rawValidatorPrefToCommission,
@@ -239,9 +241,17 @@ export class Staking extends Namespace<Account> {
   /**
    * Fetch the commission settings for this validator account
    *
-   * @returns The commission details or null if the account is not seeking nominations as a validator
+   * @param args.era - read the commission the Account was elected for in a past era, rather than
+   *   the one it is currently advertising. Defaults to the current settings
+   *
+   * @returns The commission details, or `null` if the Account is not seeking nominations as a
+   *   validator — or, when an `era` is given, was not in that era's validator set
+   *
+   * @note the two are different questions. Without an `era` this reads what the Account is
+   *   advertising *now*, which it can change at any time. With one it reads what it was actually
+   *   elected on, which is fixed for that era and is what its rewards were calculated against
    */
-  public async getCommission(): Promise<StakingCommission | null> {
+  public async getCommission(args?: { era?: BigNumber }): Promise<StakingCommission | null> {
     const {
       context,
       context: {
@@ -252,7 +262,11 @@ export class Staking extends Namespace<Account> {
 
     const rawAddress = stringToAccountId(address, context);
 
-    const rawValidator = await query.staking.validators(rawAddress);
+    const era = args?.era;
+
+    const rawValidator = era
+      ? await query.staking.erasValidatorPrefs(bigNumberToU32(era, context), rawAddress)
+      : await query.staking.validators(rawAddress);
 
     if (rawValidator.isEmpty) {
       return null;

--- a/src/api/entities/Account/__tests__/Staking.ts
+++ b/src/api/entities/Account/__tests__/Staking.ts
@@ -413,5 +413,39 @@ describe('Staking namespace', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should read the commission the account was elected on when an era is given', async () => {
+      const erasPrefsMock = dsMockUtils.createQueryMock('staking', 'erasValidatorPrefs', {
+        returnValue: dsMockUtils.createMockValidatorPref({
+          blocked: dsMockUtils.createMockBool(false),
+          commission: dsMockUtils.createMockCompact(
+            dsMockUtils.createMockPerbill(new BigNumber(250000000))
+          ),
+        }),
+      });
+
+      const currentPrefsMock = dsMockUtils.createQueryMock('staking', 'validators');
+
+      const result = await staking.getCommission({ era: new BigNumber(7131) });
+
+      expect(result).toEqual({
+        account: expect.objectContaining({ address: account.address }),
+        blocked: false,
+        commission: new BigNumber(25),
+      });
+      expect(erasPrefsMock).toHaveBeenCalled();
+      // the historical read must not fall back to what the account advertises now
+      expect(currentPrefsMock).not.toHaveBeenCalled();
+    });
+
+    it('should return null for an era the account was not in the validator set for', async () => {
+      dsMockUtils.createQueryMock('staking', 'erasValidatorPrefs', {
+        returnValue: dsMockUtils.createMockValidatorPref(),
+      });
+
+      const result = await staking.getCommission({ era: new BigNumber(7131) });
+
+      expect(result).toBeNull();
+    });
   });
 });

--- a/src/api/entities/Account/types.ts
+++ b/src/api/entities/Account/types.ts
@@ -228,7 +228,7 @@ export interface StakingNomination {
 
 export interface ActiveEraInfo {
   /**
-   * The block number in which this era became active
+   * The moment this era became active, as milliseconds since the Unix epoch
    */
   start: BigNumber;
 

--- a/src/api/procedures/__tests__/bondPolyx.ts
+++ b/src/api/procedures/__tests__/bondPolyx.ts
@@ -212,17 +212,16 @@ describe('bondPolyx procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return the appropriate roles and permissions', () => {
-      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
+    it('should require no permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext);
       const boundFunc = getAuthorization.bind(proc);
 
-      expect(boundFunc()).toEqual({
-        permissions: {
-          transactions: [],
-          assets: [],
-          portfolios: [],
-        },
-      });
+      /*
+       * `true`, not empty arrays: the staking pallet consults no `ExtrinsicPermissions`, and an
+       *   empty `SimplePermissions` would still read the key's permissions from chain — which
+       *   throws for an Account with no Identity
+       */
+      expect(boundFunc()).toEqual({ permissions: true });
     });
   });
 

--- a/src/api/procedures/__tests__/chillStaking.ts
+++ b/src/api/procedures/__tests__/chillStaking.ts
@@ -1,0 +1,111 @@
+import BigNumber from 'bignumber.js';
+
+import {
+  getAuthorization,
+  prepareChillStaking,
+  prepareStorage,
+  Storage,
+} from '~/api/procedures/chillStaking';
+import { Account, Context, PolymeshError } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { ErrorCode } from '~/types';
+import { PolymeshTx } from '~/types/internal';
+import { DUMMY_ACCOUNT_ID } from '~/utils/constants';
+
+describe('chillStaking procedure', () => {
+  beforeAll(() => {
+    entityMockUtils.initMocks();
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+  });
+
+  let mockContext: Mocked<Context>;
+  let chillTx: PolymeshTx<[]>;
+  let actingAccount: Account;
+
+  let storage: Storage;
+
+  beforeEach(() => {
+    chillTx = dsMockUtils.createTxMock('staking', 'chill');
+    mockContext = dsMockUtils.getContextInstance();
+    actingAccount = entityMockUtils.getAccountInstance({ address: DUMMY_ACCOUNT_ID });
+
+    storage = {
+      actingAccount,
+      controllerEntry: {
+        stash: entityMockUtils.getAccountInstance(),
+        total: new BigNumber(100),
+        active: new BigNumber(100),
+        unlocking: [],
+        claimedRewards: [],
+      },
+    };
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  describe('chillStaking', () => {
+    it('should throw an error if the acting account is not a controller', () => {
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext, {
+        ...storage,
+        controllerEntry: null,
+      });
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'The caller must be a controller account',
+      });
+
+      expect(() => prepareChillStaking.call(proc)).toThrow(expectedError);
+    });
+
+    it('should return a chill transaction spec', async () => {
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext, storage);
+
+      const result = await prepareChillStaking.call(proc);
+
+      expect(result).toEqual({
+        transaction: chillTx,
+        args: undefined,
+        resolver: undefined,
+      });
+    });
+  });
+
+  describe('getAuthorization', () => {
+    it('should require no permissions', () => {
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+
+      /*
+       * `true`, not empty arrays: the staking pallet consults no `ExtrinsicPermissions`, and an
+       *   empty `SimplePermissions` would still read the key's permissions from chain — which
+       *   throws for an Account with no Identity
+       */
+      expect(boundFunc()).toEqual({ permissions: true });
+    });
+  });
+
+  describe('prepareStorage', () => {
+    it('should return the storage', () => {
+      mockContext.getActingAccount.mockResolvedValue(actingAccount);
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext);
+      const boundFunc = prepareStorage.bind(proc);
+
+      return expect(boundFunc()).resolves.toEqual({
+        actingAccount: expect.objectContaining({ address: DUMMY_ACCOUNT_ID }),
+        controllerEntry: null,
+      });
+    });
+  });
+});

--- a/src/api/procedures/__tests__/nominateValidators.ts
+++ b/src/api/procedures/__tests__/nominateValidators.ts
@@ -177,13 +177,16 @@ describe('nominateValidators procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return the appropriate roles and permissions', () => {
-      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
+    it('should require no permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext);
       const boundFunc = getAuthorization.bind(proc);
 
-      expect(boundFunc()).toEqual({
-        signerPermissions: true,
-      });
+      /*
+       * `true`, not empty arrays: the staking pallet consults no `ExtrinsicPermissions`, and an
+       *   empty `SimplePermissions` would still read the key's permissions from chain — which
+       *   throws for an Account with no Identity
+       */
+      expect(boundFunc()).toEqual({ permissions: true });
     });
   });
 

--- a/src/api/procedures/__tests__/setStakingController.ts
+++ b/src/api/procedures/__tests__/setStakingController.ts
@@ -82,17 +82,16 @@ describe('setStakingController procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return the appropriate roles and permissions', () => {
-      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext, storage);
+    it('should require no permissions', () => {
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext);
       const boundFunc = getAuthorization.bind(proc);
 
-      expect(boundFunc()).toEqual({
-        permissions: {
-          transactions: [],
-          assets: [],
-          portfolios: [],
-        },
-      });
+      /*
+       * `true`, not empty arrays: the staking pallet consults no `ExtrinsicPermissions`, and an
+       *   empty `SimplePermissions` would still read the key's permissions from chain — which
+       *   throws for an Account with no Identity
+       */
+      expect(boundFunc()).toEqual({ permissions: true });
     });
   });
 

--- a/src/api/procedures/__tests__/setStakingPayee.ts
+++ b/src/api/procedures/__tests__/setStakingPayee.ts
@@ -141,17 +141,16 @@ describe('setStakingPayee procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return the appropriate roles and permissions', () => {
+    it('should require no permissions', () => {
       const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
       const boundFunc = getAuthorization.bind(proc);
 
-      expect(boundFunc()).toEqual({
-        permissions: {
-          transactions: [],
-          assets: [],
-          portfolios: [],
-        },
-      });
+      /*
+       * `true`, not empty arrays: the staking pallet consults no `ExtrinsicPermissions`, and an
+       *   empty `SimplePermissions` would still read the key's permissions from chain — which
+       *   throws for an Account with no Identity
+       */
+      expect(boundFunc()).toEqual({ permissions: true });
     });
   });
 

--- a/src/api/procedures/__tests__/updateBondedPolyx.ts
+++ b/src/api/procedures/__tests__/updateBondedPolyx.ts
@@ -29,6 +29,7 @@ describe('updateBondedPolyx procedure', () => {
   let mockContext: Mocked<Context>;
   let unbondTx: PolymeshTx<[Balance]>;
   let bondExtraTx: PolymeshTx<[Balance]>;
+  let rebondTx: PolymeshTx<[Balance]>;
   let actingAccount: Account;
   let rawAmount: Balance;
 
@@ -39,6 +40,7 @@ describe('updateBondedPolyx procedure', () => {
   beforeEach(() => {
     unbondTx = dsMockUtils.createTxMock('staking', 'unbond');
     bondExtraTx = dsMockUtils.createTxMock('staking', 'bondExtra');
+    rebondTx = dsMockUtils.createTxMock('staking', 'rebond');
     mockContext = dsMockUtils.getContextInstance();
     actingAccount = entityMockUtils.getAccountInstance({ address: DUMMY_ACCOUNT_ID });
     rawAmount = dsMockUtils.createMockBalance(amount);
@@ -206,6 +208,82 @@ describe('updateBondedPolyx procedure', () => {
     });
   });
 
+  describe('rebond', () => {
+    it('should throw an error if the acting account is not a controller', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        ...storage,
+        controllerEntry: null,
+      });
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'The caller must be a controller account',
+      });
+
+      expect(() => prepareUnbondPolyx.call(proc, { type: 'rebond', amount })).toThrow(
+        expectedError
+      );
+    });
+
+    it('should throw an error if there is insufficient unbonding POLYX', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        ...storage,
+        controllerEntry: {
+          ...storage.controllerEntry!,
+          unlocking: [{ value: new BigNumber(4), era: new BigNumber(1) }],
+        },
+      });
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.InsufficientBalance,
+        message: 'Insufficient unbonding POLYX',
+      });
+
+      expect(() => prepareUnbondPolyx.call(proc, { type: 'rebond', amount })).toThrow(
+        expectedError
+      );
+    });
+
+    it('should sum every unlocking chunk when checking the amount', async () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        ...storage,
+        controllerEntry: {
+          ...storage.controllerEntry!,
+          unlocking: [
+            { value: new BigNumber(4), era: new BigNumber(1) },
+            { value: new BigNumber(6), era: new BigNumber(2) },
+          ],
+        },
+      });
+
+      const result = await prepareUnbondPolyx.call(proc, { type: 'rebond', amount });
+
+      expect(result).toEqual({
+        transaction: rebondTx,
+        args: [rawAmount],
+        resolver: undefined,
+      });
+    });
+
+    it('should return a rebond transaction spec', async () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+        ...storage,
+        controllerEntry: {
+          ...storage.controllerEntry!,
+          unlocking: [{ value: new BigNumber(100), era: new BigNumber(1) }],
+        },
+      });
+
+      const result = await prepareUnbondPolyx.call(proc, { type: 'rebond', amount });
+
+      expect(result).toEqual({
+        transaction: rebondTx,
+        args: [rawAmount],
+        resolver: undefined,
+      });
+    });
+  });
+
   describe('getAuthorization', () => {
     it('should return the Unbond TxTag', () => {
       const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
@@ -227,6 +305,19 @@ describe('updateBondedPolyx procedure', () => {
       expect(boundFunc({ amount: new BigNumber(1), type: 'bondExtra' })).toEqual({
         permissions: {
           transactions: [TxTags.staking.BondExtra],
+          assets: [],
+          portfolios: [],
+        },
+      });
+    });
+
+    it('should return the Rebond TxTag', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(boundFunc({ amount: new BigNumber(1), type: 'rebond' })).toEqual({
+        permissions: {
+          transactions: [TxTags.staking.Rebond],
           assets: [],
           portfolios: [],
         },

--- a/src/api/procedures/__tests__/updateBondedPolyx.ts
+++ b/src/api/procedures/__tests__/updateBondedPolyx.ts
@@ -12,7 +12,7 @@ import {
 import { Account, Context, PolymeshError } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { ErrorCode, TxTags } from '~/types';
+import { ErrorCode } from '~/types';
 import { PolymeshTx } from '~/types/internal';
 import { DUMMY_ACCOUNT_ID } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';
@@ -285,43 +285,16 @@ describe('updateBondedPolyx procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return the Unbond TxTag', () => {
-      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
+    it('should require no permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext);
       const boundFunc = getAuthorization.bind(proc);
 
-      expect(boundFunc({ amount: new BigNumber(1), type: 'unbond' })).toEqual({
-        permissions: {
-          transactions: [TxTags.staking.Unbond],
-          assets: [],
-          portfolios: [],
-        },
-      });
-    });
-
-    it('should return the BondExtra TxTag', () => {
-      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
-      const boundFunc = getAuthorization.bind(proc);
-
-      expect(boundFunc({ amount: new BigNumber(1), type: 'bondExtra' })).toEqual({
-        permissions: {
-          transactions: [TxTags.staking.BondExtra],
-          assets: [],
-          portfolios: [],
-        },
-      });
-    });
-
-    it('should return the Rebond TxTag', () => {
-      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
-      const boundFunc = getAuthorization.bind(proc);
-
-      expect(boundFunc({ amount: new BigNumber(1), type: 'rebond' })).toEqual({
-        permissions: {
-          transactions: [TxTags.staking.Rebond],
-          assets: [],
-          portfolios: [],
-        },
-      });
+      /*
+       * `true`, not empty arrays: the staking pallet consults no `ExtrinsicPermissions`, and an
+       *   empty `SimplePermissions` would still read the key's permissions from chain — which
+       *   throws for an Account with no Identity
+       */
+      expect(boundFunc()).toEqual({ permissions: true });
     });
   });
 

--- a/src/api/procedures/__tests__/withdrawUnbondedPolyx.ts
+++ b/src/api/procedures/__tests__/withdrawUnbondedPolyx.ts
@@ -134,17 +134,16 @@ describe('withdrawUnbondedPolyx procedure', () => {
   });
 
   describe('getAuthorization', () => {
-    it('should return empty permissions', () => {
-      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext, storage);
+    it('should require no permissions', () => {
+      const proc = procedureMockUtils.getInstance<void, void, Storage>(mockContext);
       const boundFunc = getAuthorization.bind(proc);
 
-      expect(boundFunc()).toEqual({
-        permissions: {
-          transactions: [],
-          assets: [],
-          portfolios: [],
-        },
-      });
+      /*
+       * `true`, not empty arrays: the staking pallet consults no `ExtrinsicPermissions`, and an
+       *   empty `SimplePermissions` would still read the key's permissions from chain — which
+       *   throws for an Account with no Identity
+       */
+      expect(boundFunc()).toEqual({ permissions: true });
     });
   });
 

--- a/src/api/procedures/bondPolyx.ts
+++ b/src/api/procedures/bondPolyx.ts
@@ -64,15 +64,19 @@ export async function prepareBondPolyx(
 
 /**
  * @hidden
- * @note the staking module is exempt from permission checks
+ *
+ * The staking pallet does not consult a signer's `ExtrinsicPermissions` — no Substrate pallet in
+ *   the Polymesh runtime does — so no permission is required to run this, for a secondary key or
+ *   an external agent alike.
+ *
+ * `true` rather than empty arrays: an empty `SimplePermissions` still routes through
+ *   `Account.checkPermissions`, which reads the key's permissions from chain and **throws** for an
+ *   Account with no Identity. That turns a check that should be a no-op into a failure, and costs
+ *   a query either way.
  */
 export function getAuthorization(this: Procedure<Params, void, Storage>): ProcedureAuthorization {
   return {
-    permissions: {
-      assets: [],
-      transactions: [],
-      portfolios: [],
-    },
+    permissions: true,
   };
 }
 

--- a/src/api/procedures/chillStaking.ts
+++ b/src/api/procedures/chillStaking.ts
@@ -1,0 +1,83 @@
+import { PolymeshError, Procedure } from '~/internal';
+import { Account, ErrorCode, StakingLedger } from '~/types';
+import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
+
+/**
+ * @hidden
+ */
+export interface Storage {
+  actingAccount: Account;
+  controllerEntry: StakingLedger | null;
+}
+
+/**
+ * @hidden
+ */
+export function prepareChillStaking(
+  this: Procedure<void, void, Storage>
+): Promise<TransactionSpec<void, ExtrinsicParams<'staking', 'chill'>>> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: {
+          staking: { chill },
+        },
+      },
+    },
+    storage: { actingAccount, controllerEntry },
+  } = this;
+
+  if (!controllerEntry) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The caller must be a controller account',
+      data: { actingAccount: actingAccount.address },
+    });
+  }
+
+  return Promise.resolve({
+    transaction: chill,
+    args: undefined,
+    resolver: undefined,
+  });
+}
+
+/**
+ * @hidden
+ *
+ * The staking pallet does not consult a signer's `ExtrinsicPermissions` — no Substrate pallet in
+ *   the Polymesh runtime does — so no permission is required to run this, for a secondary key or
+ *   an external agent alike.
+ *
+ * `true` rather than empty arrays: an empty `SimplePermissions` still routes through
+ *   `Account.checkPermissions`, which reads the key's permissions from chain and **throws** for an
+ *   Account with no Identity. That turns a check that should be a no-op into a failure, and costs
+ *   a query either way.
+ */
+export function getAuthorization(this: Procedure<void, void, Storage>): ProcedureAuthorization {
+  return {
+    permissions: true,
+  };
+}
+
+/**
+ * @hidden
+ */
+export async function prepareStorage(this: Procedure<void, void, Storage>): Promise<Storage> {
+  const { context } = this;
+
+  const actingAccount = await context.getActingAccount();
+
+  const controllerEntry = await actingAccount.staking.getLedger();
+
+  return {
+    actingAccount,
+    controllerEntry,
+  };
+}
+
+/**
+ * @hidden
+ */
+export const chillStaking = (): Procedure<void, void, Storage> =>
+  new Procedure(prepareChillStaking, getAuthorization, prepareStorage);

--- a/src/api/procedures/nominateValidators.ts
+++ b/src/api/procedures/nominateValidators.ts
@@ -117,11 +117,16 @@ export async function prepareNominateValidators(
 /**
  * @hidden
  *
- * @note the staking module is exempt from permission checks
+ * The staking pallet does not consult a signer's `ExtrinsicPermissions` — no Substrate pallet in
+ *   the Polymesh runtime does — so no permission is required to run this, for a secondary key or
+ *   an external agent alike.
+ *
+ * `permissions` rather than `signerPermissions`: the latter only overrides the secondary-key
+ *   branch, which reads as though external agents were restricted when they are not.
  */
 export function getAuthorization(this: Procedure<Params, void, Storage>): ProcedureAuthorization {
   return {
-    signerPermissions: true,
+    permissions: true,
   };
 }
 

--- a/src/api/procedures/setStakingController.ts
+++ b/src/api/procedures/setStakingController.ts
@@ -43,15 +43,19 @@ export function prepareSetStakingController(
 
 /**
  * @hidden
- * @note the staking module is exempt from permission checks
+ *
+ * The staking pallet does not consult a signer's `ExtrinsicPermissions` — no Substrate pallet in
+ *   the Polymesh runtime does — so no permission is required to run this, for a secondary key or
+ *   an external agent alike.
+ *
+ * `true` rather than empty arrays: an empty `SimplePermissions` still routes through
+ *   `Account.checkPermissions`, which reads the key's permissions from chain and **throws** for an
+ *   Account with no Identity. That turns a check that should be a no-op into a failure, and costs
+ *   a query either way.
  */
 export function getAuthorization(this: Procedure<void, void, Storage>): ProcedureAuthorization {
   return {
-    permissions: {
-      assets: [],
-      transactions: [],
-      portfolios: [],
-    },
+    permissions: true,
   };
 }
 

--- a/src/api/procedures/setStakingPayee.ts
+++ b/src/api/procedures/setStakingPayee.ts
@@ -62,15 +62,19 @@ export async function prepareSetStakingPayee(
 
 /**
  * @hidden
- * @note the staking module is exempt from permission checks
+ *
+ * The staking pallet does not consult a signer's `ExtrinsicPermissions` — no Substrate pallet in
+ *   the Polymesh runtime does — so no permission is required to run this, for a secondary key or
+ *   an external agent alike.
+ *
+ * `true` rather than empty arrays: an empty `SimplePermissions` still routes through
+ *   `Account.checkPermissions`, which reads the key's permissions from chain and **throws** for an
+ *   Account with no Identity. That turns a check that should be a no-op into a failure, and costs
+ *   a query either way.
  */
 export function getAuthorization(this: Procedure<Params, void, Storage>): ProcedureAuthorization {
   return {
-    permissions: {
-      assets: [],
-      transactions: [],
-      portfolios: [],
-    },
+    permissions: true,
   };
 }
 

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1960,7 +1960,7 @@ export interface SetStakingPayeeParams {
 
 export interface UpdatePolyxBondParams {
   /**
-   * The amount of POLYX to unbond from staking
+   * The amount of POLYX to bond, unbond or rebond, depending on the operation
    */
   amount: BigNumber;
 }

--- a/src/api/procedures/updateBondedPolyx.ts
+++ b/src/api/procedures/updateBondedPolyx.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import { PolymeshError, Procedure } from '~/internal';
-import { Account, Balance, ErrorCode, StakingLedger, TxTags, UpdatePolyxBondParams } from '~/types';
+import { Account, Balance, ErrorCode, StakingLedger, UpdatePolyxBondParams } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import { bigNumberToBalance } from '~/utils/conversion';
 
@@ -133,24 +133,19 @@ export function prepareUnbondPolyx(
 
 /**
  * @hidden
+ *
+ * The staking pallet does not consult a signer's `ExtrinsicPermissions` — no Substrate pallet in
+ *   the Polymesh runtime does — so no permission is required to run this, for a secondary key or
+ *   an external agent alike.
+ *
+ * `true` rather than empty arrays: an empty `SimplePermissions` still routes through
+ *   `Account.checkPermissions`, which reads the key's permissions from chain and **throws** for an
+ *   Account with no Identity. That turns a check that should be a no-op into a failure, and costs
+ *   a query either way.
  */
-export function getAuthorization(
-  this: Procedure<Params, void, Storage>,
-  args: Params
-): ProcedureAuthorization {
-  const { type } = args;
-  const txTagByType = {
-    unbond: TxTags.staking.Unbond,
-    bondExtra: TxTags.staking.BondExtra,
-    rebond: TxTags.staking.Rebond,
-  } as const;
-
+export function getAuthorization(this: Procedure<Params, void, Storage>): ProcedureAuthorization {
   return {
-    permissions: {
-      assets: [],
-      transactions: [txTagByType[type]],
-      portfolios: [],
-    },
+    permissions: true,
   };
 }
 

--- a/src/api/procedures/updateBondedPolyx.ts
+++ b/src/api/procedures/updateBondedPolyx.ts
@@ -1,3 +1,5 @@
+import BigNumber from 'bignumber.js';
+
 import { PolymeshError, Procedure } from '~/internal';
 import { Account, Balance, ErrorCode, StakingLedger, TxTags, UpdatePolyxBondParams } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
@@ -16,7 +18,8 @@ export interface Storage {
 /**
  * @hidden
  */
-export type Params = UpdatePolyxBondParams & ({ type: 'unbond' } | { type: 'bondExtra' });
+export type Params = UpdatePolyxBondParams &
+  ({ type: 'unbond' } | { type: 'bondExtra' } | { type: 'rebond' });
 
 /**
  * @hidden
@@ -27,12 +30,13 @@ export function prepareUnbondPolyx(
 ): Promise<
   | TransactionSpec<void, ExtrinsicParams<'staking', 'unbond'>>
   | TransactionSpec<void, ExtrinsicParams<'staking', 'bondExtra'>>
+  | TransactionSpec<void, ExtrinsicParams<'staking', 'rebond'>>
 > {
   const {
     context: {
       polymeshApi: {
         tx: {
-          staking: { bondExtra, unbond },
+          staking: { bondExtra, rebond, unbond },
         },
       },
     },
@@ -42,9 +46,36 @@ export function prepareUnbondPolyx(
 
   const { amount, type } = args;
 
-  let transaction: typeof bondExtra | typeof unbond;
+  let transaction: typeof bondExtra | typeof rebond | typeof unbond;
 
-  if (type === 'unbond') {
+  if (type === 'rebond') {
+    transaction = rebond;
+
+    if (!controllerEntry) {
+      throw new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'The caller must be a controller account',
+        data: { actingAccount: actingAccount.address },
+      });
+    }
+
+    const unlockingTotal = controllerEntry.unlocking.reduce(
+      (total, { value }) => total.plus(value),
+      new BigNumber(0)
+    );
+
+    if (unlockingTotal.lt(amount)) {
+      throw new PolymeshError({
+        code: ErrorCode.InsufficientBalance,
+        message: 'Insufficient unbonding POLYX',
+        data: {
+          amount: amount.toString(),
+          unlocking: unlockingTotal.toString(),
+          actingAccount: actingAccount.address,
+        },
+      });
+    }
+  } else if (type === 'unbond') {
     transaction = unbond;
 
     if (!controllerEntry) {
@@ -108,12 +139,16 @@ export function getAuthorization(
   args: Params
 ): ProcedureAuthorization {
   const { type } = args;
-  const txTag = type === 'unbond' ? TxTags.staking.Unbond : TxTags.staking.BondExtra;
+  const txTagByType = {
+    unbond: TxTags.staking.Unbond,
+    bondExtra: TxTags.staking.BondExtra,
+    rebond: TxTags.staking.Rebond,
+  } as const;
 
   return {
     permissions: {
       assets: [],
-      transactions: [txTag],
+      transactions: [txTagByType[type]],
       portfolios: [],
     },
   };

--- a/src/api/procedures/withdrawUnbondedPolyx.ts
+++ b/src/api/procedures/withdrawUnbondedPolyx.ts
@@ -57,15 +57,19 @@ export function prepareWithdrawUnbondedPolyx(
 
 /**
  * @hidden
- * @note the staking module is exempt from permission checks
+ *
+ * The staking pallet does not consult a signer's `ExtrinsicPermissions` — no Substrate pallet in
+ *   the Polymesh runtime does — so no permission is required to run this, for a secondary key or
+ *   an external agent alike.
+ *
+ * `true` rather than empty arrays: an empty `SimplePermissions` still routes through
+ *   `Account.checkPermissions`, which reads the key's permissions from chain and **throws** for an
+ *   Account with no Identity. That turns a check that should be a no-op into a failure, and costs
+ *   a query either way.
  */
 export function getAuthorization(this: Procedure<void, void, Storage>): ProcedureAuthorization {
   return {
-    permissions: {
-      assets: [],
-      transactions: [],
-      portfolios: [],
-    },
+    permissions: true,
   };
 }
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -188,6 +188,7 @@ export { setStakingController } from '~/api/procedures/setStakingController';
 export { setStakingPayee } from '~/api/procedures/setStakingPayee';
 export { withdrawUnbondedPolyx } from '~/api/procedures/withdrawUnbondedPolyx';
 export { nominateValidators } from '~/api/procedures/nominateValidators';
+export { chillStaking } from '~/api/procedures/chillStaking';
 export { enableOffChainFundingForOfferings } from '~/api/procedures/enableOffChainFundingForOfferings';
 export { approveAllowance } from '~/api/procedures/approveAllowance';
 export { transferFunds } from '~/api/procedures/transferFunds';

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -70,9 +70,11 @@ import {
   PalletCorporateActionsRecordDateSpec,
   PalletCorporateActionsTargetIdentities,
   PalletCorporateActionsTargetTreatment,
+  PalletElectionProviderMultiPhasePhase,
   PalletIdentityClaim1stKey,
   PalletRelayerSubsidy,
   PalletStakingActiveEraInfo,
+  PalletStakingEraRewardPoints,
   PalletStakingNominations,
   PalletStakingSlashingSlashingSpans,
   PalletStakingStakingLedger,
@@ -154,6 +156,9 @@ import {
   PolymeshPrimitivesTransferComplianceAssetTransferCompliance,
   PolymeshPrimitivesTransferComplianceTransferCondition,
   PolymeshPrimitivesTransferComplianceTransferConditionExemptKey,
+  SpStakingExposurePage,
+  SpStakingIndividualExposure,
+  SpStakingPagedExposureMetadata,
 } from '@polkadot/types/lookup';
 import {
   Codec,
@@ -4953,6 +4958,76 @@ export const createMockActiveEraInfo = (
 
   return createMockCodec<PalletStakingActiveEraInfo>({ index, start }, !activeEra);
 };
+
+export const createMockEraRewardPoints = (
+  points?: { total: u32; individual: BTreeMap<AccountId32, u32> } | PalletStakingEraRewardPoints
+): MockCodec<PalletStakingEraRewardPoints> => {
+  const { total, individual } = points ?? {
+    total: createMockU32(),
+    individual: new Map() as unknown as BTreeMap<AccountId32, u32>,
+  };
+
+  return createMockCodec<PalletStakingEraRewardPoints>({ total, individual }, !points);
+};
+
+export const createMockPagedExposureMetadata = (
+  metadata?:
+    | {
+        total: Compact<u128>;
+        own: Compact<u128>;
+        nominatorCount: u32;
+        pageCount: u32;
+      }
+    | SpStakingPagedExposureMetadata
+): MockCodec<SpStakingPagedExposureMetadata> => {
+  const { total, own, nominatorCount, pageCount } = metadata ?? {
+    total: createMockCompact(),
+    own: createMockCompact(),
+    nominatorCount: createMockU32(),
+    pageCount: createMockU32(),
+  };
+
+  return createMockCodec<SpStakingPagedExposureMetadata>(
+    { total, own, nominatorCount, pageCount },
+    !metadata
+  );
+};
+
+export const createMockIndividualExposure = (
+  exposure?: { who: AccountId32; value: Compact<u128> } | SpStakingIndividualExposure
+): MockCodec<SpStakingIndividualExposure> => {
+  const { who, value } = exposure ?? {
+    who: createMockAccountId(),
+    value: createMockCompact(),
+  };
+
+  return createMockCodec<SpStakingIndividualExposure>({ who, value }, !exposure);
+};
+
+export const createMockExposurePage = (
+  page?: { pageTotal: Compact<u128>; others: SpStakingIndividualExposure[] } | SpStakingExposurePage
+): MockCodec<SpStakingExposurePage> => {
+  const { pageTotal, others } = page ?? {
+    pageTotal: createMockCompact(),
+    others: [],
+  };
+
+  return createMockCodec<SpStakingExposurePage>({ pageTotal, others }, !page);
+};
+
+export const createMockElectionPhase = (
+  phase: 'Off' | 'Signed' | 'Unsigned' | 'Emergency' = 'Off'
+): MockCodec<PalletElectionProviderMultiPhasePhase> =>
+  createMockCodec<PalletElectionProviderMultiPhasePhase>(
+    {
+      type: phase,
+      isOff: phase === 'Off',
+      isSigned: phase === 'Signed',
+      isUnsigned: phase === 'Unsigned',
+      isEmergency: phase === 'Emergency',
+    },
+    false
+  );
 
 export const createMockUnlockChunk = (
   chunk?: { value: Compact<u128>; era: Compact<u32> } | PalletStakingUnlockChunk

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -178,3 +178,12 @@ export const ASSET_ID_PREFIX = 'modlpy/pallet_asset';
 export const TX_TAG_VALUES: string[] = Object.values(TxTags).flatMap(v => Object.values(v));
 
 export const MODULE_NAMES: string[] = Object.values(ModuleName);
+
+/**
+ * Milliseconds in a year, as the chain counts one: the Julian year of 365.25 days
+ *
+ * @note the reward calculation in `pallets/validators/src/inflation.rs` uses
+ *   `1000 * 3600 * 24 * 36525 / 100`, so anything annualised against a 365 day year overstates the
+ *   result by 0.0685%
+ */
+export const MILLISECONDS_PER_YEAR = new BigNumber(1000 * 3600 * 24 * 36525).dividedBy(100);

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -632,7 +632,7 @@ export async function getApiAtBlock(
   return polymeshApi.at(blockHash);
 }
 
-type QueryMultiParam<T extends AugmentedQuery<'promise', AnyFunction>[]> = {
+export type QueryMultiParam<T extends AugmentedQuery<'promise', AnyFunction>[]> = {
   [index in keyof T]: T[index] extends AugmentedQuery<'promise', infer Fun>
     ? Fun extends (firstArg: infer First, ...restArg: infer Rest) => ReturnType<Fun>
       ? Rest extends never[]


### PR DESCRIPTION
### Description

Completes the SDK's staking coverage. 
**Actions** — `staking.chill()` and `staking.rebond()`. `chill` stops nominating without unbonding, previously only reachable by unbonding and waiting the full bonding duration.

**Reads** — `eraProgress()`, `getConstants()`, `getElectionPhase()`, five per-era reads (`getEraRewardPoints`, `getEraValidatorReward`, `getEraStartSession`, `getEraExposure`, `getEraNominators`), `getActiveValidators()`, `getValidatorCount()`, `account.staking.getCommission({ era })` and `network.getTotalIssuance()`. All previously required `_polkadotApi`.

`eraProgress` counts in **slots**, the unit the chain measures a period in, so `progress` is exact and advances every block — the same derivation `api.derive.session.progress` uses. `remaining`/`end` are projections from `expectedBlockTime` and are documented as such. It returns era **and** session progress, driven by one `queryMulti` subscription, so a progress bar needs no polling. `getEraRewardPoints` and `getElectionPhase` are subscribable too, being the other two values that change within an era.

**Two bug fixes**, both worth a look:

- Staking procedures applied permission checks `pallet_staking` doesn't make. `unbond`/`bondExtra`/`rebond` declared real tags and **refused a secondary key that lacked them**. The rest declared empty permission arrays, which pass but still route through `Account.checkPermissions` — reading permissions from chain and throwing for an Account with no Identity. All now return `permissions: true`.
- `eraInfo().totalStaked` read `erasTotalStake` without the POLYX shift, so it was 1,000,000x too large.

One thing worth care in review: `account.staking.getCommission({ era })` reads what a validator was *elected on*, while the no-arg form reads what it *advertises now* — mutable, and a different question. Both return the same type, so there's a test asserting the historical path doesn't silently fall back.

Six commits, each self-contained and green on its own.

### Breaking Changes

- **`eraInfo().totalStaked` now correctly returns POLYX**, not the chain's base unit. Callers dividing by `1e6` to compensate must stop.
- No signature changes. Everything else is additive.

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [x] Updated the Readme.md (if required) ?
