### PR TITLE
ci: 🎡 treat added optional properties as non-breaking API changes

### DIFF
--- a/scripts/compareApiSnapshot.ts
+++ b/scripts/compareApiSnapshot.ts
@@ -42,6 +42,116 @@ function logBreak(message: string) {
   console.log('❌', message);
 }
 
+/**
+ * Split an object literal type's body on its top-level member separators, so that members
+ * holding a nested object, a function type or a generic stay in one piece
+ */
+function splitMembers(body: string): string[] {
+  const members: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (const char of body) {
+    if ('{(['.includes(char)) depth++;
+    else if ('})]'.includes(char)) depth--;
+
+    if (char === ';' && depth === 0) {
+      members.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  members.push(current);
+
+  return members.map(member => member.trim()).filter(member => member.length > 0);
+}
+
+type ObjectMember = { optional: boolean; type: string };
+
+const MEMBER_REGEX =
+  /^(?:readonly\s+)?([A-Za-z_$][\w$]*|'[^']*'|"[^"]*"|\[[^\]]*\])(\?)?\s*:\s*([\s\S]+)$/;
+
+/**
+ * Parse an object literal type's text into its members, or return `null` if the type is
+ * anything else — a named type, a union, an intersection — or holds a member we can't read
+ */
+function parseObjectType(type: string): Map<string, ObjectMember> | null {
+  const trimmed = type.trim();
+
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
+
+  // reject `{ a: string; } | { b: string; }`, where the leading brace closes before the end
+  let depth = 0;
+  for (let i = 0; i < trimmed.length; i++) {
+    if (trimmed[i] === '{') depth++;
+    else if (trimmed[i] === '}') depth--;
+    if (depth === 0 && i < trimmed.length - 1) return null;
+  }
+
+  const members = new Map<string, ObjectMember>();
+
+  for (const member of splitMembers(trimmed.slice(1, -1))) {
+    const match = MEMBER_REGEX.exec(member);
+
+    if (!match) return null;
+
+    const [, name, optional, memberType] = match;
+    members.set(name!, {
+      optional: !!optional,
+      // an optional member may or may not be printed with `| undefined`; ignore the difference
+      type: memberType!.trim().replace(/\s*\|\s*undefined$/, ''),
+    });
+  }
+
+  return members;
+}
+
+/**
+ * Compare two object literal parameter types, returning the ways the current one breaks
+ * callers of the base one — an empty array meaning it doesn't, and `null` meaning the types
+ * aren't both object literals so we can't tell.
+ *
+ * A parameter object can gain optional members without breaking anyone, which is the case
+ * this exists for. Losing a member, retyping one, making one required, or gaining a required
+ * one all break callers.
+ */
+function compareObjectTypes(baseType: string, currentType: string): string[] | null {
+  const baseMembers = parseObjectType(baseType);
+  const currentMembers = parseObjectType(currentType);
+
+  if (!baseMembers || !currentMembers) return null;
+
+  const breaks: string[] = [];
+
+  baseMembers.forEach((baseMember, name) => {
+    const currentMember = currentMembers.get(name);
+
+    if (!currentMember) {
+      breaks.push(`property '${name}' removed`);
+      return;
+    }
+
+    if (baseMember.optional && !currentMember.optional) {
+      breaks.push(`property '${name}' is now required`);
+    }
+
+    if (baseMember.type !== currentMember.type) {
+      breaks.push(
+        `property '${name}' changed type from '${baseMember.type}' to '${currentMember.type}'`
+      );
+    }
+  });
+
+  currentMembers.forEach((currentMember, name) => {
+    if (!baseMembers.has(name) && !currentMember.optional) {
+      breaks.push(`required property '${name}' added`);
+    }
+  });
+
+  return breaks;
+}
+
 function compareOverloads(
   baseOverloads: Overload[],
   currentOverloads: Overload[],
@@ -79,10 +189,21 @@ function compareOverloads(
       const bp = baseSig.parameters[j]!;
       const cp = currSig.parameters[j]!;
 
-      if (bp?.name !== cp?.name || bp?.type !== cp?.type || bp?.optional !== cp?.optional) {
-        logBreak(
-          `${filePath} > ${parentName}.${methodName}: Param ${j + 1} mismatch in overload #${i + 1}`
-        );
+      const location = `${filePath} > ${parentName}.${methodName}: Param ${j + 1}`;
+
+      if (bp?.name !== cp?.name || bp?.optional !== cp?.optional) {
+        logBreak(`${location} mismatch in overload #${i + 1}`);
+        continue;
+      }
+
+      if (bp?.type !== cp?.type) {
+        const objectBreaks = compareObjectTypes(bp!.type, cp!.type);
+
+        if (!objectBreaks) {
+          logBreak(`${location} mismatch in overload #${i + 1}`);
+        } else {
+          objectBreaks.forEach(reason => logBreak(`${location} in overload #${i + 1}: ${reason}`));
+        }
       }
     }
 


### PR DESCRIPTION
### Description

`scripts/compareApiSnapshot.ts` compares each parameter's type as a raw string, so
any edit to that text is reported as a breaking change. Methods that take an inline
object of filters can't gain an optional property without changing that string:

    base:    { size?: BigNumber; start?: BigNumber; }
    current: { size?: BigNumber; start?: BigNumber; orderBy?: PolyxTransactionsOrderBy; }

No caller of the old signature is affected by that, but the check fails:

    ❌ base/Context.d.ts > Context.getPolyxTransactions: Param 1 mismatch in overload #1
    ❌ api/entities/Account/index.d.ts > Account.getPolyxTransactions: Param 1 mismatch in overload #1

22a787109 covered added trailing optional *parameters*. This is an added optional
*property inside* a parameter's type, which was never handled.

## Fix

When a parameter's type text changes and both sides parse as object literals, compare
them member by member instead.

| change | verdict |
| --- | --- |
| optional property added | passes |
| required property added | ❌ `required property 'orderBy' added` |
| property removed | ❌ `property 'start' removed` |
| optional → required | ❌ `property 'size' is now required` |
| property retyped | ❌ `property 'size' changed type from 'BigNumber' to 'string'` |
| object literal → named type, or a union | ❌ falls back to the existing string comparison |

Failures now name the property rather than reporting `Param 1 mismatch`. Nested
objects, generics and function types are kept intact when splitting members, and an
optional member printed as `T | undefined` is treated as `T`.

## Verification

Reproduced locally by snapshotting a stale `dist` as the base and a rebuilt one as
current — the two failures above reproduce, and pass with this change. The rows in
the table above were each checked by patching the property's type in the snapshot
and re-running the comparison.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
