### PR TITLE
Fix miscellaneous SDK items

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -99,6 +99,13 @@
     "no-shadow": "off",
     "arrow-parens": "off",
     "camelcase": "off",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "BinaryExpression[operator='instanceof'][right.name='BigNumber']",
+        "message": "`instanceof BigNumber` fails when the value comes from a second copy of bignumber.js (dual-package hazard). Use `BigNumber.isBigNumber(value)` instead"
+      }
+    ],
     "no-restricted-imports": [
       "error",
       {

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -214,6 +214,18 @@ await sdk.staking.chill();
 await sdk.staking.rebond({ amount: new BigNumber(100) });
 ```
 
+### Order POLYX transaction history
+
+`Account.getPolyxTransactions` accepts `orderBy`, threaded through to the indexer.
+
+```ts
+const { data } = await account.getPolyxTransactions({
+  orderBy: PolyxTransactionsOrderBy.CreatedBlockIdAsc,
+});
+```
+
+It defaults to `IdDesc`, newest first — see the behaviour change below. The indexer's `id` is `<block number>/<event index>` with both parts zero-padded, so it is unique and sorts by block and then by position within the block. `CreatedBlockIdDesc` would have left transactions sharing a block in no defined order, which makes pages repeat or skip entries.
+
 ### The middleware API key is optional
 
 `MiddlewareConfig.key` is now optional. Connecting to an indexer that requires no authentication previously meant passing `key: ''`, which sent an empty `x-api-key` header; the header is now omitted entirely when no key is given.
@@ -339,6 +351,10 @@ The helper no longer filters:
 
 Both now read only what was asked for: balances by direct key lookup, collections by prefixing the held map with each collection and checking locks only on the NFTs found. Omitting the argument is unchanged, and still unbounded.
 
+### POLYX transaction history reported a count of `NaN`
+
+`polyxTransactionsQuery` never selected `totalCount`, so the `count` on every `getPolyxTransactions` result was `NaN` and `next` was derived from it.
+
 ### Report the actual reason an on-chain transaction failed
 
 A failed transaction whose dispatch error was not a module error was reported as `Unknown error`, discarding the reason: `SpRuntimeDispatchError` has fifteen variants and only three were handled.
@@ -381,13 +397,15 @@ The count now comes from the stash named in the controller's ledger. An Account 
 
 Each of these replaces silently wrong output with correct output, but callers depending on the old behaviour must adjust.
 
-| Change                                                                                                 | What to do                                                                                                                                             |
-| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Authorizations.getReceived()` now returns expired requests by default                                 | Pass `includeExpired: false`, or filter with `isExpired()`                                                                                             |
-| `Authorizations.getOne()` returns an expired request                                                   | Check `isExpired()`; it previously returned `undefined` typed as an `AuthorizationRequest`                                                             |
-| `IdentityAuthorizations.getSent()` includes expired requests                                           | Filter with `isExpired()`; pages are now the size they claim to be                                                                                     |
-| `assets.get()` pages a different storage map, so a `next` cursor is not comparable across this upgrade | Discard any persisted cursor and start the listing again; `next` is a storage key, and it now belongs to `asset.assets` rather than `asset.assetNames` |
-| `staking.eraInfo().totalStaked` is in POLYX                                                            | Stop dividing by `1e6` — see above                                                                                                                     |
+| Change                                                                                                         | What to do                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Account.getTransactionHistory()` now defaults to `ExtrinsicsOrderBy.IdDesc` (newest first) instead of `IdAsc` | Pass `orderBy: ExtrinsicsOrderBy.IdAsc` to keep ascending order. The old default was only right for an exhaustive export; every other history read in the SDK returns newest first |
+| `getPolyxTransactions()` now defaults to `PolyxTransactionsOrderBy.IdDesc` instead of `CreatedBlockIdAsc`      | Pass `orderBy: PolyxTransactionsOrderBy.CreatedBlockIdAsc` to keep ascending order, though `IdAsc` is the stable equivalent                                                        |
+| `Authorizations.getReceived()` now returns expired requests by default                                         | Pass `includeExpired: false`, or filter with `isExpired()`                                                                                                                         |
+| `Authorizations.getOne()` returns an expired request                                                           | Check `isExpired()`; it previously returned `undefined` typed as an `AuthorizationRequest`                                                                                         |
+| `IdentityAuthorizations.getSent()` includes expired requests                                                   | Filter with `isExpired()`; pages are now the size they claim to be                                                                                                                 |
+| `assets.get()` pages a different storage map, so a `next` cursor is not comparable across this upgrade         | Discard any persisted cursor and start the listing again; `next` is a storage key, and it now belongs to `asset.assets` rather than `asset.assetNames`                             |
+| `staking.eraInfo().totalStaked` is in POLYX                                                                    | Stop dividing by `1e6` — see above                                                                                                                                                 |
 
 ---
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -14,7 +14,7 @@ This guide describes **unreleased** changes since **v31.0.0** of `@polymeshassoc
 
 ## Overview
 
-This release adds **signing Polymesh transactions with an Ethereum wallet** such as MetaMask on chains running the `revive` pallet, **Ethereum address mapping** so an Account can safely receive funds at its Ethereum address, read-only connection from runtimes that disallow WASM compilation, broadcast without waiting, and much wider staking coverage. Changes are additive — note the new `AccountKeyType.Ethereum` variant below.
+This release adds **signing Polymesh transactions with an Ethereum wallet** such as MetaMask on chains running the `revive` pallet, **Ethereum address mapping** so an Account can safely receive funds at its Ethereum address, read-only connection from runtimes that disallow WASM compilation, broadcast without waiting, and much wider staking coverage. Changes are additive — note the new `AccountKeyType.Ethereum` variant, and the **behaviour changes** listed at the end.
 
 ---
 
@@ -310,6 +310,21 @@ Thirteen places tested a caller-supplied value with `instanceof BigNumber`. Wher
 
 All of them now use the realm-safe `BigNumber.isBigNumber`, which three call sites already did, and a lint rule keeps it that way. Consumers no longer need a `resolutions` pin on `bignumber.js` to work around this.
 
+### `includeExpired` was accepted and then ignored
+
+`Authorizations.getReceived({ includeExpired: true })` could never return an expired Authorization Request. The chain's `get_filtered_authorizations` already applies `includeExpired`, and the SDK then filtered the result by expiry a second time regardless of what was asked for. That second filter lived in a shared helper, so it also reached two reads that never wanted it:
+
+- `getOne` indexed `[0]` of the filtered list behind a non-null assertion, so an expired request came back as `undefined` typed as an `AuthorizationRequest` — the failure surfaced later and somewhere else.
+- `getSent` pages storage and then filtered, so a page of 25 could return 6 while still reporting a cursor.
+
+The helper no longer filters:
+
+- `getReceived` honours `includeExpired`, which still defaults to `true`. The filtering is the chain's, applied against the timestamp of the last block rather than the caller's clock.
+- `getOne` returns the request whether or not it has expired. It exists on chain until consumed or removed, and `isExpired()` tells the two apart.
+- `getSent` returns whole pages, expired requests included, so `next` means what it says.
+
+**Behaviour change.** `getReceived()` with no arguments now returns expired requests, matching its documented default. Pass `includeExpired: false` for the previous result, or filter with `AuthorizationRequest.isExpired()`.
+
 ### Report the actual reason an on-chain transaction failed
 
 A failed transaction whose dispatch error was not a module error was reported as `Unknown error`, discarding the reason: `SpRuntimeDispatchError` has fifteen variants and only three were handled.
@@ -337,6 +352,19 @@ All seven now return `permissions: true`: it short-circuits both checks, makes n
 `staking.withdraw` read the slashing span count from the acting Account, but `staking.slashingSpans` is keyed by the stash while `withdrawUnbonded` is signed by the controller. Where `setController` had bonded a stash to a separate controller the lookup missed and the SDK sent `0`, so the chain rejected the call with `IncorrectSlashingSpans` whenever a slashed stash withdrew the last of its bond.
 
 The count now comes from the stash named in the controller's ledger. An Account that is its own controller is unaffected.
+
+---
+
+## Behaviour changes
+
+Each of these replaces silently wrong output with correct output, but callers depending on the old behaviour must adjust.
+
+| Change                                                                 | What to do                                                                                 |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `Authorizations.getReceived()` now returns expired requests by default | Pass `includeExpired: false`, or filter with `isExpired()`                                 |
+| `Authorizations.getOne()` returns an expired request                   | Check `isExpired()`; it previously returned `undefined` typed as an `AuthorizationRequest` |
+| `IdentityAuthorizations.getSent()` includes expired requests           | Filter with `isExpired()`; pages are now the size they claim to be                         |
+| `staking.eraInfo().totalStaked` is in POLYX                            | Stop dividing by `1e6` — see above                                                         |
 
 ---
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -324,6 +324,12 @@ The helper no longer filters:
 - `getSent` returns whole pages, expired requests included, so `next` means what it says.
 
 **Behaviour change.** `getReceived()` with no arguments now returns expired requests, matching its documented default. Pass `includeExpired: false` for the previous result, or filter with `AuthorizationRequest.isExpired()`.
+
+### Reading named Assets scanned the whole Portfolio
+
+`Portfolio.getAssetBalances({ assets })` and `getCollections({ collections })` fetched every holding in the Portfolio and filtered in memory — two full storage scans for balances, joined client-side. A request for one Asset paid for all of them.
+
+Both now read only what was asked for: balances by direct key lookup, collections by prefixing the held map with each collection and checking locks only on the NFTs found. Omitting the argument is unchanged, and still unbounded.
 
 ### Report the actual reason an on-chain transaction failed
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -212,6 +212,14 @@ await sdk.staking.chill();
 
 ```typescript
 await sdk.staking.rebond({ amount: new BigNumber(100) });
+```
+
+### The middleware API key is optional
+
+`MiddlewareConfig.key` is now optional. Connecting to an indexer that requires no authentication previously meant passing `key: ''`, which sent an empty `x-api-key` header; the header is now omitted entirely when no key is given.
+
+```ts
+await Polymesh.connect({ nodeUrl, middlewareV2: { link: 'https://...' } });
 ```
 
 ### Transaction inclusion is reported before finalization

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, and the units of the total staked amount.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -303,6 +303,12 @@ This drops `cross-fetch`, `node-fetch`, `whatwg-url`, `tr46` and `webidl-convers
 ---
 
 ## Bug fixes
+
+### `instanceof BigNumber` failed across two copies of `bignumber.js`
+
+Thirteen places tested a caller-supplied value with `instanceof BigNumber`. Where the caller's `BigNumber` came from a second copy of the package — a mixed CJS/ESM graph, or a transitive dependency on a different version — the check silently returned `false` and the SDK took the wrong branch. `portfolios.delete({ portfolio: new BigNumber(1) })` failed with `Cannot read properties of undefined`; `redeemTokens`, `redeemNft`, `modifyAsset`, `moveFunds`, `removeCorporateAction`, `removeAssetRequirement`, `removeCheckpointSchedule`, `configureDividendDistribution` and `acceptPrimaryKeyRotation` had the same latent fault, as did several entities' identifier checks.
+
+All of them now use the realm-safe `BigNumber.isBigNumber`, which three call sites already did, and a lint rule keeps it that way. Consumers no longer need a `resolutions` pin on `bignumber.js` to work around this.
 
 ### Report the actual reason an on-chain transaction failed
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -361,16 +361,25 @@ The count now comes from the stash named in the controller's ledger. An Account 
 
 ---
 
+## Other changes
+
+### `assets.get()` reads one map instead of two
+
+`Assets.get()` paged `asset.assetNames` and then issued a second `.multi()` against `asset.assets` for the details. `asset.assets` is keyed by asset id alone, so paging it directly returns the details in the same response and halves the round trips. The Assets returned, and their order, are unchanged — both maps are keyed by the same asset id, so they iterate in the same order.
+
+---
+
 ## Behaviour changes
 
 Each of these replaces silently wrong output with correct output, but callers depending on the old behaviour must adjust.
 
-| Change                                                                 | What to do                                                                                 |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `Authorizations.getReceived()` now returns expired requests by default | Pass `includeExpired: false`, or filter with `isExpired()`                                 |
-| `Authorizations.getOne()` returns an expired request                   | Check `isExpired()`; it previously returned `undefined` typed as an `AuthorizationRequest` |
-| `IdentityAuthorizations.getSent()` includes expired requests           | Filter with `isExpired()`; pages are now the size they claim to be                         |
-| `staking.eraInfo().totalStaked` is in POLYX                            | Stop dividing by `1e6` — see above                                                         |
+| Change                                                                                                 | What to do                                                                                                                                             |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Authorizations.getReceived()` now returns expired requests by default                                 | Pass `includeExpired: false`, or filter with `isExpired()`                                                                                             |
+| `Authorizations.getOne()` returns an expired request                                                   | Check `isExpired()`; it previously returned `undefined` typed as an `AuthorizationRequest`                                                             |
+| `IdentityAuthorizations.getSent()` includes expired requests                                           | Filter with `isExpired()`; pages are now the size they claim to be                                                                                     |
+| `assets.get()` pages a different storage map, so a `next` cursor is not comparable across this upgrade | Discard any persisted cursor and start the listing again; `next` is a storage key, and it now belongs to `asset.assets` rather than `asset.assetNames` |
+| `staking.eraInfo().totalStaked` is in POLYX                                                            | Stop dividing by `1e6` — see above                                                                                                                     |
 
 ---
 

--- a/src/api/client/Assets.ts
+++ b/src/api/client/Assets.ts
@@ -1,4 +1,5 @@
-import { PolymeshPrimitivesAssetAssetId, PolymeshPrimitivesTicker } from '@polkadot/types/lookup';
+import { Option } from '@polkadot/types';
+import { PalletAssetAssetDetails, PolymeshPrimitivesAssetAssetId } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 
 import {
@@ -420,25 +421,24 @@ export class Assets {
       context,
     } = this;
 
-    const { entries, lastKey: next } = await requestPaginated(asset.assetNames, {
+    const { entries, lastKey: next } = await requestPaginated(asset.assets, {
       paginationOpts,
     });
 
     const assetIds: string[] = [];
-    const rawAssetIds: (PolymeshPrimitivesTicker | PolymeshPrimitivesAssetAssetId)[] = [];
+    const details: Option<PalletAssetAssetDetails>[] = [];
 
     entries.forEach(
       ([
         {
           args: [rawAssetId],
         },
+        rawDetails,
       ]) => {
-        rawAssetIds.push(rawAssetId);
         assetIds.push(assetIdToString(rawAssetId));
+        details.push(rawDetails);
       }
     );
-
-    const details = await asset.assets.multi(rawAssetIds);
 
     const data = assembleAssetQuery(details, assetIds, context);
 

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -66,7 +66,7 @@ function createMiddlewareApi(
           uri: middleware.link,
           fetch,
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          headers: { 'x-api-key': middleware.key },
+          headers: middleware.key ? { 'x-api-key': middleware.key } : {},
         }),
         cache: new InMemoryCache(),
         defaultOptions: {

--- a/src/api/client/__tests__/Assets.ts
+++ b/src/api/client/__tests__/Assets.ts
@@ -520,50 +520,55 @@ describe('Assets Class', () => {
         .mockImplementation();
     });
 
+    const rawFungibleDetails = (): unknown =>
+      dsMockUtils.createMockOption(
+        dsMockUtils.createMockSecurityToken({
+          ownerDid: dsMockUtils.createMockIdentityId('someDid'),
+          assetType: dsMockUtils.createMockAssetType(KnownAssetType.Commodity),
+          divisible: dsMockUtils.createMockBool(false),
+          totalSupply: dsMockUtils.createMockBalance(new BigNumber(0)),
+        })
+      );
+
+    const rawNftDetails = (): unknown =>
+      dsMockUtils.createMockOption(
+        dsMockUtils.createMockSecurityToken({
+          ownerDid: dsMockUtils.createMockIdentityId('someDid'),
+          assetType: dsMockUtils.createMockAssetType({
+            NonFungible: dsMockUtils.createMockNftType(KnownAssetType.Derivative),
+          }),
+          divisible: dsMockUtils.createMockBool(false),
+          totalSupply: dsMockUtils.createMockBalance(new BigNumber(0)),
+        })
+      );
+
+    let assetsMock: ReturnType<typeof dsMockUtils.createQueryMock<'asset', 'assets'>>;
+
     beforeEach(() => {
-      dsMockUtils.createQueryMock('asset', 'assetNames');
+      assetsMock = dsMockUtils.createQueryMock('asset', 'assets');
     });
 
     afterAll(() => {
       jest.restoreAllMocks();
     });
 
-    it('should retrieve all Assets on the chain', async () => {
-      const entries = expectedAssets.map(({ name, id }) =>
+    it('should page asset.assets and take the details from the same response', async () => {
+      const details = [rawFungibleDetails(), rawNftDetails()];
+      const entries = expectedAssets.map(({ id }, index) =>
         tuple(
           {
             args: [dsMockUtils.createMockAssetId(uuidToHex(id))],
           } as unknown as StorageKey,
-          dsMockUtils.createMockBytes(name)
+          details[index]
         )
       );
-
-      dsMockUtils.createQueryMock('asset', 'assets', {
-        multi: [
-          dsMockUtils.createMockOption(
-            dsMockUtils.createMockSecurityToken({
-              ownerDid: dsMockUtils.createMockIdentityId('someDid'),
-              assetType: dsMockUtils.createMockAssetType(KnownAssetType.Commodity),
-              divisible: dsMockUtils.createMockBool(false),
-              totalSupply: dsMockUtils.createMockBalance(new BigNumber(0)),
-            })
-          ),
-          dsMockUtils.createMockOption(
-            dsMockUtils.createMockSecurityToken({
-              ownerDid: dsMockUtils.createMockIdentityId('someDid'),
-              assetType: dsMockUtils.createMockAssetType({
-                NonFungible: dsMockUtils.createMockNftType(KnownAssetType.Derivative),
-              }),
-              divisible: dsMockUtils.createMockBool(false),
-              totalSupply: dsMockUtils.createMockBalance(new BigNumber(0)),
-            })
-          ),
-        ],
-      });
 
       requestPaginatedSpy.mockResolvedValue({ entries, lastKey: null });
 
       const result = await assets.get();
+
+      expect(requestPaginatedSpy).toHaveBeenCalledWith(assetsMock, expect.anything());
+      expect(assetsMock.multi).not.toHaveBeenCalled();
 
       const expectedData = expectedAssets.map(({ id }) => expect.objectContaining({ id }));
       expect(result).toEqual({ data: expect.arrayContaining(expectedData), next: null });
@@ -575,22 +580,9 @@ describe('Assets Class', () => {
           {
             args: [dsMockUtils.createMockAssetId(uuidToHex(expectedAssets[0]!.id))],
           } as unknown as StorageKey,
-          dsMockUtils.createMockBytes(expectedAssets[0]!.name)
+          rawFungibleDetails()
         ),
       ];
-
-      dsMockUtils.createQueryMock('asset', 'assets', {
-        multi: [
-          dsMockUtils.createMockOption(
-            dsMockUtils.createMockSecurityToken({
-              ownerDid: dsMockUtils.createMockIdentityId('someDid'),
-              assetType: dsMockUtils.createMockAssetType(KnownAssetType.Commodity),
-              divisible: dsMockUtils.createMockBool(false),
-              totalSupply: dsMockUtils.createMockBalance(new BigNumber(0)),
-            })
-          ),
-        ],
-      });
 
       requestPaginatedSpy.mockResolvedValue({ entries, lastKey: 'someKey' });
 

--- a/src/api/client/__tests__/Polymesh.ts
+++ b/src/api/client/__tests__/Polymesh.ts
@@ -17,10 +17,21 @@ jest.mock(
   '~/base/Context',
   require('~/testUtils/mocks/dataSources').mockContextModule('~/base/Context')
 );
-jest.mock(
-  '@apollo/client/core',
-  require('~/testUtils/mocks/dataSources').mockApolloModule('@apollo/client/core')
-);
+const mockCreateHttpLink = jest.fn();
+
+// wraps the shared Apollo mock so the options `createMiddlewareApi` builds can be asserted on
+jest.mock('@apollo/client/core', () => {
+  const actual = jest.requireActual('@apollo/client/core');
+
+  return {
+    ...require('~/testUtils/mocks/dataSources').mockApolloModule('@apollo/client/core')(),
+    createHttpLink: (...args: unknown[]): unknown => {
+      mockCreateHttpLink(...args);
+
+      return actual.createHttpLink(...args);
+    },
+  };
+});
 jest.mock(
   '~/api/entities/TickerReservation',
   require('~/testUtils/mocks/entities').mockTickerReservationModule(
@@ -181,6 +192,29 @@ describe('Polymesh Class', () => {
       });
 
       expect(createMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should send the api key header only when a key is configured', async () => {
+      mockCreateHttpLink.mockClear();
+
+      await Polymesh.connect({
+        nodeUrl: 'wss://some.url',
+        middlewareV2: { link: 'someLink' },
+      });
+
+      expect(mockCreateHttpLink).toHaveBeenLastCalledWith(
+        expect.objectContaining({ uri: 'someLink', headers: {} })
+      );
+
+      await Polymesh.connect({
+        nodeUrl: 'wss://some.url',
+        middlewareV2: { link: 'someLink', key: 'someKey' },
+      });
+
+      expect(mockCreateHttpLink).toHaveBeenLastCalledWith(
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        expect.objectContaining({ headers: { 'x-api-key': 'someKey' } })
+      );
     });
 
     it('should instantiate Context with Polkadot config and return  Polymesh instance', async () => {

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -145,7 +145,11 @@ export enum ErrorCode {
 
 export interface MiddlewareConfig {
   link: string;
-  key: string;
+  /**
+   * API key for the middleware, sent as the `x-api-key` header. Optional: an indexer that
+   * requires no authentication needs none, and the header is omitted rather than sent empty
+   */
+  key?: string;
 }
 
 export interface PolkadotConfig {

--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -231,7 +231,8 @@ describe('Account class', () => {
       const blockHash2 = 'otherHash';
       const blockDate1 = new Date('2022-12-25T00:00:00Z');
       const blockDate2 = new Date('2022-12-25T12:00:00Z');
-      const order = ExtrinsicsOrderBy.IdAsc;
+      // `getTransactionHistory` defaults to newest first
+      const order = ExtrinsicsOrderBy.IdDesc;
 
       when(txTagToExtrinsicIdentifierSpy).calledWith(tag).mockReturnValue({
         moduleId,

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -37,7 +37,7 @@ import {
   Staking,
 } from '~/internal';
 import { extrinsicsByArgs } from '~/middleware/queries/extrinsics';
-import { ExtrinsicsOrderBy, Query } from '~/middleware/types';
+import { ExtrinsicsOrderBy, PolyxTransactionsOrderBy, Query } from '~/middleware/types';
 import {
   AccountBalance,
   AccountCollection,
@@ -298,6 +298,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
    * @param filters.success - whether the transaction was successful or not
    * @param filters.size - page size
    * @param filters.start - page offset
+   * @param filters.orderBy - ordering of the results. Defaults to `ExtrinsicsOrderBy.IdDesc`, newest first
    *
    * @note uses the middleware v2
    *
@@ -317,7 +318,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       orderBy?: ExtrinsicsOrderBy;
     } = {}
   ): Promise<ResultSet<ExtrinsicData>> {
-    const { tag, success, size, start, orderBy = ExtrinsicsOrderBy.IdAsc, blockHash } = filters;
+    const { tag, success, size, start, orderBy = ExtrinsicsOrderBy.IdDesc, blockHash } = filters;
 
     const { context, address } = this;
 
@@ -671,12 +672,16 @@ export class Account extends Entity<UniqueIdentifiers, string> {
    *
    * @param filters.size - page size
    * @param filters.start - page offset
+   * @param filters.orderBy - ordering of the results. Defaults to `PolyxTransactionsOrderBy.IdDesc`, newest first.
+   *   The indexer's `id` is `<block number>/<event index>`, so it orders by block and then by position within
+   *   the block — ordering by block alone leaves transactions sharing a block in no defined order
    *
    * @note uses the middleware
    */
   public getPolyxTransactions(filters: {
     size?: BigNumber;
     start?: BigNumber;
+    orderBy?: PolyxTransactionsOrderBy;
   }): Promise<ResultSet<HistoricPolyxTransaction>> {
     const { context } = this;
 

--- a/src/api/entities/Asset/Base/BaseAsset.ts
+++ b/src/api/entities/Asset/Base/BaseAsset.ts
@@ -391,7 +391,7 @@ export class BaseAsset extends Entity<UniqueIdentifiers, string> {
       const { value, type } = assetTypeToKnownOrId(rawAssetType);
 
       let assetType: string;
-      if (value instanceof BigNumber) {
+      if (BigNumber.isBigNumber(value)) {
         const customType = await asset.customTypes(bigNumberToU32(value, context));
         assetType = bytesToString(customType);
       } else {

--- a/src/api/entities/Asset/NonFungible/Nft.ts
+++ b/src/api/entities/Asset/NonFungible/Nft.ts
@@ -64,7 +64,7 @@ export class Nft extends Entity<NftUniqueIdentifiers, HumanReadable> {
   ): identifier is NftUniqueIdentifiers {
     const { assetId, id } = identifier as NftUniqueIdentifiers;
 
-    return typeof assetId === 'string' && id instanceof BigNumber;
+    return typeof assetId === 'string' && BigNumber.isBigNumber(id);
   }
 
   /**

--- a/src/api/entities/AuthorizationRequest.ts
+++ b/src/api/entities/AuthorizationRequest.ts
@@ -56,7 +56,7 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { authId } = identifier as UniqueIdentifiers;
 
-    return authId instanceof BigNumber;
+    return BigNumber.isBigNumber(authId);
   }
 
   /**

--- a/src/api/entities/Checkpoint.ts
+++ b/src/api/entities/Checkpoint.ts
@@ -41,7 +41,7 @@ export class Checkpoint extends Entity<UniqueIdentifiers, HumanReadable> {
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { id, assetId } = identifier as UniqueIdentifiers;
 
-    return id instanceof BigNumber && typeof assetId === 'string';
+    return BigNumber.isBigNumber(id) && typeof assetId === 'string';
   }
 
   /**

--- a/src/api/entities/CheckpointSchedule/index.ts
+++ b/src/api/entities/CheckpointSchedule/index.ts
@@ -39,7 +39,7 @@ export class CheckpointSchedule extends Entity<UniqueIdentifiers, HumanReadable>
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { id, assetId } = identifier as UniqueIdentifiers;
 
-    return id instanceof BigNumber && typeof assetId === 'string';
+    return BigNumber.isBigNumber(id) && typeof assetId === 'string';
   }
 
   /**

--- a/src/api/entities/CorporateActionBase/index.ts
+++ b/src/api/entities/CorporateActionBase/index.ts
@@ -71,7 +71,7 @@ export abstract class CorporateActionBase extends Entity<UniqueIdentifiers, unkn
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { id, assetId } = identifier as UniqueIdentifiers;
 
-    return id instanceof BigNumber && typeof assetId === 'string';
+    return BigNumber.isBigNumber(id) && typeof assetId === 'string';
   }
 
   /**

--- a/src/api/entities/CustomPermissionGroup.ts
+++ b/src/api/entities/CustomPermissionGroup.ts
@@ -38,7 +38,7 @@ export class CustomPermissionGroup extends PermissionGroup {
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { id, assetId } = identifier as UniqueIdentifiers;
 
-    return id instanceof BigNumber && typeof assetId === 'string';
+    return BigNumber.isBigNumber(id) && typeof assetId === 'string';
   }
 
   public id: BigNumber;

--- a/src/api/entities/Identity/IdentityAuthorizations.ts
+++ b/src/api/entities/Identity/IdentityAuthorizations.ts
@@ -14,6 +14,8 @@ export class IdentityAuthorizations extends Authorizations<Identity> {
    * Fetch all pending authorization requests issued by this Identity
    *
    * @note supports pagination
+   * @note expired requests are included, so that a page holds as many entries as it says it does.
+   *   Use {@link api/entities/AuthorizationRequest!AuthorizationRequest.isExpired | isExpired} to skip them
    */
   public async getSent(
     paginationOpts?: PaginationOptions
@@ -56,6 +58,9 @@ export class IdentityAuthorizations extends Authorizations<Identity> {
    * Retrieve a single Authorization Request targeting or issued by this Identity by its ID
    *
    * @throws if there is no Authorization Request with the passed ID targeting or issued by this Identity
+   *
+   * @note an expired Authorization Request is still returned. Check
+   *   {@link api/entities/AuthorizationRequest!AuthorizationRequest.isExpired | isExpired} before acting on it
    */
   public override async getOne(args: { id: BigNumber }): Promise<AuthorizationRequest> {
     const {

--- a/src/api/entities/Identity/Portfolios.ts
+++ b/src/api/entities/Identity/Portfolios.ts
@@ -45,7 +45,7 @@ export class Portfolios extends Namespace<Identity> {
       {
         getProcedureAndArgs: args => {
           const { portfolio } = args;
-          const id = portfolio instanceof BigNumber ? portfolio : portfolio.id;
+          const id = BigNumber.isBigNumber(portfolio) ? portfolio : portfolio.id;
 
           return [deletePortfolio, { id, did }];
         },

--- a/src/api/entities/Identity/__tests__/IdentityAuthorizations.ts
+++ b/src/api/entities/Identity/__tests__/IdentityAuthorizations.ts
@@ -162,6 +162,59 @@ describe('IdentityAuthorizations class', () => {
     });
   });
 
+  describe('method: getSent', () => {
+    it('should return a full page, including expired requests, so the cursor stays honest', async () => {
+      jest.spyOn(utilsConversionModule, 'signerValueToSignatory').mockImplementation();
+      dsMockUtils.createQueryMock('identity', 'authorizationsGiven');
+
+      const requestPaginatedSpy = jest.spyOn(utilsInternalModule, 'requestPaginated');
+
+      const did = 'someDid';
+      const context = dsMockUtils.getContextInstance({ did });
+      const identity = entityMockUtils.getIdentityInstance({ did });
+      const authsNamespace = new IdentityAuthorizations(identity, context);
+
+      entityMockUtils.configureMocks({ authorizationRequestOptions: { isExpired: true } });
+
+      const rawAuthorization = dsMockUtils.createMockAuthorization({
+        authId: dsMockUtils.createMockU64(new BigNumber(1)),
+        expiry: dsMockUtils.createMockOption(
+          dsMockUtils.createMockMoment(new BigNumber(new Date('10/14/1987').getTime()))
+        ),
+        authorizationData: dsMockUtils.createMockAuthorizationData({
+          TransferAssetOwnership: dsMockUtils.createMockAssetId(
+            '0x12341234123412341234123412341234'
+          ),
+        }),
+        authorizedBy: dsMockUtils.createMockIdentityId(did),
+      });
+
+      requestPaginatedSpy.mockResolvedValue({
+        entries: [
+          tuple(
+            {
+              args: [rawAuthorization.authorizedBy, rawAuthorization.authId],
+            } as unknown as StorageKey,
+            dsMockUtils.createMockSignatory({
+              Identity: dsMockUtils.createMockIdentityId('alice'),
+            })
+          ),
+        ],
+        lastKey: 'someKey',
+      });
+
+      const authorizationsMock = dsMockUtils.createQueryMock('identity', 'authorizations');
+      authorizationsMock.multi.mockResolvedValue([dsMockUtils.createMockOption(rawAuthorization)]);
+
+      const result = await authsNamespace.getSent();
+
+      expect(result.data).toHaveLength(1);
+      expect(result.next).toBe('someKey');
+
+      requestPaginatedSpy.mockRestore();
+    });
+  });
+
   describe('method: getOne', () => {
     afterAll(() => {
       jest.restoreAllMocks();
@@ -248,6 +301,44 @@ describe('IdentityAuthorizations class', () => {
 
       expect(result).toBe(mockAuthRequest);
       spy.mockRestore();
+    });
+
+    it('should return an expired Authorization Request issued by the parent Identity', async () => {
+      const did = 'someDid';
+      const context = dsMockUtils.getContextInstance({ did });
+      const identity = entityMockUtils.getIdentityInstance({ did });
+      const authsNamespace = new IdentityAuthorizations(identity, context);
+      const id = new BigNumber(1);
+
+      entityMockUtils.configureMocks({ authorizationRequestOptions: { isExpired: true } });
+
+      dsMockUtils.createQueryMock('identity', 'authorizationsGiven', {
+        returnValue: dsMockUtils.createMockSignatory({
+          Identity: dsMockUtils.createMockIdentityId('alice'),
+        }),
+      });
+
+      dsMockUtils.createQueryMock('identity', 'authorizations', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockAuthorization({
+            authId: dsMockUtils.createMockU64(id),
+            authorizationData: dsMockUtils.createMockAuthorizationData({
+              TransferAssetOwnership: dsMockUtils.createMockAssetId(
+                '0x12341234123412341234123412341234'
+              ),
+            }),
+            expiry: dsMockUtils.createMockOption(
+              dsMockUtils.createMockMoment(new BigNumber(new Date('10/14/1987').getTime()))
+            ),
+            authorizedBy: dsMockUtils.createMockIdentityId(did),
+          })
+        ),
+      });
+
+      const result = await authsNamespace.getOne({ id });
+
+      expect(result.authId).toEqual(id);
+      expect(result.isExpired()).toBe(true);
     });
 
     it('should throw an error if the Authorization Request does not exist', async () => {

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -122,7 +122,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { id } = identifier as UniqueIdentifiers;
 
-    return id instanceof BigNumber;
+    return BigNumber.isBigNumber(id);
   }
 
   /**

--- a/src/api/entities/MetadataEntry/index.ts
+++ b/src/api/entities/MetadataEntry/index.ts
@@ -65,7 +65,7 @@ export class MetadataEntry extends Entity<UniqueIdentifiers, HumanReadable> {
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { id, assetId, type } = identifier as UniqueIdentifiers;
 
-    return id instanceof BigNumber && typeof assetId === 'string' && type in MetadataType;
+    return BigNumber.isBigNumber(id) && typeof assetId === 'string' && type in MetadataType;
   }
 
   /**

--- a/src/api/entities/NumberedPortfolio.ts
+++ b/src/api/entities/NumberedPortfolio.ts
@@ -36,7 +36,7 @@ export class NumberedPortfolio extends Portfolio {
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { did, id } = identifier as UniqueIdentifiers;
 
-    return typeof did === 'string' && id instanceof BigNumber;
+    return typeof did === 'string' && BigNumber.isBigNumber(id);
   }
 
   /**

--- a/src/api/entities/NumberedPortfolio.ts
+++ b/src/api/entities/NumberedPortfolio.ts
@@ -152,6 +152,10 @@ export class NumberedPortfolio extends Portfolio {
   /**
    * Send an invitation to an Identity to assign it as custodian for this Numbered Portfolio
    *
+   * @note only a numbered Portfolio can have a custodian. The chain rejects custody of a default
+   *   Portfolio with `DefaultPortfoliosCannotHaveCustodians`, so this is deliberately not on the
+   *   {@link api/entities/Portfolio!Portfolio | Portfolio} base class
+   *
    * @note this will create an {@link AuthorizationRequest | Authorization Request} which has to be accepted by the `targetIdentity`.
    *   An {@link api/entities/Account!Account | Account} or {@link api/entities/Identity!Identity | Identity} can fetch its pending Authorization Requests by calling {@link api/entities/common/namespaces/Authorizations!Authorizations.getReceived | authorizations.getReceived}.
    *   Also, an Account or Identity can directly fetch the details of an Authorization Request by calling {@link api/entities/common/namespaces/Authorizations!Authorizations.getOne | authorizations.getOne}

--- a/src/api/entities/Offering/index.ts
+++ b/src/api/entities/Offering/index.ts
@@ -72,7 +72,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { id, assetId } = identifier as UniqueIdentifiers;
 
-    return id instanceof BigNumber && typeof assetId === 'string';
+    return BigNumber.isBigNumber(id) && typeof assetId === 'string';
   }
 
   /**

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -275,10 +275,11 @@ describe('Portfolio class', () => {
       expect(result[1]!.free).toEqual(total1.minus(locked1));
     });
 
-    it('should return the requested portfolio assets and their balances', async () => {
+    it('should look up only the requested assets, without scanning the whole portfolio', async () => {
       const portfolio = new NonAbstract({ did, id }, context);
 
-      const otherAssetId = '0x99999999999999999999999999999999';
+      const otherAssetId = hexToUuid('0x99999999999999999999999999999999');
+      const rawZero = dsMockUtils.createMockBalance(new BigNumber(0));
 
       when(asFungibleAssetSpy)
         .calledWith(hexToUuid(assetId0), context)
@@ -290,9 +291,21 @@ describe('Portfolio class', () => {
         .calledWith(otherAssetId, context)
         .mockResolvedValue(entityMockUtils.getFungibleAssetInstance({ assetId: otherAssetId }));
 
+      const totalsMock = dsMockUtils.createQueryMock('portfolio', 'portfolioAssetBalances', {
+        multi: [rawTotal0, rawZero],
+      });
+      const lockedMock = dsMockUtils.createQueryMock('portfolio', 'portfolioLockedAssets', {
+        multi: [rawLocked0, rawZero],
+      });
+
       const result = await portfolio.getAssetBalances({
         assets: [hexToUuid(assetId0), new FungibleAsset({ assetId: otherAssetId }, context)],
       });
+
+      expect(totalsMock.multi).toHaveBeenCalledTimes(1);
+      expect(lockedMock.multi).toHaveBeenCalledTimes(1);
+      expect(totalsMock.entries).not.toHaveBeenCalled();
+      expect(lockedMock.entries).not.toHaveBeenCalled();
 
       expect(result).toHaveLength(2);
       expect(result[0]!.asset.id).toBe(hexToUuid(assetId0));
@@ -420,12 +433,31 @@ describe('Portfolio class', () => {
       );
     });
 
-    it('should filter assets if any are specified', async () => {
+    it('should read only the requested collections, without scanning the whole portfolio', async () => {
       const portfolio = new NonAbstract({ did, id: portfolioId }, context);
 
       jest.spyOn(utilsInternalModule, 'asAssetId').mockResolvedValue(hexToUuid(assetId));
 
+      const rawFalse = dsMockUtils.createMockBool(false);
+
+      const heldMock = dsMockUtils.createQueryMock('portfolio', 'portfolioNFT', {
+        entries: [
+          tuple([rawPortfolioId, rawAssetId, rawNftId], rawTrue),
+          tuple([rawPortfolioId, rawAssetId, rawSecondId], rawTrue),
+          tuple([rawPortfolioId, rawAssetId, rawLockedId], rawTrue),
+        ],
+      });
+
+      const lockedMock = dsMockUtils.createQueryMock('portfolio', 'portfolioLockedNFT', {
+        multi: [rawFalse, rawFalse, rawTrue],
+      });
+
       const result = await portfolio.getCollections({ collections: [hexToUuid(assetId)] });
+
+      // the held map is prefixed by collection, and only the NFTs found are checked for locks
+      expect(heldMock.entries).toHaveBeenCalledTimes(1);
+      expect(lockedMock.multi).toHaveBeenCalledTimes(1);
+      expect(lockedMock.entries).not.toHaveBeenCalled();
 
       expect(result).toHaveLength(1);
 
@@ -442,6 +474,39 @@ describe('Portfolio class', () => {
           },
         ])
       );
+    });
+
+    it('should not query locked NFTs when the requested collections hold none', async () => {
+      const portfolio = new NonAbstract({ did, id: portfolioId }, context);
+
+      jest.spyOn(utilsInternalModule, 'asAssetId').mockResolvedValue(hexToUuid(assetId));
+
+      dsMockUtils.createQueryMock('portfolio', 'portfolioNFT', { entries: [] });
+      const lockedMock = dsMockUtils.createQueryMock('portfolio', 'portfolioLockedNFT');
+
+      const result = await portfolio.getCollections({ collections: [hexToUuid(assetId)] });
+
+      expect(result).toEqual([]);
+      expect(lockedMock.multi).not.toHaveBeenCalled();
+    });
+
+    it('should return a collection once even if it is asked for twice', async () => {
+      const portfolio = new NonAbstract({ did, id: portfolioId }, context);
+
+      jest.spyOn(utilsInternalModule, 'asAssetId').mockResolvedValue(hexToUuid(assetId));
+
+      dsMockUtils.createQueryMock('portfolio', 'portfolioNFT', {
+        entries: [tuple([rawPortfolioId, rawAssetId, rawNftId], rawTrue)],
+      });
+      dsMockUtils.createQueryMock('portfolio', 'portfolioLockedNFT', {
+        multi: [dsMockUtils.createMockBool(false)],
+      });
+
+      const result = await portfolio.getCollections({
+        collections: [hexToUuid(assetId), hexToUuid(assetId)],
+      });
+
+      expect(result).toHaveLength(1);
     });
 
     it('should throw an error if the portfolio does not exist', () => {

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -326,6 +326,24 @@ describe('Portfolio class', () => {
         "The Portfolio doesn't exist or was removed by its owner"
       );
     });
+
+    it('should throw an error if the portfolio does not exist and assets were requested', async () => {
+      const portfolio = new NonAbstract({ did, id }, context);
+      exists = false;
+
+      when(asFungibleAssetSpy)
+        .calledWith(hexToUuid(assetId0), context)
+        .mockResolvedValue(
+          entityMockUtils.getFungibleAssetInstance({ assetId: hexToUuid(assetId0) })
+        );
+
+      dsMockUtils.createQueryMock('portfolio', 'portfolioAssetBalances', { multi: [rawTotal0] });
+      dsMockUtils.createQueryMock('portfolio', 'portfolioLockedAssets', { multi: [rawLocked0] });
+
+      await expect(portfolio.getAssetBalances({ assets: [hexToUuid(assetId0)] })).rejects.toThrow(
+        "The Portfolio doesn't exist or was removed by its owner"
+      );
+    });
   });
 
   describe('method: getCollections', () => {
@@ -514,6 +532,21 @@ describe('Portfolio class', () => {
       exists = false;
 
       return expect(portfolio.getCollections()).rejects.toThrow(
+        "The Portfolio doesn't exist or was removed by its owner"
+      );
+    });
+
+    it('should throw an error if the portfolio does not exist and collections were requested', async () => {
+      const portfolio = new NonAbstract({ did, id: portfolioId }, context);
+      exists = false;
+
+      jest.spyOn(utilsInternalModule, 'asAssetId').mockResolvedValue(hexToUuid(assetId));
+
+      dsMockUtils.createQueryMock('portfolio', 'portfolioNFT', {
+        entries: [tuple([rawPortfolioId, rawAssetId, rawNftId], rawTrue)],
+      });
+
+      await expect(portfolio.getCollections({ collections: [hexToUuid(assetId)] })).rejects.toThrow(
         "The Portfolio doesn't exist or was removed by its owner"
       );
     });

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -398,7 +398,8 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
 
     const lockedIds = new Set<string>();
     heldNftKeys.forEach(([, [rawAssetId, rawNftId]], index) => {
-      if (lockStatuses[index]?.isTrue) {
+      // `multi` returns one result per key, so this is always defined
+      if (lockStatuses[index]!.isTrue) {
         lockedIds.add(`${assetIdToString(rawAssetId)}/${u64ToBigNumber(rawNftId).toString()}`);
       }
     });

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -81,7 +81,7 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { did, id } = identifier as UniqueIdentifiers;
 
-    return typeof did === 'string' && (id === undefined || id instanceof BigNumber);
+    return typeof did === 'string' && (id === undefined || BigNumber.isBigNumber(id));
   }
 
   /**

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -35,7 +35,7 @@ import {
   ProcedureMethod,
   ResultSet,
 } from '~/types';
-import { Ensured } from '~/types/utils';
+import { Ensured, tuple } from '~/types/utils';
 import {
   assetIdToString,
   assetToMeshAssetId,
@@ -43,6 +43,7 @@ import {
   boolToBoolean,
   identityIdToString,
   portfolioIdToMeshPortfolioId,
+  stringToAssetId,
   toHistoricalSettlements,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -224,9 +225,60 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
   }
 
   /**
+   * @hidden
+   *
+   * Retrieve the balances of a known set of Assets by reading their storage keys directly
+   *
+   * @note this is what makes a fully specified request cost a lookup per Asset rather than a scan
+   *   of every Asset the Portfolio holds
+   */
+  private async getBalancesForAssets(
+    rawPortfolioId: PolymeshPrimitivesIdentityIdPortfolioId,
+    assets: (string | FungibleAsset)[]
+  ): Promise<PortfolioBalance[]> {
+    const {
+      context,
+      context: {
+        polymeshApi: {
+          query: { portfolio },
+        },
+      },
+    } = this;
+
+    const requestedAssets = await Promise.all(assets.map(asset => asFungibleAsset(asset, context)));
+
+    const keys = requestedAssets.map(asset =>
+      tuple(rawPortfolioId, assetToMeshAssetId(asset, context))
+    );
+
+    const [exists, rawTotals, rawLocked] = await Promise.all([
+      this.exists(),
+      portfolio.portfolioAssetBalances.multi(keys),
+      portfolio.portfolioLockedAssets.multi(keys),
+    ]);
+
+    if (!exists) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: notExistsMessage,
+      });
+    }
+
+    return requestedAssets.map((asset, index) => {
+      const total = balanceToBigNumber(rawTotals[index]!);
+      const locked = balanceToBigNumber(rawLocked[index]!);
+
+      return { asset, total, locked, free: total.minus(locked) };
+    });
+  }
+
+  /**
    * Retrieve the balances of all fungible assets in this Portfolio
    *
    * @param args.assets - array of FungibleAssets (or tickers) for which to fetch balances (optional, all balances are retrieved if not passed)
+   *
+   * @note passing `args.assets` reads only those Assets' storage keys. Omitting it scans every
+   *   Asset the Portfolio holds, which is unbounded
    */
   public async getAssetBalances(args?: {
     assets: (string | FungibleAsset)[];
@@ -243,6 +295,11 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
     } = this;
 
     const rawPortfolioId = portfolioIdToMeshPortfolioId({ did, number: portfolioId }, context);
+
+    if (args?.assets.length) {
+      return this.getBalancesForAssets(rawPortfolioId, args.assets);
+    }
+
     const [exists, totalBalanceEntries, lockedBalanceEntries] = await Promise.all([
       this.exists(),
       portfolio.portfolioAssetBalances.entries(rawPortfolioId),
@@ -282,30 +339,105 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
       }
     });
 
-    if (args?.assets.length) {
-      const filteredBalances: PortfolioBalance[] = [];
-      for (const asset of args.assets) {
-        const argAsset = await asFungibleAsset(asset, context);
-        const portfolioBalance = {
-          total: new BigNumber(0),
-          locked: new BigNumber(0),
-          free: new BigNumber(0),
-          asset: argAsset,
-        };
+    return Object.values(assetBalances);
+  }
 
-        filteredBalances.push(assetBalances[argAsset.id] ?? portfolioBalance);
-      }
+  /**
+   * @hidden
+   *
+   * Retrieve the NFTs held for a known set of collections, by prefixing the held map with each
+   * collection rather than scanning every NFT the Portfolio holds
+   */
+  private async getNftsForCollections(
+    rawPortfolioId: PolymeshPrimitivesIdentityIdPortfolioId,
+    collections: (string | NftCollection)[]
+  ): Promise<PortfolioCollection[]> {
+    const {
+      context,
+      context: {
+        polymeshApi: {
+          query: { portfolio },
+        },
+      },
+    } = this;
 
-      return filteredBalances;
+    // the same collection asked for twice must not come back twice, as it did not before
+    const assetIds = [
+      ...new Set(await Promise.all(collections.map(asset => asAssetId(asset, context)))),
+    ];
+
+    const [exists, ...heldEntries] = await Promise.all([
+      this.exists(),
+      ...assetIds.map(assetId =>
+        portfolio.portfolioNFT.entries(rawPortfolioId, stringToAssetId(assetId, context))
+      ),
+    ]);
+
+    if (!exists) {
+      throw new PolymeshError({ code: ErrorCode.DataUnavailable, message: notExistsMessage });
     }
 
-    return Object.values(assetBalances);
+    /*
+     * `portfolioLockedNFT` is keyed by (portfolioId, (assetId, nftId)), so it cannot be prefixed by
+     * collection. Every held NFT has to be asked about individually, which keeps the cost
+     * proportional to the answer rather than to every locked NFT in the Portfolio
+     */
+    const heldNftKeys = heldEntries.flatMap(entries =>
+      entries.map(
+        ([
+          {
+            args: [, rawAssetId, rawNftId],
+          },
+        ]) => tuple(rawPortfolioId, tuple(rawAssetId, rawNftId))
+      )
+    );
+
+    const lockStatuses = heldNftKeys.length
+      ? await portfolio.portfolioLockedNFT.multi(heldNftKeys)
+      : [];
+
+    const lockedIds = new Set<string>();
+    heldNftKeys.forEach(([, [rawAssetId, rawNftId]], index) => {
+      if (lockStatuses[index]?.isTrue) {
+        lockedIds.add(`${assetIdToString(rawAssetId)}/${u64ToBigNumber(rawNftId).toString()}`);
+      }
+    });
+
+    return assetIds.reduce<PortfolioCollection[]>((result, assetId, index) => {
+      const entries = heldEntries[index]!;
+
+      if (!entries.length) {
+        return result;
+      }
+
+      const held = entries.map(
+        ([
+          {
+            args: [, , rawNftId],
+          },
+        ]) => new Nft({ id: u64ToBigNumber(rawNftId), assetId }, context)
+      );
+      const locked = held.filter(({ id }) => lockedIds.has(`${assetId}/${id.toString()}`));
+      const lockedNftIds = new Set(locked.map(({ id }) => id.toString()));
+
+      result.push({
+        collection: new NftCollection({ assetId }, context),
+        free: held.filter(({ id }) => !lockedNftIds.has(id.toString())),
+        locked,
+        total: new BigNumber(held.length),
+      });
+
+      return result;
+    }, []);
   }
 
   /**
    * Retrieve the NFTs held in this portfolio
    *
    *  @param args.collections - array of NftCollection (or tickers) for which to fetch holdings (optional, all holdings are retrieved if not passed)
+   *
+   * @note passing `args.collections` reads only those collections. Omitting it scans every NFT the
+   *   Portfolio holds, which is unbounded
    */
   public async getCollections(args?: {
     collections: (string | NftCollection)[];
@@ -322,6 +454,10 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
     } = this;
 
     const rawPortfolioId = portfolioIdToMeshPortfolioId({ did, number: portfolioId }, context);
+
+    if (args?.collections.length) {
+      return this.getNftsForCollections(rawPortfolioId, args.collections);
+    }
 
     // portfolioNFT uses key [portfolioId, assetId, nftId]. Cast required to query with a single
     // arg as Polkadot defaults to N-1 args.
@@ -348,16 +484,11 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
       throw new PolymeshError({ code: ErrorCode.DataUnavailable, message: notExistsMessage });
     }
 
-    const queriedCollections = args?.collections
-      ? await Promise.all(args.collections.map(asset => asAssetId(asset, context)))
-      : undefined;
-
     const seenAssetIds = new Set<string>();
     const heldCollections: Record<string, Nft[]> = {};
     const lockedCollections: Record<string, Nft[]> = {};
 
     const addNft = (record: Record<string, Nft[]>, assetId: string, nftId: BigNumber): void => {
-      if (queriedCollections && !queriedCollections.includes(assetId)) return;
       seenAssetIds.add(assetId);
       const nft = new Nft({ id: nftId, assetId }, context);
       if (record[assetId]) {

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -80,7 +80,7 @@ export class Venue extends Entity<UniqueIdentifiers, string> {
   public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
     const { id } = identifier as UniqueIdentifiers;
 
-    return id instanceof BigNumber;
+    return BigNumber.isBigNumber(id);
   }
 
   /**

--- a/src/api/entities/common/namespaces/Authorizations.ts
+++ b/src/api/entities/common/namespaces/Authorizations.ts
@@ -37,7 +37,10 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
    * Fetch all pending Authorization Requests for which this Signer is the target
    *
    * @param opts.type - fetch only authorizations of this type. Fetches all types if not passed
-   * @param opts.includeExpired - whether to include expired authorizations. Defaults to true
+   * @param opts.includeExpired - whether to include expired authorizations. Defaults to true.
+   *   The chain applies this filter, against the timestamp of the last block
+   *
+   * @note expired Authorization Requests can be told apart with {@link api/entities/AuthorizationRequest!AuthorizationRequest.isExpired | isExpired}
    */
   public async getReceived(opts?: {
     type?: AuthorizationType;
@@ -76,6 +79,9 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
    * Retrieve a single Authorization Request targeting this Signer by its ID
    *
    * @throws if there is no Authorization Request with the passed ID targeting this Signer
+   *
+   * @note an expired Authorization Request is still returned — it exists on chain until it is
+   *   consumed or removed. Check {@link api/entities/AuthorizationRequest!AuthorizationRequest.isExpired | isExpired} before acting on it
    */
   public async getOne(args: { id: BigNumber }): Promise<AuthorizationRequest> {
     const {
@@ -107,6 +113,10 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
    * @hidden
    *
    * Create an array of AuthorizationRequests from an array of on-chain Authorizations
+   *
+   * @note expired Authorizations are **not** filtered out here. Filtering made `getReceived`'s
+   *   `includeExpired` inert (the chain already applies it), turned an expired `getOne` into an
+   *   `undefined` behind a non-null assertion, and made `getSent` return short pages with a live cursor
    */
   protected createAuthorizationRequests(
     auths: { auth: PolymeshPrimitivesAuthorization; target: SignerValue }[]
@@ -130,7 +140,6 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
           issuer: new Identity({ did: identityIdToString(issuer) }, context),
         };
       })
-      .filter(({ expiry }) => expiry === null || expiry > new Date())
       .map(args => {
         return new AuthorizationRequest(args, context);
       });

--- a/src/api/entities/common/namespaces/__tests__/Authorizations.ts
+++ b/src/api/entities/common/namespaces/__tests__/Authorizations.ts
@@ -70,7 +70,7 @@ describe('Authorizations class', () => {
       );
     });
 
-    it('should retrieve all pending authorizations received by the Identity and filter out expired ones', async () => {
+    it('should retrieve all pending authorizations received by the Identity', async () => {
       const did = 'someDid';
       const filter = AuthorizationType.RotatePrimaryKey;
       const context = dsMockUtils.getContextInstance({ did });
@@ -152,6 +152,54 @@ describe('Authorizations class', () => {
       expect(JSON.stringify(result)).toBe(JSON.stringify(expectedAuthorizations));
     });
 
+    it('should leave the expiry filter to the chain and return what it sends back', async () => {
+      const did = 'someDid';
+      const context = dsMockUtils.getContextInstance({ did });
+      const identity = entityMockUtils.getIdentityInstance({ did });
+      const authsNamespace = new Authorizations(identity, context);
+
+      const rawSignatory = dsMockUtils.createMockSignatory();
+      const rawTrue = dsMockUtils.createMockBool(true);
+      const rawFalse = dsMockUtils.createMockBool(false);
+
+      when(signerValueToSignatorySpy).mockReturnValue(rawSignatory);
+      when(booleanToBoolSpy).calledWith(true, context).mockReturnValue(rawTrue);
+      when(booleanToBoolSpy).calledWith(false, context).mockReturnValue(rawFalse);
+
+      const expiredAuth = dsMockUtils.createMockAuthorization({
+        authId: dsMockUtils.createMockU64(new BigNumber(1)),
+        expiry: dsMockUtils.createMockOption(
+          dsMockUtils.createMockMoment(new BigNumber(new Date('10/14/1987').getTime()))
+        ),
+        authorizationData: dsMockUtils.createMockAuthorizationData({
+          TransferAssetOwnership: dsMockUtils.createMockAssetId(
+            '0x12341234123412341234123412341234'
+          ),
+        }),
+        authorizedBy: dsMockUtils.createMockIdentityId('alice'),
+      });
+
+      const callMock = dsMockUtils.createCallMock('identityApi', 'getFilteredAuthorizations');
+
+      /*
+       * `getFilteredAuthorizations` applies the expiry filter itself, so an expired request coming
+       * back means the chain meant to send it. It must not be dropped a second time client-side
+       */
+      callMock.mockResolvedValue([expiredAuth]);
+
+      const withExpired = await authsNamespace.getReceived();
+
+      expect(callMock).toHaveBeenLastCalledWith(rawSignatory, rawTrue, null);
+      expect(withExpired).toHaveLength(1);
+
+      callMock.mockResolvedValue([]);
+
+      const withoutExpired = await authsNamespace.getReceived({ includeExpired: false });
+
+      expect(callMock).toHaveBeenLastCalledWith(rawSignatory, rawFalse, null);
+      expect(withoutExpired).toEqual([]);
+    });
+
     it('should fetch authorizations of the OldAddRelayerPayingKey type', async () => {
       const did = 'someDid';
       const context = dsMockUtils.getContextInstance({ did });
@@ -227,6 +275,40 @@ describe('Authorizations class', () => {
       });
       expect((result.target as Identity).did).toEqual(did);
       expect(result.issuer.did).toEqual(issuerDid);
+    });
+
+    it('should return an expired Authorization Request, rather than undefined', async () => {
+      const did = 'someDid';
+      const context = dsMockUtils.getContextInstance({ did });
+      const identity = entityMockUtils.getIdentityInstance({ did });
+      const authsNamespace = new Authorizations(identity, context);
+
+      const expiry = new Date('10/14/1987');
+
+      entityMockUtils.configureMocks({ authorizationRequestOptions: { isExpired: true } });
+
+      dsMockUtils.createQueryMock('identity', 'authorizations', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockAuthorization({
+            authId: dsMockUtils.createMockU64(new BigNumber(1)),
+            authorizationData: dsMockUtils.createMockAuthorizationData({
+              TransferAssetOwnership: dsMockUtils.createMockAssetId(
+                '0x12341234123412341234123412341234'
+              ),
+            }),
+            expiry: dsMockUtils.createMockOption(
+              dsMockUtils.createMockMoment(new BigNumber(expiry.getTime()))
+            ),
+            authorizedBy: dsMockUtils.createMockIdentityId('alice'),
+          })
+        ),
+      });
+
+      const result = await authsNamespace.getOne({ id: new BigNumber(1) });
+
+      expect(result.authId).toEqual(new BigNumber(1));
+      expect(result.expiry).toEqual(expiry);
+      expect(result.isExpired()).toBe(true);
     });
 
     it('should throw an error if the Authorization Request does not exist', () => {

--- a/src/api/procedures/__tests__/setCustodian.ts
+++ b/src/api/procedures/__tests__/setCustodian.ts
@@ -17,6 +17,7 @@ import {
   RoleType,
   SignerType,
   SignerValue,
+  SimplePermissions,
   TxTags,
 } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
@@ -198,14 +199,16 @@ describe('setCustodian procedure', () => {
       const boundFunc = getAuthorization.bind(proc);
       const id = new BigNumber(1);
       const did = 'someDid';
-      let args = {
+      const args = {
         id,
         did,
       } as Params;
 
-      let portfolioId = { did: args.did, number: args.id } as PortfolioId;
+      const portfolioId = { did: args.did, number: args.id } as PortfolioId;
 
-      expect(boundFunc(args)).toEqual({
+      const result = boundFunc(args);
+
+      expect(result).toEqual({
         roles: [{ type: RoleType.PortfolioCustodian, portfolioId }],
         permissions: {
           transactions: [TxTags.identity.AddAuthorization],
@@ -214,20 +217,11 @@ describe('setCustodian procedure', () => {
         },
       });
 
-      args = {
-        did,
-      } as Params;
-
-      portfolioId = { did: args.did, number: new BigNumber(0) };
-
-      expect(boundFunc(args)).toEqual({
-        roles: [{ type: RoleType.PortfolioCustodian, portfolioId }],
-        permissions: {
-          transactions: [TxTags.identity.AddAuthorization],
-          portfolios: [expect.objectContaining({ owner: expect.objectContaining({ did }) })],
-          assets: [],
-        },
-      });
+      /*
+       * a numbered Portfolio is the only kind the chain lets have a custodian, so the resolved
+       * Portfolio must carry the id it was given rather than falling back to Portfolio 0
+       */
+      expect((result.permissions as SimplePermissions).portfolios?.[0]).toHaveProperty('id', id);
     });
   });
 });

--- a/src/api/procedures/acceptPrimaryKeyRotation.ts
+++ b/src/api/procedures/acceptPrimaryKeyRotation.ts
@@ -73,7 +73,7 @@ export async function prepareStorage(
   const getAuthRequest = (
     auth: BigNumber | AuthorizationRequest
   ): Promise<AuthorizationRequest> => {
-    if (auth && auth instanceof BigNumber) {
+    if (auth && BigNumber.isBigNumber(auth)) {
       return actingAccount.authorizations.getOne({ id: auth });
     }
     return Promise.resolve(auth);

--- a/src/api/procedures/configureDividendDistribution.ts
+++ b/src/api/procedures/configureDividendDistribution.ts
@@ -193,7 +193,7 @@ export async function prepareConfigureDividendDistribution(
   const rawPortfolioNumber =
     originPortfolio &&
     optionize(bigNumberToU64)(
-      originPortfolio instanceof BigNumber ? originPortfolio : originPortfolio.id,
+      BigNumber.isBigNumber(originPortfolio) ? originPortfolio : originPortfolio.id,
       context
     );
   const rawCurrency = assetToMeshAssetId(currencyAsset, context);
@@ -264,7 +264,7 @@ export async function prepareStorage(
 
   let portfolio = originPortfolio || new DefaultPortfolio({ did }, context);
 
-  if (portfolio instanceof BigNumber) {
+  if (BigNumber.isBigNumber(portfolio)) {
     portfolio = new NumberedPortfolio({ id: portfolio, did }, context);
   }
 

--- a/src/api/procedures/modifyAsset.ts
+++ b/src/api/procedures/modifyAsset.ts
@@ -171,7 +171,7 @@ function getTxForAssetTypeChange(
   /* eslint-enable max-params */
   if (
     (typeof newType === 'string' && newType === assetType) ||
-    (newType instanceof BigNumber && newType.eq(assetType))
+    (BigNumber.isBigNumber(newType) && newType.eq(assetType))
   ) {
     throw new PolymeshError({
       code: ErrorCode.NoDataChange,

--- a/src/api/procedures/moveFunds.ts
+++ b/src/api/procedures/moveFunds.ts
@@ -114,7 +114,7 @@ export async function prepareMoveFunds(
   let toPortfolio;
   if (!to) {
     toPortfolio = new DefaultPortfolio({ did: fromDid }, context);
-  } else if (to instanceof BigNumber) {
+  } else if (BigNumber.isBigNumber(to)) {
     toPortfolio = new NumberedPortfolio({ did: fromDid, id: to }, context);
   } else {
     toPortfolio = to;
@@ -240,7 +240,7 @@ export function getAuthorization(
   let toPortfolio;
   if (!to) {
     toPortfolio = new DefaultPortfolio({ did }, context);
-  } else if (to instanceof BigNumber) {
+  } else if (BigNumber.isBigNumber(to)) {
     toPortfolio = new NumberedPortfolio({ did, id: to }, context);
   } else {
     toPortfolio = to;

--- a/src/api/procedures/redeemNft.ts
+++ b/src/api/procedures/redeemNft.ts
@@ -118,7 +118,7 @@ export async function prepareStorage(
     fromAssetHolder = asAccount(fromAccount, context);
   } else if (!from) {
     fromAssetHolder = new DefaultPortfolio({ did }, context);
-  } else if (from instanceof BigNumber) {
+  } else if (BigNumber.isBigNumber(from)) {
     fromAssetHolder = new NumberedPortfolio({ did, id: from }, context);
   } else {
     fromAssetHolder = from;

--- a/src/api/procedures/redeemTokens.ts
+++ b/src/api/procedures/redeemTokens.ts
@@ -113,7 +113,7 @@ export async function prepareStorage(
     fromAssetHolder = asAccount(fromAccount, context);
   } else if (!from) {
     fromAssetHolder = new DefaultPortfolio({ did }, context);
-  } else if (from instanceof BigNumber) {
+  } else if (BigNumber.isBigNumber(from)) {
     fromAssetHolder = new NumberedPortfolio({ did, id: from }, context);
   } else {
     fromAssetHolder = from;

--- a/src/api/procedures/removeAssetRequirement.ts
+++ b/src/api/procedures/removeAssetRequirement.ts
@@ -31,7 +31,7 @@ export async function prepareRemoveAssetRequirement(
 
   const rawAssetId = assetToMeshAssetId(asset, context);
 
-  const reqId = requirement instanceof BigNumber ? requirement : requirement.id;
+  const reqId = BigNumber.isBigNumber(requirement) ? requirement : requirement.id;
 
   const { requirements } = await query.complianceManager.assetCompliances(rawAssetId);
 

--- a/src/api/procedures/removeCheckpointSchedule.ts
+++ b/src/api/procedures/removeCheckpointSchedule.ts
@@ -27,7 +27,7 @@ export async function prepareRemoveCheckpointSchedule(
   } = this;
   const { asset, schedule } = args;
 
-  const scheduleId = schedule instanceof BigNumber ? schedule : schedule.id;
+  const scheduleId = BigNumber.isBigNumber(schedule) ? schedule : schedule.id;
   const rawAssetId = assetToMeshAssetId(asset, context);
 
   const rawScheduleId = bigNumberToU64(scheduleId, context);

--- a/src/api/procedures/removeCorporateAction.ts
+++ b/src/api/procedures/removeCorporateAction.ts
@@ -41,14 +41,14 @@ const assertCaIsRemovable = async (
   const distribution = await query.capitalDistribution.distributions(rawCaId);
   const exists = distribution.isSome;
 
-  if (!exists && !(corporateAction instanceof BigNumber)) {
+  if (!exists && !BigNumber.isBigNumber(corporateAction)) {
     throw new PolymeshError({
       code: ErrorCode.DataUnavailable,
       message: "The Distribution doesn't exist",
     });
   }
 
-  if (corporateAction instanceof BigNumber) {
+  if (BigNumber.isBigNumber(corporateAction)) {
     const CA = await query.corporateAction.corporateActions(
       assetToMeshAssetId(asset, context),
       bigNumberToU32(corporateAction, context)
@@ -91,7 +91,7 @@ export async function prepareRemoveCorporateAction(
     corporateAction instanceof CorporateActionBase ? corporateAction.id : corporateAction;
   const rawCaId = corporateActionIdentifierToCaId({ asset, localId }, context);
 
-  if (corporateAction instanceof DividendDistribution || corporateAction instanceof BigNumber) {
+  if (corporateAction instanceof DividendDistribution || BigNumber.isBigNumber(corporateAction)) {
     await assertCaIsRemovable(rawCaId, query, asset, context, corporateAction);
   } else {
     const exists = await corporateAction.exists();

--- a/src/api/procedures/setCustodian.ts
+++ b/src/api/procedures/setCustodian.ts
@@ -23,8 +23,12 @@ import { assertNoPendingAuthorizationExists, optionize } from '~/utils/internal'
 
 /**
  * @hidden
+ *
+ * @note `id` is required: the chain's `accept_portfolio_custody` rejects a default Portfolio with
+ *   `DefaultPortfoliosCannotHaveCustodians`, and `add_authorization` does not check, so allowing
+ *   one here would only produce an Authorization Request that can never be accepted
  */
-export type Params = { did: string; id?: BigNumber | undefined } & SetCustodianParams;
+export type Params = { did: string; id: BigNumber } & SetCustodianParams;
 
 /**
  * @hidden
@@ -96,12 +100,13 @@ export function getAuthorization(
   { did, id }: Params
 ): ProcedureAuthorization {
   const { context } = this;
-  const portfolioId: PortfolioId = { did, number: id ?? new BigNumber(0) };
+
+  const portfolioId: PortfolioId = { did, number: id };
   return {
     roles: [{ type: RoleType.PortfolioCustodian, portfolioId }],
     permissions: {
       transactions: [TxTags.identity.AddAuthorization],
-      portfolios: [portfolioIdToPortfolio({ did, number: id ?? new BigNumber(0) }, context)],
+      portfolios: [portfolioIdToPortfolio(portfolioId, context)],
       assets: [],
     },
   };

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -36,7 +36,7 @@ import {
 import { claimsQuery } from '~/middleware/queries/claims';
 import { heartbeatQuery, metadataQuery } from '~/middleware/queries/common';
 import { polyxTransactionsQuery } from '~/middleware/queries/polyxTransactions';
-import { Query } from '~/middleware/types';
+import { PolyxTransactionsOrderBy, Query } from '~/middleware/types';
 import {
   AccountBalance,
   ClaimData,
@@ -1440,12 +1440,14 @@ export class Context {
     accounts?: (string | Account)[];
     size?: BigNumber;
     start?: BigNumber;
+    orderBy?: PolyxTransactionsOrderBy;
   }): Promise<ResultSet<HistoricPolyxTransaction>> {
     const {
       identity,
       accounts,
       size = new BigNumber(DEFAULT_GQL_PAGE_SIZE),
       start = new BigNumber(0),
+      orderBy,
     } = args;
 
     const {
@@ -1459,7 +1461,8 @@ export class Context {
           addresses: accounts?.map(account => signerToString(account)),
         },
         size,
-        start
+        start,
+        orderBy
       )
     );
 

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -18,6 +18,7 @@ import {
   ClaimTypeEnum,
   EventIdEnum,
   ModuleIdEnum,
+  PolyxTransactionsOrderBy,
 } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
 import { createMockAccountId, getAtMock } from '~/testUtils/mocks/dataSources';
@@ -2596,6 +2597,32 @@ describe('Context class', () => {
       expect(result.data).toEqual([]);
       expect(result.count).toEqual(new BigNumber(0));
       expect(result.next).toBeNull();
+    });
+
+    it('should pass a requested ordering through to the query', async () => {
+      const context = await Context.create({
+        polymeshApi: dsMockUtils.getApiInstance(),
+        middlewareApiV2: dsMockUtils.getMiddlewareApi(),
+        signingManager: dsMockUtils.getSigningManagerInstance(),
+      });
+
+      dsMockUtils.createApolloQueryMock(
+        polyxTransactionsQuery(
+          {},
+          new BigNumber(25),
+          new BigNumber(0),
+          PolyxTransactionsOrderBy.CreatedBlockIdAsc
+        ),
+        {
+          polyxTransactions: { nodes: [], totalCount: 0 },
+        }
+      );
+
+      const result = await context.getPolyxTransactions({
+        orderBy: PolyxTransactionsOrderBy.CreatedBlockIdAsc,
+      });
+
+      expect(result.data).toEqual([]);
     });
   });
 

--- a/src/middleware/__tests__/queries/polyxTransactions.ts
+++ b/src/middleware/__tests__/queries/polyxTransactions.ts
@@ -1,6 +1,8 @@
 import BigNumber from 'bignumber.js';
+import { print } from 'graphql';
 
 import { polyxTransactionsQuery } from '~/middleware/queries/polyxTransactions';
+import { PolyxTransactionsOrderBy } from '~/middleware/types';
 import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 
 describe('polyxTransactionsQuery', () => {
@@ -24,5 +26,28 @@ describe('polyxTransactionsQuery', () => {
       size: 10,
       start: 2,
     });
+  });
+
+  it('should default to newest first, ordered by the id that encodes block and event index', () => {
+    const { query } = polyxTransactionsQuery({});
+
+    expect(print(query)).toContain('orderBy: [ID_DESC]');
+  });
+
+  it('should pass a requested ordering straight through', () => {
+    const { query } = polyxTransactionsQuery(
+      {},
+      undefined,
+      undefined,
+      PolyxTransactionsOrderBy.CreatedBlockIdAsc
+    );
+
+    expect(print(query)).toContain('orderBy: [CREATED_BLOCK_ID_ASC]');
+  });
+
+  it('should request totalCount, which the ResultSet count is built from', () => {
+    const { query } = polyxTransactionsQuery({});
+
+    expect(print(query)).toContain('totalCount');
   });
 });

--- a/src/middleware/queries/polyxTransactions.ts
+++ b/src/middleware/queries/polyxTransactions.ts
@@ -56,11 +56,16 @@ function createPolyxTransactionFilters({ identityId, addresses }: QueryPolyxTran
 export function polyxTransactionsQuery(
   filters: QueryPolyxTransactionFilters,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  /*
+   * `id` is the indexer's `<block number>/<event index>`, both zero padded, so it is unique and
+   * ordering it as a string orders by block and then by position within the block. Ordering by
+   * `createdBlockId` alone leaves transactions in the same block in no defined order, which makes
+   * pages repeat or skip entries
+   */
+  orderBy: PolyxTransactionsOrderBy = PolyxTransactionsOrderBy.IdDesc
 ): QueryOptions<PaginatedQueryArgs<QueryPolyxTransactionFilters>> {
   const { args, filter, variables } = createPolyxTransactionFilters(filters);
-
-  const orderBy = `${PolyxTransactionsOrderBy.CreatedBlockIdAsc}`;
 
   const query = gql`
     query PolyxTransactionsQuery
@@ -72,6 +77,7 @@ export function polyxTransactionsQuery(
         offset: $start
         orderBy: [${orderBy}]
       ) {
+        totalCount
         nodes {
           id
           identityId

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -2103,7 +2103,7 @@ export const createMockBtreeSet = <T extends Codec>(
       return createMockStringCodec(item);
     }
 
-    if (typeof item === 'number' || item instanceof BigNumber) {
+    if (typeof item === 'number' || BigNumber.isBigNumber(item)) {
       return createMockNumberCodec(new BigNumber(item));
     }
 
@@ -2153,7 +2153,7 @@ export const createMockVec = <T extends Codec>(
       return createMockStringCodec(item);
     }
 
-    if (typeof item === 'number' || item instanceof BigNumber) {
+    if (typeof item === 'number' || BigNumber.isBigNumber(item)) {
       return createMockNumberCodec(new BigNumber(item));
     }
 

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -1265,7 +1265,7 @@ export function toHumanReadable<T>(obj: T): HumanReadableType<T> {
     return obj.toHuman();
   }
 
-  if (obj instanceof BigNumber) {
+  if (BigNumber.isBigNumber(obj)) {
     return obj.toString() as HumanReadableType<T>;
   }
 
@@ -2043,7 +2043,7 @@ export function assembleAssetQuery(
  * @hidden
  */
 export function asNftId(nft: Nft | BigNumber): BigNumber {
-  if (nft instanceof BigNumber) {
+  if (BigNumber.isBigNumber(nft)) {
     return nft;
   } else {
     return nft.id;
@@ -2245,7 +2245,7 @@ export async function prepareStorageForCustomType(
 ): Promise<Storage['customTypeData']> {
   let customTypeData: Storage['customTypeData'];
 
-  if (customType instanceof BigNumber) {
+  if (BigNumber.isBigNumber(customType)) {
     const rawId = bigNumberToU32(customType, context);
     const rawValue = await context.polymeshApi.query.asset.customTypes(rawId);
 


### PR DESCRIPTION
### Description

Stacks on #1659 — review that one first; this branch is the seven commits after it.

Seven fixes, each self-contained and green on its own.

**`instanceof BigNumber` → `BigNumber.isBigNumber`** (G-SDK-16). Thirty call sites tested caller-supplied values with `instanceof`, which returns `false` when the value comes from a second copy of `bignumber.js` — a mixed CJS/ESM graph, or a transitive dependency on a different version. The reported `portfolios.delete({ portfolio: BigNumber })` failure was this; `redeemTokens`, `redeemNft`, `modifyAsset`, `moveFunds`, `removeCorporateAction`, `removeAssetRequirement`, `removeCheckpointSchedule`, `configureDividendDistribution` and `acceptPrimaryKeyRotation` had the same latent fault. A `no-restricted-syntax` rule keeps it fixed. Consumers no longer need a `resolutions` pin.

**Authorization expiry** (three defects found while validating, not in the register). `createAuthorizationRequests` filtered by expiry on behalf of three callers that each wanted something different. The chain's `get_filtered_authorizations` already applies `includeExpired`, so the second filter made that option inert, turned an expired `getOne` into an `undefined` behind a non-null assertion, and made `getSent` return short pages while still reporting a cursor — a page of 25 could come back with 6. The helper no longer filters.

**`setCustodian`** (G-SDK-15, reframed). `id` is now a required `BigNumber`, deleting an `id ?? new BigNumber(0)` default that would have resolved a default Portfolio to `NumberedPortfolio(0)` — and, because the permission comparator matches on `{ did }` with no `number` key, would have reported a granted permission as missing.

**Portfolio holdings reads** (defect found while validating). `getAssetBalances({ assets })` and `getCollections({ collections })` scanned every holding and filtered in memory — twice over, for balances. They now read only what was asked for.

**`Assets.get()`** (G-SDK-22, reframed) reads `asset.assets` directly instead of paging `asset.assetNames` and then `.multi()`-ing the details: one round trip instead of two.

**Optional middleware API key** (G-SDK-11). `MiddlewareConfig.key` is optional and the `x-api-key` header is omitted rather than sent empty.

**Ordering and paging of history** (G-SDK-13). `polyxTransactionsQuery` never selected `totalCount`, so `count` was `NaN`; `next` derives from it via `totalCount.gt(next)`, and a `NaN` comparison is always false — `getPolyxTransactions` **could not be paged past its first page**, silently. Ordering was a hardcoded `CreatedBlockIdAsc`, which leaves rows sharing a block in no defined order. Both history reads now order newest first by an id that is unique.

### Breaking Changes

Behaviour changes, all replacing silently wrong output with correct output. Each is called out in `changelogs/v31.0.0-next.md` under **Behaviour changes**.

- **`Account.getTransactionHistory()` now defaults to `ExtrinsicsOrderBy.IdDesc`** (newest first), not `IdAsc`. Pass `IdAsc` to keep ascending order.
- **`getPolyxTransactions()` now defaults to `PolyxTransactionsOrderBy.IdDesc`**, not `CreatedBlockIdAsc`. `IdAsc` is the stable equivalent of the old default.
- **`Authorizations.getReceived()` returns expired requests by default**, matching its documented `includeExpired: true`. Pass `includeExpired: false`, or filter with `isExpired()`.
- **`Authorizations.getOne()` returns an expired request** instead of `undefined` typed as an `AuthorizationRequest`.
- **`IdentityAuthorizations.getSent()` includes expired requests**, so pages are the size they claim to be.
- **`assets.get()` pages a different storage map**, so a `next` cursor persisted across this upgrade is not comparable — it is a storage key, and it now belongs to `asset.assets`.
- `MiddlewareConfig.key` optional and `setCustodian`'s `id` required are both source-compatible for existing callers.

### Follow-up

A full audit of the 13 middleware query files identified nine more queries that have the same ordering fault this PR fixes for POLYX history — three page with no `orderBy` at all — and only two of the fourteen paginated queries accept an ordering from the caller. Proposed as Phase 2b.

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [x] Updated the Readme.md (if required) ?
