### PR TITLE
Ordering, filtering and paging for indexer-backed reads

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -226,6 +226,32 @@ const { data } = await account.getPolyxTransactions({
 
 It defaults to `IdDesc`, newest first — see the behaviour change below. The indexer's `id` is `<block number>/<event index>` with both parts zero-padded, so it is unique and sorts by block and then by position within the block. `CreatedBlockIdDesc` would have left transactions sharing a block in no defined order, which makes pages repeat or skip entries.
 
+### Choose the order of indexer-backed results
+
+Every paginated indexer query now accepts an `orderBy`, so a caller is no longer stuck with the SDK's default. The reads that expose it:
+
+| Method                                                                       | Ordering type                       |
+| ---------------------------------------------------------------------------- | ----------------------------------- |
+| `FungibleAsset.getTransactionHistory`, `NftCollection.getTransactionHistory` | `AssetTransactionsOrderBy`          |
+| `DividendDistribution.getPaymentHistory`                                     | `DistributionPaymentsOrderBy`       |
+| `MultiSig.getHistoricalProposals`                                            | `MultiSigProposalsOrderBy`          |
+| `AssetPermissions.getOperationHistory`                                       | `TickerExternalAgentActionsOrderBy` |
+| `Offering.getInvestments`                                                    | `InvestmentsOrderBy`                |
+| `Claims.getAllCustomClaimTypes`                                              | `CustomClaimTypesOrderBy`           |
+| `Authorizations.getHistoricalAuthorizations`                                 | `AuthorizationsOrderBy`             |
+| `Identity.getHistoricalInstructions`                                         | `InstructionsOrderBy`               |
+| `Network.getEventsByIndexedArgs`                                             | `EventsOrderBy`                     |
+
+```ts
+const { data } = await asset.getTransactionHistory({
+  orderBy: AssetTransactionsOrderBy.DatetimeDesc,
+});
+```
+
+Every default is unchanged, so omitting `orderBy` behaves exactly as before. Note that a supplied ordering **replaces** the default outright, including any tiebreaker it carried — if the field you order by is not unique, paging over it can repeat and skip rows.
+
+`Instruction.getAffirmations`, `getMediators` and `getLegs` are not in the list: they take the shared `MiddlewarePaginationOptions`, and extending that type is separate work.
+
 ### The middleware API key is optional
 
 `MiddlewareConfig.key` is now optional. Connecting to an indexer that requires no authentication previously meant passing `key: ''`, which sent an empty `x-api-key` header; the header is now omitted entirely when no key is given.

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -267,7 +267,17 @@ const { data } = await asset.getTransactionHistory({
 });
 ```
 
-Every default is unchanged, so omitting `orderBy` behaves exactly as before. Note that a supplied ordering **replaces** the default outright, including any tiebreaker it carried — if the field you order by is not unique, paging over it can repeat and skip rows.
+Pass several keys to decide the rows a single key leaves tied:
+
+```ts
+const { data } = await offering.getInvestments({
+  orderBy: [InvestmentsOrderBy.OfferingTokenAsc, InvestmentsOrderBy.DatetimeDesc],
+});
+```
+
+Every default is unchanged, so omitting `orderBy` behaves exactly as before. A supplied ordering comes **first**, and the key that makes the read's order unique is appended behind it, so paging cannot repeat or skip a row — order by `AmountAsc` and the query runs `[AMOUNT_ASC, ID_ASC]`. Where you order by that key yourself it is not appended again, so `IdDesc` stays `[ID_DESC]` and your direction is honoured.
+
+`Identity.getAssetHoldings` takes an ordering too. `getHeldNfts` and the deprecated `getHeldAssets` now take `orderBy` alongside the `order` they were published with, so that every read names it the same way; `order` still works and is deprecated, and passing both throws, since neither could be said to have been meant.
 
 `Instruction.getAffirmations`, `getMediators` and `getLegs` are not in the list: they take the shared `MiddlewarePaginationOptions`, and extending that type is separate work.
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, the units of the total staked amount, and a false "not included" rejection when claiming dividends.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, reading what an Identity holds now with the amount, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, the units of the total staked amount, and a false "not included" rejection when claiming dividends.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -225,6 +225,25 @@ const { data } = await account.getPolyxTransactions({
 ```
 
 It defaults to `IdDesc`, newest first — see the behaviour change below. The indexer's `id` is `<block number>/<event index>` with both parts zero-padded, so it is unique and sorts by block and then by position within the block. `CreatedBlockIdDesc` would have left transactions sharing a block in no defined order, which makes pages repeat or skip entries.
+
+### Read what an Identity holds now, with the amount
+
+`Identity.getAssetHoldings()` returns each fungible Asset the Identity holds **with the amount held**, and can exclude the ones it has transferred away in full:
+
+```ts
+const { data, count } = await identity.getAssetHoldings({ heldNow: true });
+
+data[0].asset; // FungibleAsset
+data[0].amount; // BigNumber, in POLYX-scale units
+```
+
+Each entry is a `FungibleAssetHolding` — named for the kind of Asset it carries, since `Asset` on its own means either a `FungibleAsset` or an `NftCollection`.
+
+The indexer keeps a holding record once it has existed, so an Asset held at any point stays in the result with an `amount` of `0`. `heldNow: true` applies the exclusion **inside the query**, which is what makes `count` and `next` describe the filtered set — filtering client-side would leave both describing the unfiltered one, so a caller paging through holdings would see short pages and a cursor that never ends.
+
+`Identity.getHeldNfts()` gains the same `heldNow` option, excluding collections the Identity no longer holds any NFT of. Its return type already carried the detail, so nothing about it changes.
+
+**`Identity.getHeldAssets()` is deprecated** in favour of `getAssetHoldings()` and will be removed in the next major. It returns `ResultSet<FungibleAsset>` with no amount and no way to exclude spent holdings; it is otherwise unchanged, so existing callers keep working.
 
 ### Choose the order of indexer-backed results
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -351,9 +351,19 @@ The helper no longer filters:
 
 Both now read only what was asked for: balances by direct key lookup, collections by prefixing the held map with each collection and checking locks only on the NFTs found. Omitting the argument is unchanged, and still unbounded.
 
-### POLYX transaction history reported a count of `NaN`
+### Indexer-backed reads could repeat and skip rows while paging
 
-`polyxTransactionsQuery` never selected `totalCount`, so the `count` on every `getPolyxTransactions` result was `NaN` and `next` was derived from it.
+Ten paginated indexer queries had no order that was both defined and unique. Three — behind `Claims.getCustomClaimTypes`, `DividendDistribution.getPaymentHistory` and `MultiSig.getProposals` — had **no `orderBy` at all**, so the database was free to return rows in any order, and `first`/`offset` paging over that can show one row twice and never show another. Seven more ordered by a block-level field only, which leaves rows sharing a block undefined relative to each other, with the same effect at every block boundary.
+
+Every paginated query now orders by something unique. Where the indexer's `id` is block-derived it is used directly — it is `<block number>/<event index>` with both parts zero-padded, so ordering it as a string orders by block and then by position within the block. Where an id is not block-derived it is used only to break ties, never as the primary sort: a custom claim type's id is the chain's numeric id, and a MultiSig proposal's embeds an unpadded proposal number, so proposals order by `proposalId` instead.
+
+Affected reads: `FungibleAsset`/`NftCollection.getTransactionHistory`, `Network.getEventByIndexedArgs`, `Network.getEventsByIndexedArgs`, `Account.getTransactionHistory`, `AssetPermissions.getOperationHistory`, `Instruction.getAffirmations`, `Instruction.getMediators`, `Identity.getHistoricalInstructions`, `Offering.getInvestments`, `Claims.getCustomClaimTypes`, `DividendDistribution.getPaymentHistory` and `MultiSig.getProposals`.
+
+Sort direction is unchanged everywhere one was already defined, so only the relative order of rows that were previously tied changes. The three queries that had no ordering now have one: custom claim types and distribution payments oldest first, MultiSig proposals newest first.
+
+### POLYX transaction history could not be paged past the first page
+
+`polyxTransactionsQuery` never selected `totalCount`, so the `count` on every `getPolyxTransactions` result was `NaN`. `next` is derived from it by `totalCount.gt(next) ? next : null`, and a `NaN` comparison is always false — so `next` was always `null` and a caller paging through history stopped after the first page, with no error to say why.
 
 ### Report the actual reason an on-chain transaction failed
 

--- a/scripts/compareApiSnapshot.ts
+++ b/scripts/compareApiSnapshot.ts
@@ -67,6 +67,49 @@ function splitMembers(body: string): string[] {
   return members.map(member => member.trim()).filter(member => member.length > 0);
 }
 
+/**
+ * Split a type's text on its top-level union bars, so that a bar inside an object, a generic or a
+ * parameter list stays where it is
+ */
+function splitTopLevelUnion(text: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!;
+
+    if ('{([<'.includes(char)) depth++;
+    // the `>` of an arrow closes nothing
+    else if (')]}'.includes(char) || (char === '>' && text[i - 1] !== '=')) depth--;
+
+    if (char === '|' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  parts.push(current);
+
+  return parts.map(part => part.trim()).filter(part => part.length > 0);
+}
+
+/**
+ * Whether a parameter's type only got wider — everything it used to accept, it still accepts.
+ *
+ * A caller passes a parameter in, so taking more than before cannot break a call already written:
+ * `orderBy?: X` becoming `orderBy?: X | X[]` is not a change a caller has to make. This holds for a
+ * parameter only. A *return* type that gains a member breaks the caller reading it, which is why
+ * return types are compared as plain text
+ */
+function isWidenedParameterType(baseType: string, currentType: string): boolean {
+  const accepted = new Set(splitTopLevelUnion(currentType));
+
+  return splitTopLevelUnion(baseType).every(member => accepted.has(member));
+}
+
 type ObjectMember = { optional: boolean; type: string };
 
 const MEMBER_REGEX =
@@ -137,7 +180,10 @@ function compareObjectTypes(baseType: string, currentType: string): string[] | n
       breaks.push(`property '${name}' is now required`);
     }
 
-    if (baseMember.type !== currentMember.type) {
+    if (
+      baseMember.type !== currentMember.type &&
+      !isWidenedParameterType(baseMember.type, currentMember.type)
+    ) {
       breaks.push(
         `property '${name}' changed type from '${baseMember.type}' to '${currentMember.type}'`
       );
@@ -201,7 +247,7 @@ function compareOverloads(
         continue;
       }
 
-      if (bp?.type !== cp?.type) {
+      if (bp?.type !== cp?.type && !isWidenedParameterType(bp!.type, cp!.type)) {
         const objectBreaks = compareObjectTypes(bp!.type, cp!.type);
 
         if (!objectBreaks) {

--- a/src/api/client/Claims.ts
+++ b/src/api/client/Claims.ts
@@ -13,7 +13,7 @@ import {
   claimsQuery,
   customClaimTypeQuery,
 } from '~/middleware/queries/claims';
-import { ClaimsOrderBy, Query } from '~/middleware/types';
+import { ClaimsOrderBy, CustomClaimTypesOrderBy, Query } from '~/middleware/types';
 import {
   ClaimData,
   ClaimOperation,
@@ -566,6 +566,7 @@ export class Claims {
       size?: BigNumber;
       start?: BigNumber;
       dids?: string[];
+      orderBy?: CustomClaimTypesOrderBy;
     } = {}
   ): Promise<ResultSet<CustomClaimTypeWithDid>> {
     const { context } = this;
@@ -579,14 +580,19 @@ export class Claims {
       });
     }
 
-    const { size = new BigNumber(DEFAULT_GQL_PAGE_SIZE), start = new BigNumber(0), dids } = opts;
+    const {
+      size = new BigNumber(DEFAULT_GQL_PAGE_SIZE),
+      start = new BigNumber(0),
+      dids,
+      orderBy,
+    } = opts;
 
     const {
       data: {
         customClaimTypes: { nodes, totalCount },
       },
     } = await context.queryMiddleware<Ensured<Query, 'customClaimTypes'>>(
-      customClaimTypeQuery(size, start, dids)
+      customClaimTypeQuery(size, start, dids, orderBy)
     );
 
     const count = new BigNumber(totalCount);

--- a/src/api/client/Claims.ts
+++ b/src/api/client/Claims.ts
@@ -557,6 +557,9 @@ export class Claims {
    * Retrieve registered CustomClaimTypes
    *
    * @param opts.dids - Fetch CustomClaimTypes issued by the given `dids`
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
    *
    * @note supports pagination
    * @note uses the middlewareV2 (Required)
@@ -566,7 +569,7 @@ export class Claims {
       size?: BigNumber;
       start?: BigNumber;
       dids?: string[];
-      orderBy?: CustomClaimTypesOrderBy;
+      orderBy?: CustomClaimTypesOrderBy | CustomClaimTypesOrderBy[];
     } = {}
   ): Promise<ResultSet<CustomClaimTypeWithDid>> {
     const { context } = this;

--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -15,7 +15,7 @@ import {
 import { Account, Context, PolymeshError, transferPolyx } from '~/internal';
 import { eventsByArgs } from '~/middleware/queries/events';
 import { extrinsicByHash } from '~/middleware/queries/extrinsics';
-import { EventIdEnum, ModuleIdEnum, Query } from '~/middleware/types';
+import { EventIdEnum, EventsOrderBy, ModuleIdEnum, Query } from '~/middleware/types';
 import {
   ErrorCode,
   EventIdentifier,
@@ -599,10 +599,11 @@ export class Network {
     eventArg2?: string;
     size?: BigNumber;
     start?: BigNumber;
+    orderBy?: EventsOrderBy;
   }): Promise<EventIdentifier[] | null> {
     const { context } = this;
 
-    const { moduleId, eventId, eventArg0, eventArg1, eventArg2, size, start } = opts;
+    const { moduleId, eventId, eventArg0, eventArg1, eventArg2, size, start, orderBy } = opts;
 
     const {
       data: {
@@ -618,7 +619,8 @@ export class Network {
           eventArg2,
         },
         size,
-        start
+        start,
+        orderBy
       )
     );
 

--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -588,6 +588,9 @@ export class Network {
    * @param opts.eventArg2 - event parameter value to filter by in position 2
    * @param opts.size - page size
    * @param opts.start - page offset
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
    *
    * @note uses the middlewareV2
    */
@@ -599,7 +602,7 @@ export class Network {
     eventArg2?: string;
     size?: BigNumber;
     start?: BigNumber;
-    orderBy?: EventsOrderBy;
+    orderBy?: EventsOrderBy | EventsOrderBy[];
   }): Promise<EventIdentifier[] | null> {
     const { context } = this;
 

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -284,7 +284,7 @@ export interface HistoricalInstructionFilters {
   /**
    * The ordering of the results. Defaults to oldest first
    */
-  orderBy?: InstructionsOrderBy;
+  orderBy?: InstructionsOrderBy | InstructionsOrderBy[];
 }
 
 /**

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -2,6 +2,7 @@ import { ApiOptions } from '@polkadot/api/types';
 import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
+import { InstructionsOrderBy } from '~/middleware/types';
 import { Account, Asset, Identity, InstructionStatusEnum, TxTag } from '~/types';
 
 export { InstructionStatusEnum };
@@ -280,6 +281,10 @@ export interface HistoricalInstructionFilters {
    * The number of results to skip
    */
   start?: BigNumber;
+  /**
+   * The ordering of the results. Defaults to oldest first
+   */
+  orderBy?: InstructionsOrderBy;
 }
 
 /**

--- a/src/api/entities/Account/MultiSig/index.ts
+++ b/src/api/entities/Account/MultiSig/index.ts
@@ -198,13 +198,17 @@ export class MultiSig extends Account {
 
   /**
    * Return a set of {@link MultiSigProposal} for this MultiSig Account
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
+   *
    *
    * @note uses the middlewareV2
    */
   public async getHistoricalProposals(opts?: {
     size?: BigNumber;
     start?: BigNumber;
-    orderBy?: MultiSigProposalsOrderBy;
+    orderBy?: MultiSigProposalsOrderBy | MultiSigProposalsOrderBy[];
   }): Promise<ResultSet<HistoricalMultiSigProposal>> {
     const { context, address } = this;
     const { size, start, orderBy } = opts ?? {};

--- a/src/api/entities/Account/MultiSig/index.ts
+++ b/src/api/entities/Account/MultiSig/index.ts
@@ -14,7 +14,13 @@ import {
   removeMultiSigPayer,
 } from '~/internal';
 import { multiSigProposalsQuery } from '~/middleware/queries/multisigs';
-import { CallIdEnum, ModuleIdEnum, Query, Scalars } from '~/middleware/types';
+import {
+  CallIdEnum,
+  ModuleIdEnum,
+  MultiSigProposalsOrderBy,
+  Query,
+  Scalars,
+} from '~/middleware/types';
 import { MultiSigProposalStatusEnum } from '~/middleware/typesV1';
 import {
   AnyJson,
@@ -198,16 +204,17 @@ export class MultiSig extends Account {
   public async getHistoricalProposals(opts?: {
     size?: BigNumber;
     start?: BigNumber;
+    orderBy?: MultiSigProposalsOrderBy;
   }): Promise<ResultSet<HistoricalMultiSigProposal>> {
     const { context, address } = this;
-    const { size, start } = opts ?? {};
+    const { size, start, orderBy } = opts ?? {};
 
     const {
       data: {
         multiSigProposals: { nodes, totalCount },
       },
     } = await context.queryMiddleware<Ensured<Query, 'multiSigProposals'>>(
-      multiSigProposalsQuery(address, size, start)
+      multiSigProposalsQuery(address, size, start, orderBy)
     );
 
     const getTxTagAndArgs = (

--- a/src/api/entities/Account/MultiSig/index.ts
+++ b/src/api/entities/Account/MultiSig/index.ts
@@ -214,7 +214,7 @@ export class MultiSig extends Account {
         multiSigProposals: { nodes, totalCount },
       },
     } = await context.queryMiddleware<Ensured<Query, 'multiSigProposals'>>(
-      multiSigProposalsQuery(address, size, start, orderBy)
+      multiSigProposalsQuery({ multisigId: address }, size, start, orderBy)
     );
 
     const getTxTagAndArgs = (

--- a/src/api/entities/Account/__tests__/MultiSig.ts
+++ b/src/api/entities/Account/__tests__/MultiSig.ts
@@ -267,7 +267,7 @@ describe('MultiSig class', () => {
       };
 
       dsMockUtils.createApolloQueryMock(
-        multiSigProposalsQuery(address, new BigNumber(1), new BigNumber(0)),
+        multiSigProposalsQuery({ multisigId: address }, new BigNumber(1), new BigNumber(0)),
         {
           multiSigProposals: multiSigProposalsResponse,
         }
@@ -332,7 +332,7 @@ describe('MultiSig class', () => {
         nodes: [mockHistoricalMultisig],
       };
 
-      dsMockUtils.createApolloQueryMock(multiSigProposalsQuery(address), {
+      dsMockUtils.createApolloQueryMock(multiSigProposalsQuery({ multisigId: address }), {
         multiSigProposals: multiSigProposalsResponse,
       });
 

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -315,7 +315,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       success?: boolean;
       size?: BigNumber;
       start?: BigNumber;
-      orderBy?: ExtrinsicsOrderBy;
+      orderBy?: ExtrinsicsOrderBy | ExtrinsicsOrderBy[];
     } = {}
   ): Promise<ResultSet<ExtrinsicData>> {
     const { tag, success, size, start, orderBy = ExtrinsicsOrderBy.IdDesc, blockHash } = filters;
@@ -681,7 +681,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
   public getPolyxTransactions(filters: {
     size?: BigNumber;
     start?: BigNumber;
-    orderBy?: PolyxTransactionsOrderBy;
+    orderBy?: PolyxTransactionsOrderBy | PolyxTransactionsOrderBy[];
   }): Promise<ResultSet<HistoricPolyxTransaction>> {
     const { context } = this;
 

--- a/src/api/entities/Asset/Fungible/index.ts
+++ b/src/api/entities/Asset/Fungible/index.ts
@@ -187,13 +187,17 @@ export class FungibleAsset extends BaseAsset {
 
   /**
    * Retrieve this Asset's transaction History
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
+   *
    *
    * @note uses the middlewareV2
    */
   public async getTransactionHistory(opts: {
     size?: BigNumber;
     start?: BigNumber;
-    orderBy?: AssetTransactionsOrderBy;
+    orderBy?: AssetTransactionsOrderBy | AssetTransactionsOrderBy[];
   }): Promise<ResultSet<HistoricAssetTransaction>> {
     const { context, id } = this;
     const { size, start, orderBy } = opts;

--- a/src/api/entities/Asset/Fungible/index.ts
+++ b/src/api/entities/Asset/Fungible/index.ts
@@ -20,7 +20,7 @@ import {
 } from '~/internal';
 import { assetQuery, assetTransactionQuery } from '~/middleware/queries/assets';
 import { tickerExternalAgentHistoryQuery } from '~/middleware/queries/externalAgents';
-import { Query } from '~/middleware/types';
+import { AssetTransactionsOrderBy, Query } from '~/middleware/types';
 import {
   ApproveAllowanceParams,
   ControllerTransferParams,
@@ -193,9 +193,10 @@ export class FungibleAsset extends BaseAsset {
   public async getTransactionHistory(opts: {
     size?: BigNumber;
     start?: BigNumber;
+    orderBy?: AssetTransactionsOrderBy;
   }): Promise<ResultSet<HistoricAssetTransaction>> {
     const { context, id } = this;
-    const { size, start } = opts;
+    const { size, start, orderBy } = opts;
 
     const middlewareAssetId = await getAssetIdForMiddleware(id, context);
 
@@ -209,7 +210,8 @@ export class FungibleAsset extends BaseAsset {
           assetId: middlewareAssetId,
         },
         size,
-        start
+        start,
+        orderBy
       )
     );
 

--- a/src/api/entities/Asset/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/NonFungible/NftCollection.ts
@@ -354,13 +354,17 @@ export class NftCollection extends BaseAsset {
 
   /**
    * Retrieve this Collection's transaction history
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
+   *
    *
    * @note uses the middlewareV2
    */
   public async getTransactionHistory(opts: {
     size?: BigNumber;
     start?: BigNumber;
-    orderBy?: AssetTransactionsOrderBy;
+    orderBy?: AssetTransactionsOrderBy | AssetTransactionsOrderBy[];
   }): Promise<ResultSet<HistoricNftTransaction>> {
     const { context, id } = this;
     const { size, start, orderBy } = opts;

--- a/src/api/entities/Asset/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/NonFungible/NftCollection.ts
@@ -7,7 +7,7 @@ import { NonFungibleSettlements } from '~/api/entities/Asset/Base/Settlements';
 import { AssetHolders } from '~/api/entities/Asset/NonFungible/AssetHolders';
 import { Account, Context, issueNft, Nft, nftControllerTransfer, PolymeshError } from '~/internal';
 import { assetQuery, assetTransactionQuery } from '~/middleware/queries/assets';
-import { Query } from '~/middleware/types';
+import { AssetTransactionsOrderBy, Query } from '~/middleware/types';
 import {
   AssetDetails,
   BatchIssueNftParams,
@@ -360,9 +360,10 @@ export class NftCollection extends BaseAsset {
   public async getTransactionHistory(opts: {
     size?: BigNumber;
     start?: BigNumber;
+    orderBy?: AssetTransactionsOrderBy;
   }): Promise<ResultSet<HistoricNftTransaction>> {
     const { context, id } = this;
-    const { size, start } = opts;
+    const { size, start, orderBy } = opts;
 
     const {
       data: {
@@ -374,7 +375,8 @@ export class NftCollection extends BaseAsset {
           assetId: id,
         },
         size,
-        start
+        start,
+        orderBy
       )
     );
 

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -368,6 +368,18 @@ export interface HeldNfts {
 }
 
 /**
+ * A fungible Asset held by an Identity, with the amount held
+ */
+export interface FungibleAssetHolding {
+  asset: FungibleAsset;
+  /**
+   * amount of the Asset currently held. The indexer keeps a holding once it has existed, so this
+   * is `0` for an Asset the Identity held at some point and has since transferred away in full
+   */
+  amount: BigNumber;
+}
+
+/**
  * For all claim types except Jurisdiction - tracks holders with and without the claim
  */
 export type ClaimValue = {

--- a/src/api/entities/DividendDistribution/index.ts
+++ b/src/api/entities/DividendDistribution/index.ts
@@ -24,7 +24,7 @@ import {
   reclaimDividendDistributionFunds,
 } from '~/internal';
 import { distributionPaymentsQuery, distributionQuery } from '~/middleware/queries/distributions';
-import { Query } from '~/middleware/types';
+import { DistributionPaymentsOrderBy, Query } from '~/middleware/types';
 import {
   CorporateActionKind,
   DistributionPayment,
@@ -491,14 +491,14 @@ export class DividendDistribution extends CorporateActionBase {
    * @note supports pagination
    */
   public async getPaymentHistory(
-    opts: { size?: BigNumber; start?: BigNumber } = {}
+    opts: { size?: BigNumber; start?: BigNumber; orderBy?: DistributionPaymentsOrderBy } = {}
   ): Promise<ResultSet<DistributionPayment>> {
     const {
       id,
       asset: { id: assetId },
       context,
     } = this;
-    const { size, start } = opts;
+    const { size, start, orderBy } = opts;
 
     const middlewareAssetId = await getAssetIdForMiddleware(assetId, context);
 
@@ -508,7 +508,8 @@ export class DividendDistribution extends CorporateActionBase {
           distributionId: `${middlewareAssetId}/${id.toString()}`,
         },
         size,
-        start
+        start,
+        orderBy
       )
     );
 

--- a/src/api/entities/DividendDistribution/index.ts
+++ b/src/api/entities/DividendDistribution/index.ts
@@ -486,12 +486,20 @@ export class DividendDistribution extends CorporateActionBase {
 
   /**
    * Retrieve the payment history for this Distribution
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
+   *
    *
    * @note uses the middleware V2
    * @note supports pagination
    */
   public async getPaymentHistory(
-    opts: { size?: BigNumber; start?: BigNumber; orderBy?: DistributionPaymentsOrderBy } = {}
+    opts: {
+      size?: BigNumber;
+      start?: BigNumber;
+      orderBy?: DistributionPaymentsOrderBy | DistributionPaymentsOrderBy[];
+    } = {}
   ): Promise<ResultSet<DistributionPayment>> {
     const {
       id,

--- a/src/api/entities/Identity/AssetPermissions.ts
+++ b/src/api/entities/Identity/AssetPermissions.ts
@@ -368,6 +368,9 @@ export class AssetPermissions extends Namespace<Identity> {
    * @param opts.eventId - filters results by event
    * @param opts.size - page size
    * @param opts.start - page offset
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
    *
    * @note uses the middlewareV2
    * @note supports pagination
@@ -378,7 +381,7 @@ export class AssetPermissions extends Namespace<Identity> {
     eventId?: EventIdEnum;
     size?: BigNumber;
     start?: BigNumber;
-    orderBy?: TickerExternalAgentActionsOrderBy;
+    orderBy?: TickerExternalAgentActionsOrderBy | TickerExternalAgentActionsOrderBy[];
   }): Promise<ResultSet<EventIdentifier>> {
     const {
       context,

--- a/src/api/entities/Identity/AssetPermissions.ts
+++ b/src/api/entities/Identity/AssetPermissions.ts
@@ -16,7 +16,12 @@ import {
   tickerExternalAgentActionsQuery,
   tickerExternalAgentsQuery,
 } from '~/middleware/queries/externalAgents';
-import { EventIdEnum, ModuleIdEnum, Query } from '~/middleware/types';
+import {
+  EventIdEnum,
+  ModuleIdEnum,
+  Query,
+  TickerExternalAgentActionsOrderBy,
+} from '~/middleware/types';
 import {
   Asset,
   AssetWithGroup,
@@ -373,13 +378,14 @@ export class AssetPermissions extends Namespace<Identity> {
     eventId?: EventIdEnum;
     size?: BigNumber;
     start?: BigNumber;
+    orderBy?: TickerExternalAgentActionsOrderBy;
   }): Promise<ResultSet<EventIdentifier>> {
     const {
       context,
       parent: { did },
     } = this;
 
-    const { asset, moduleId: palletName, eventId, size, start } = opts;
+    const { asset, moduleId: palletName, eventId, size, start, orderBy } = opts;
 
     const middlewareAssetId = await getAssetIdForMiddleware(asset, context);
 
@@ -396,7 +402,8 @@ export class AssetPermissions extends Namespace<Identity> {
           eventId,
         },
         size,
-        start
+        start,
+        orderBy
       )
     );
 

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -706,7 +706,7 @@ describe('Identity class', () => {
       result = await identity.getHeldNfts({
         start: new BigNumber(0),
         size: new BigNumber(1),
-        order: NftHoldersOrderBy.CreatedBlockIdAsc,
+        orderBy: NftHoldersOrderBy.CreatedBlockIdAsc,
       });
 
       expect(result.data[0]!.collection.id).toBe(assetIds[0]);
@@ -740,6 +740,44 @@ describe('Identity class', () => {
 
       expect(result.data).toHaveLength(1);
       expect(result.count).toEqual(new BigNumber(1));
+    });
+
+    it('should still order by the deprecated `order` it was published with', async () => {
+      const identity = new Identity({ did }, context);
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const assetId = assetIds[0]!;
+      when(getAssetIdFromMiddlewareSpy).calledWith(assetId).mockReturnValue(assetId);
+
+      dsMockUtils.createApolloQueryMock(
+        nftHoldersQuery(
+          { identityId: did },
+          undefined,
+          undefined,
+          NftHoldersOrderBy.CreatedBlockIdAsc
+        ),
+        {
+          nftHolders: {
+            nodes: [{ asset: { id: assetId }, nftIds: [1] }],
+            totalCount: 1,
+          },
+        }
+      );
+
+      const result = await identity.getHeldNfts({ order: NftHoldersOrderBy.CreatedBlockIdAsc });
+
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('should throw when both `order` and `orderBy` are passed, since neither can be meant', () => {
+      const identity = new Identity({ did }, context);
+
+      return expect(
+        identity.getHeldNfts({
+          order: NftHoldersOrderBy.CreatedBlockIdAsc,
+          orderBy: NftHoldersOrderBy.CreatedBlockIdDesc,
+        })
+      ).rejects.toThrow('Pass "orderBy" or the deprecated "order", not both');
     });
   });
 

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -611,6 +611,60 @@ describe('Identity class', () => {
     });
   });
 
+  describe('method: getAssetHoldings', () => {
+    const did = 'someDid';
+    const assetIds = ['0x12341234123412341234123412341234', '0x5678'];
+
+    it('should return each Asset with the amount held', async () => {
+      const identity = new Identity({ did }, context);
+
+      assetIds.forEach(assetId =>
+        when(getAssetIdFromMiddlewareSpy).calledWith({ id: assetId }).mockReturnValue(assetId)
+      );
+
+      dsMockUtils.createApolloQueryMock(assetHoldersQuery({ identityId: did }), {
+        assetHolders: {
+          nodes: [
+            { asset: { id: assetIds[0] }, amount: '1000000' },
+            { asset: { id: assetIds[1] }, amount: '0' },
+          ],
+          totalCount: 2,
+        },
+      });
+
+      const result = await identity.getAssetHoldings();
+
+      expect(result.data[0]!.asset.id).toBe(assetIds[0]);
+      expect(result.data[0]!.amount).toEqual(new BigNumber(1));
+      // a holding the Identity has transferred away in full is still returned, at zero
+      expect(result.data[1]!.amount).toEqual(new BigNumber(0));
+      expect(result.count).toEqual(new BigNumber(2));
+    });
+
+    it('should ask the indexer to exclude zero balances when heldNow is passed', async () => {
+      const identity = new Identity({ did }, context);
+
+      when(getAssetIdFromMiddlewareSpy)
+        .calledWith({ id: assetIds[0] })
+        .mockReturnValue(assetIds[0]!);
+
+      dsMockUtils.createApolloQueryMock(
+        assetHoldersQuery({ identityId: did, amount: '0' }, undefined, undefined, undefined),
+        {
+          assetHolders: {
+            nodes: [{ asset: { id: assetIds[0] }, amount: '1000000' }],
+            totalCount: 1,
+          },
+        }
+      );
+
+      const result = await identity.getAssetHoldings({ heldNow: true });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.count).toEqual(new BigNumber(1));
+    });
+  });
+
   describe('method: getHeldNfts', () => {
     const did = 'someDid';
     const assetIds = ['0x12341234123412341234123412341234', '0x4321'];
@@ -663,6 +717,29 @@ describe('Identity class', () => {
           expect.objectContaining({ id: new BigNumber(3) }),
         ])
       );
+    });
+
+    it('should ask the indexer to exclude collections held down to nothing', async () => {
+      const identity = new Identity({ did }, context);
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const assetId = assetIds[0]!;
+      when(getAssetIdFromMiddlewareSpy).calledWith(assetId).mockReturnValue(assetId);
+
+      dsMockUtils.createApolloQueryMock(
+        nftHoldersQuery({ identityId: did, nftIds: [] }, undefined, undefined, undefined),
+        {
+          nftHolders: {
+            nodes: [{ asset: { id: assetId }, nftIds: [1] }],
+            totalCount: 1,
+          },
+        }
+      );
+
+      const result = await identity.getHeldNfts({ heldNow: true });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.count).toEqual(new BigNumber(1));
     });
   });
 

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -1195,10 +1195,16 @@ describe('Identity class', () => {
 
       const identity = new Identity({ did: 'someDid' }, context);
 
-      const heldAssetsSpy = jest.spyOn(identity, 'getHeldAssets');
-      heldAssetsSpy
-        .mockResolvedValueOnce({ data: [assets[0]!], next: new BigNumber(1) })
-        .mockResolvedValue({ data: [assets[1]!], next: null });
+      const assetHoldingsSpy = jest.spyOn(identity, 'getAssetHoldings');
+      assetHoldingsSpy
+        .mockResolvedValueOnce({
+          data: [{ asset: assets[0]!, amount: new BigNumber(10) }],
+          next: new BigNumber(1),
+        })
+        .mockResolvedValue({
+          data: [{ asset: assets[1]!, amount: new BigNumber(20) }],
+          next: null,
+        });
 
       const result = await identity.getPendingDistributions();
 

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -36,6 +36,7 @@ import {
   DefaultPortfolio,
   DistributionWithDetails,
   ErrorCode,
+  FungibleAssetHolding,
   GroupedInstructions,
   GroupedInvolvedInstructions,
   HeldNfts,
@@ -388,6 +389,10 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
   /**
    * Retrieve a list of all Assets which were held at one point by this Identity
    *
+   * @deprecated in favour of {@link getAssetHoldings}, which reports the amount held alongside
+   *   each Asset and can exclude the ones held down to zero. This method will be removed in the
+   *   next major version
+   *
    * @note uses the middlewareV2
    * @note supports pagination
    */
@@ -432,13 +437,72 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
   }
 
   /**
+   * Retrieve the fungible Assets held by this Identity, with the amount held of each
+   *
+   * @param opts.heldNow - exclude Assets the Identity has transferred away in full. The indexer
+   *   keeps a holding once it has existed, so by default an Asset held at any point is returned,
+   *   with an `amount` of 0
+   *
+   * @note uses the middlewareV2
+   * @note supports pagination
+   */
+  public async getAssetHoldings(
+    opts: {
+      heldNow?: boolean;
+      orderBy?: AssetHoldersOrderBy;
+      size?: BigNumber;
+      start?: BigNumber;
+    } = {}
+  ): Promise<ResultSet<FungibleAssetHolding>> {
+    const { context, did } = this;
+
+    const { size, start, orderBy, heldNow } = opts;
+
+    const {
+      data: {
+        assetHolders: { nodes, totalCount },
+      },
+    } = await context.queryMiddleware<Ensured<Query, 'assetHolders'>>(
+      assetHoldersQuery(
+        {
+          identityId: did,
+          ...(heldNow && { amount: '0' }),
+        },
+        size,
+        start,
+        orderBy
+      )
+    );
+
+    const count = new BigNumber(totalCount);
+
+    const data = nodes.map(({ asset, amount }) => ({
+      asset: new FungibleAsset({ assetId: getAssetIdFromMiddleware(asset!.id) }, context),
+      amount: new BigNumber(amount).shiftedBy(-6),
+    }));
+
+    const next = calculateNextKey(count, data.length, start);
+
+    return {
+      data,
+      next,
+      count,
+    };
+  }
+
+  /**
    * Retrieve a list of all NftCollections which were held at one point by this Identity
+   *
+   * @param opts.heldNow - exclude collections the Identity no longer holds any NFT of. The
+   *   indexer keeps a holding once it has existed, so by default a collection held at any point
+   *   is returned, with an empty `nfts` list
    *
    * @note uses the middlewareV2
    * @note supports pagination
    */
   public async getHeldNfts(
     opts: {
+      heldNow?: boolean;
       order?: NftHoldersOrderBy;
       size?: BigNumber;
       start?: BigNumber;
@@ -446,7 +510,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
   ): Promise<ResultSet<HeldNfts>> {
     const { context, did } = this;
 
-    const { size, start, order } = opts;
+    const { size, start, order, heldNow } = opts;
 
     const {
       data: {
@@ -456,6 +520,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
       nftHoldersQuery(
         {
           identityId: did,
+          ...(heldNow && { nftIds: [] }),
         },
         size,
         start,

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -451,7 +451,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
       heldNow?: boolean;
       orderBy?: AssetHoldersOrderBy;
       size?: BigNumber;
-      start?: BigNumber;
+      start?: BigNumber | undefined;
     } = {}
   ): Promise<ResultSet<FungibleAssetHolding>> {
     const { context, did } = this;
@@ -875,13 +875,13 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
     let start: BigNumber | undefined;
 
     while (!allFetched) {
-      const { data, next } = await this.getHeldAssets({
+      const { data, next } = await this.getAssetHoldings({
         size: MAX_PAGE_SIZE,
         start,
       });
       start = next ? new BigNumber(next) : undefined;
       allFetched = !next;
-      assets = [...assets, ...data];
+      assets = [...assets, ...data.map(({ asset }) => asset)];
     }
 
     const distributions = await this.context.getDividendDistributionsForAssets({ assets });

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -92,6 +92,26 @@ import {
 } from '~/utils/internal';
 
 /**
+ * @hidden
+ *
+ * Read the ordering from a method that still accepts the `order` it was first published with.
+ *
+ * The two mean the same thing, so passing both says nothing about which was meant
+ */
+function orderingFrom<Key>(opts: { order?: Key; orderBy?: Key | Key[] }): Key | Key[] | undefined {
+  const { order, orderBy } = opts;
+
+  if (order !== undefined && orderBy !== undefined) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Pass "orderBy" or the deprecated "order", not both',
+    });
+  }
+
+  return orderBy ?? order;
+}
+
+/**
  * Properties that uniquely identify an Identity
  */
 export interface UniqueIdentifiers {
@@ -393,19 +413,31 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    *   each Asset and can exclude the ones held down to zero. This method will be removed in the
    *   next major version
    *
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
+   * @param opts.order - deprecated in favour of `orderBy`, which it means the same thing as.
+   *   Passing both throws, since neither can be said to have been meant
+   *
    * @note uses the middlewareV2
    * @note supports pagination
    */
   public async getHeldAssets(
     opts: {
+      /**
+       * @deprecated in favour of `orderBy`, which every other read is ordered by. Passing both
+       *   throws
+       */
       order?: AssetHoldersOrderBy;
+      orderBy?: AssetHoldersOrderBy | AssetHoldersOrderBy[];
       size?: BigNumber;
       start?: BigNumber | undefined;
     } = {}
   ): Promise<ResultSet<FungibleAsset>> {
     const { context, did } = this;
 
-    const { size, start, order } = opts;
+    const { size, start } = opts;
+    const ordering = orderingFrom(opts);
 
     const {
       data: {
@@ -418,7 +450,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
         },
         size,
         start,
-        order
+        ordering
       )
     );
     const count = new BigNumber(totalCount);
@@ -442,6 +474,9 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    * @param opts.heldNow - exclude Assets the Identity has transferred away in full. The indexer
    *   keeps a holding once it has existed, so by default an Asset held at any point is returned,
    *   with an `amount` of 0
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
    *
    * @note uses the middlewareV2
    * @note supports pagination
@@ -449,7 +484,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
   public async getAssetHoldings(
     opts: {
       heldNow?: boolean;
-      orderBy?: AssetHoldersOrderBy;
+      orderBy?: AssetHoldersOrderBy | AssetHoldersOrderBy[];
       size?: BigNumber;
       start?: BigNumber | undefined;
     } = {}
@@ -496,6 +531,11 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    * @param opts.heldNow - exclude collections the Identity no longer holds any NFT of. The
    *   indexer keeps a holding once it has existed, so by default a collection held at any point
    *   is returned, with an empty `nfts` list
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
+   * @param opts.order - deprecated in favour of `orderBy`, which it means the same thing as.
+   *   Passing both throws, since neither can be said to have been meant
    *
    * @note uses the middlewareV2
    * @note supports pagination
@@ -503,14 +543,20 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
   public async getHeldNfts(
     opts: {
       heldNow?: boolean;
+      /**
+       * @deprecated in favour of `orderBy`, which every other read is ordered by. Passing both
+       *   throws
+       */
       order?: NftHoldersOrderBy;
+      orderBy?: NftHoldersOrderBy | NftHoldersOrderBy[];
       size?: BigNumber;
       start?: BigNumber;
     } = {}
   ): Promise<ResultSet<HeldNfts>> {
     const { context, did } = this;
 
-    const { size, start, order, heldNow } = opts;
+    const { size, start, heldNow } = opts;
+    const ordering = orderingFrom(opts);
 
     const {
       data: {
@@ -524,7 +570,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
         },
         size,
         start,
-        order
+        ordering
       )
     );
 

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -1004,7 +1004,11 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
   ): Promise<ResultSet<HistoricInstruction>> {
     const { context, did } = this;
 
-    const query = await historicalInstructionsQuery({ ...filter, identity: did }, context);
+    const query = await historicalInstructionsQuery(
+      { ...filter, identity: did },
+      context,
+      filter?.orderBy
+    );
 
     const {
       data: {

--- a/src/api/entities/Offering/index.ts
+++ b/src/api/entities/Offering/index.ts
@@ -16,7 +16,7 @@ import {
   toggleFreezeOffering,
 } from '~/internal';
 import { investmentsQuery } from '~/middleware/queries/stos';
-import { Query } from '~/middleware/types';
+import { InvestmentsOrderBy, Query } from '~/middleware/types';
 import {
   Account,
   EnableOffChainFundingParams,
@@ -253,6 +253,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
     opts: {
       size?: BigNumber;
       start?: BigNumber;
+      orderBy?: InvestmentsOrderBy;
     } = {}
   ): Promise<ResultSet<Investment>> {
     const {
@@ -263,7 +264,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
 
     const middlewareAssetId = await getAssetIdForMiddleware(assetId, context);
 
-    const { size, start } = opts;
+    const { size, start, orderBy } = opts;
 
     const {
       data: {
@@ -276,7 +277,8 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
           offeringAssetId: middlewareAssetId,
         },
         size,
-        start
+        start,
+        orderBy
       )
     );
 

--- a/src/api/entities/Offering/index.ts
+++ b/src/api/entities/Offering/index.ts
@@ -245,6 +245,9 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
    *
    * @param opts.size - page size
    * @param opts.start - page offset
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
    *
    * @note supports pagination
    * @note uses the middleware V2
@@ -253,7 +256,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
     opts: {
       size?: BigNumber;
       start?: BigNumber;
-      orderBy?: InvestmentsOrderBy;
+      orderBy?: InvestmentsOrderBy | InvestmentsOrderBy[];
     } = {}
   ): Promise<ResultSet<Investment>> {
     const {

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -248,6 +248,9 @@ export class Venue extends Entity<UniqueIdentifiers, string> {
    *
    * @param opts.size - page size
    * @param opts.start - page offset
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
    *
    * @note uses the middleware V2
    * @note supports pagination

--- a/src/api/entities/common/namespaces/Authorizations.ts
+++ b/src/api/entities/common/namespaces/Authorizations.ts
@@ -153,6 +153,9 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
    * @param opts.status - fetch only authorizations with this status. Fetches all statuses if not passed
    * @param opts.size - page size
    * @param opts.start - page offset
+   * @param opts.orderBy - how to order the results: one key, or several to decide the rows a
+   *   single key leaves tied. The read's own unique key is appended to whatever is passed, so
+   *   that paging cannot repeat or skip a row
    *
    * @note supports pagination
    * @note uses the middlewareV2
@@ -163,7 +166,7 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
       type?: AuthTypeEnum;
       size?: BigNumber;
       start?: BigNumber;
-      orderBy?: AuthorizationsOrderBy;
+      orderBy?: AuthorizationsOrderBy | AuthorizationsOrderBy[];
     } = {}
   ): Promise<ResultSet<AuthorizationRequest>> {
     const { context, parent } = this;

--- a/src/api/entities/common/namespaces/Authorizations.ts
+++ b/src/api/entities/common/namespaces/Authorizations.ts
@@ -6,6 +6,7 @@ import { Account, AuthorizationRequest, Identity, Namespace, PolymeshError } fro
 import { AuthorizationArgs, authorizationsQuery } from '~/middleware/queries/authorizations';
 import {
   Authorization as MiddlewareAuthorization,
+  AuthorizationsOrderBy,
   AuthorizationStatusEnum,
   AuthTypeEnum,
   Query,
@@ -162,13 +163,14 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
       type?: AuthTypeEnum;
       size?: BigNumber;
       start?: BigNumber;
+      orderBy?: AuthorizationsOrderBy;
     } = {}
   ): Promise<ResultSet<AuthorizationRequest>> {
     const { context, parent } = this;
 
     const signerValue = signerToSignerValue(parent);
 
-    const { status, type, start, size } = opts;
+    const { status, type, start, size, orderBy } = opts;
 
     const filters: QueryArgs<MiddlewareAuthorization, AuthorizationArgs> = {
       type,
@@ -185,7 +187,7 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
         authorizations: { totalCount, nodes: authorizationResult },
       },
     } = await context.queryMiddleware<Ensured<Query, 'authorizations'>>(
-      authorizationsQuery(filters, size, start)
+      authorizationsQuery(filters, size, start, orderBy)
     );
 
     const data = authorizationResult.map(middlewareAuthorization => {

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -1440,7 +1440,7 @@ export class Context {
     accounts?: (string | Account)[];
     size?: BigNumber;
     start?: BigNumber;
-    orderBy?: PolyxTransactionsOrderBy;
+    orderBy?: PolyxTransactionsOrderBy | PolyxTransactionsOrderBy[];
   }): Promise<ResultSet<HistoricPolyxTransaction>> {
     const {
       identity,

--- a/src/middleware/__tests__/queries/assets.ts
+++ b/src/middleware/__tests__/queries/assets.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { print } from 'graphql';
 
 import {
   assetHoldersQuery,
@@ -110,5 +111,31 @@ describe('nftCollectionHoldersQuery', () => {
       size: 1,
       start: 0,
     });
+  });
+});
+
+describe('holder queries', () => {
+  it('should select the amount held, which callers need to tell a live holding from a spent one', () => {
+    expect(print(assetHoldersQuery({ identityId: 'someDid' }).query)).toContain('amount');
+  });
+
+  it('should exclude zero balances in the query, so totalCount and the cursor stay honest', () => {
+    const { query, variables } = assetHoldersQuery({ identityId: 'someDid', amount: '0' });
+
+    expect(print(query)).toContain('amount: {greaterThan: $amount}');
+    expect(print(query)).toContain('$amount: BigFloat!');
+    expect(variables).toMatchObject({ amount: '0' });
+  });
+
+  it('should omit the amount filter when it is not asked for', () => {
+    expect(print(assetHoldersQuery({ identityId: 'someDid' }).query)).not.toContain('greaterThan');
+  });
+
+  it('should exclude collections held down to nothing in the query', () => {
+    const { query, variables } = nftHoldersQuery({ identityId: 'someDid', nftIds: [] });
+
+    expect(print(query)).toContain('nftIds: {notEqualTo: $nftIds}');
+    expect(print(query)).toContain('$nftIds: JSON!');
+    expect(variables).toMatchObject({ nftIds: [] });
   });
 });

--- a/src/middleware/__tests__/queries/assets.ts
+++ b/src/middleware/__tests__/queries/assets.ts
@@ -8,6 +8,7 @@ import {
   nftCollectionHolders,
   nftHoldersQuery,
 } from '~/middleware/queries/assets';
+import { AssetHoldersOrderBy, NftHoldersOrderBy } from '~/middleware/types';
 import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 
 describe('assetQuery', () => {
@@ -115,12 +116,14 @@ describe('nftCollectionHoldersQuery', () => {
 });
 
 describe('holder queries', () => {
+  const identityId = 'someDid';
+
   it('should select the amount held, which callers need to tell a live holding from a spent one', () => {
-    expect(print(assetHoldersQuery({ identityId: 'someDid' }).query)).toContain('amount');
+    expect(print(assetHoldersQuery({ identityId }).query)).toContain('amount');
   });
 
   it('should exclude zero balances in the query, so totalCount and the cursor stay honest', () => {
-    const { query, variables } = assetHoldersQuery({ identityId: 'someDid', amount: '0' });
+    const { query, variables } = assetHoldersQuery({ identityId, amount: '0' });
 
     expect(print(query)).toContain('amount: {greaterThan: $amount}');
     expect(print(query)).toContain('$amount: BigFloat!');
@@ -128,11 +131,36 @@ describe('holder queries', () => {
   });
 
   it('should omit the amount filter when it is not asked for', () => {
-    expect(print(assetHoldersQuery({ identityId: 'someDid' }).query)).not.toContain('greaterThan');
+    expect(print(assetHoldersQuery({ identityId }).query)).not.toContain('greaterThan');
+  });
+
+  it('should map the createdAt orderings onto block order, which the indexer exposes', () => {
+    expect(
+      print(
+        assetHoldersQuery({ identityId }, undefined, undefined, AssetHoldersOrderBy.CreatedAtAsc)
+          .query
+      )
+    ).toContain('orderBy: [CREATED_BLOCK_ID_ASC]');
+    expect(
+      print(
+        assetHoldersQuery({ identityId }, undefined, undefined, AssetHoldersOrderBy.CreatedAtDesc)
+          .query
+      )
+    ).toContain('orderBy: [CREATED_BLOCK_ID_DESC]');
+    expect(
+      print(
+        nftHoldersQuery({ identityId }, undefined, undefined, NftHoldersOrderBy.CreatedAtAsc).query
+      )
+    ).toContain('orderBy: [CREATED_BLOCK_ID_ASC]');
+    expect(
+      print(
+        nftHoldersQuery({ identityId }, undefined, undefined, NftHoldersOrderBy.CreatedAtDesc).query
+      )
+    ).toContain('orderBy: [CREATED_BLOCK_ID_DESC]');
   });
 
   it('should exclude collections held down to nothing in the query', () => {
-    const { query, variables } = nftHoldersQuery({ identityId: 'someDid', nftIds: [] });
+    const { query, variables } = nftHoldersQuery({ identityId, nftIds: [] });
 
     expect(print(query)).toContain('nftIds: {notEqualTo: $nftIds}');
     expect(print(query)).toContain('$nftIds: JSON!');

--- a/src/middleware/__tests__/queries/assets.ts
+++ b/src/middleware/__tests__/queries/assets.ts
@@ -140,23 +140,23 @@ describe('holder queries', () => {
         assetHoldersQuery({ identityId }, undefined, undefined, AssetHoldersOrderBy.CreatedAtAsc)
           .query
       )
-    ).toContain('orderBy: [CREATED_BLOCK_ID_ASC]');
+    ).toContain('orderBy: [CREATED_BLOCK_ID_ASC, ASSET_ID_ASC]');
     expect(
       print(
         assetHoldersQuery({ identityId }, undefined, undefined, AssetHoldersOrderBy.CreatedAtDesc)
           .query
       )
-    ).toContain('orderBy: [CREATED_BLOCK_ID_DESC]');
+    ).toContain('orderBy: [CREATED_BLOCK_ID_DESC, ASSET_ID_ASC]');
     expect(
       print(
         nftHoldersQuery({ identityId }, undefined, undefined, NftHoldersOrderBy.CreatedAtAsc).query
       )
-    ).toContain('orderBy: [CREATED_BLOCK_ID_ASC]');
+    ).toContain('orderBy: [CREATED_BLOCK_ID_ASC, ASSET_ID_ASC]');
     expect(
       print(
         nftHoldersQuery({ identityId }, undefined, undefined, NftHoldersOrderBy.CreatedAtDesc).query
       )
-    ).toContain('orderBy: [CREATED_BLOCK_ID_DESC]');
+    ).toContain('orderBy: [CREATED_BLOCK_ID_DESC, ASSET_ID_ASC]');
   });
 
   it('should exclude collections held down to nothing in the query', () => {

--- a/src/middleware/__tests__/queries/common.ts
+++ b/src/middleware/__tests__/queries/common.ts
@@ -7,7 +7,9 @@ import {
   latestBlockQuery,
   latestSqVersionQuery,
   metadataQuery,
+  orderByClause,
   removeUndefinedValues,
+  toOrderByList,
 } from '~/middleware/queries/common';
 import { DEFAULT_GQL_PAGE_SIZE } from '~/utils/constants';
 
@@ -171,5 +173,48 @@ describe('createArgsAndFilters', () => {
 
   it('should emit no filter block when nothing is supplied', () => {
     expect(createArgsAndFilters({}, {}).filter).toBe('');
+  });
+});
+
+describe('orderByClause', () => {
+  const ID_ASC = 'ID_ASC';
+  const ID_DESC = 'ID_DESC';
+  const DATETIME_DESC = 'DATETIME_DESC';
+  const AMOUNT_ASC = 'AMOUNT_ASC';
+
+  it('should order by the unique key alone when nothing is supplied', () => {
+    expect(orderByClause(undefined, [ID_ASC])).toBe(ID_ASC);
+    expect(orderByClause([], [ID_ASC])).toBe(ID_ASC);
+  });
+
+  it('should keep the unique key behind what a caller asks for, so paging stays stable', () => {
+    // `AMOUNT_ASC` decides no row on its own: paging over it can repeat and skip rows
+    expect(orderByClause(AMOUNT_ASC, [ID_ASC])).toBe(`${AMOUNT_ASC}, ${ID_ASC}`);
+  });
+
+  it('should keep several supplied keys in the order they were given', () => {
+    expect(orderByClause([AMOUNT_ASC, DATETIME_DESC], [ID_ASC])).toBe(
+      `${AMOUNT_ASC}, ${DATETIME_DESC}, ${ID_ASC}`
+    );
+  });
+
+  it('should not append a key whose column the caller already ordered by', () => {
+    // appending `ID_ASC` behind their `ID_DESC` says nothing, and ahead of it would ignore them
+    expect(orderByClause(ID_DESC, [ID_ASC])).toBe(ID_DESC);
+    expect(orderByClause([AMOUNT_ASC, ID_DESC], [ID_ASC])).toBe(`${AMOUNT_ASC}, ${ID_DESC}`);
+  });
+
+  it('should append every key a query needs to decide a row', () => {
+    expect(orderByClause(AMOUNT_ASC, ['CREATED_BLOCK_ID_DESC', ID_DESC])).toBe(
+      `${AMOUNT_ASC}, CREATED_BLOCK_ID_DESC, ${ID_DESC}`
+    );
+  });
+});
+
+describe('toOrderByList', () => {
+  it('should read one key, several, or none', () => {
+    expect(toOrderByList('ID_ASC')).toEqual(['ID_ASC']);
+    expect(toOrderByList(['ID_ASC', 'ID_DESC'])).toEqual(['ID_ASC', 'ID_DESC']);
+    expect(toOrderByList(undefined)).toEqual([]);
   });
 });

--- a/src/middleware/__tests__/queries/common.ts
+++ b/src/middleware/__tests__/queries/common.ts
@@ -158,6 +158,17 @@ describe('createArgsAndFilters', () => {
     expect(filter).toBe('filter: { amount: { greaterThan: $amount } }');
   });
 
+  it('should filter on a falsy value that was supplied', () => {
+    // `success: 0` means "only the failed ones"; dropping it returned everything
+    const { filter } = createArgsAndFilters({ success: 0 }, { success: 'Int' });
+
+    expect(filter).toBe('filter: { success: { equalTo: $success } }');
+  });
+
+  it('should skip an attribute that was not supplied', () => {
+    expect(createArgsAndFilters({ address: undefined, moduleId: null }, {}).filter).toBe('');
+  });
+
   it('should emit no filter block when nothing is supplied', () => {
     expect(createArgsAndFilters({}, {}).filter).toBe('');
   });

--- a/src/middleware/__tests__/queries/common.ts
+++ b/src/middleware/__tests__/queries/common.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import {
+  createArgsAndFilters,
   getSizeAndOffset,
   heartbeatQuery,
   latestBlockQuery,
@@ -129,5 +130,35 @@ describe('removeUndefinedValues', () => {
     const result = removeUndefinedValues(input);
 
     expect(result).toEqual(input);
+  });
+});
+
+describe('createArgsAndFilters', () => {
+  it('should only emit the attributes actually supplied', () => {
+    const { args, filter } = createArgsAndFilters({ assetId: 'someAsset', ticker: undefined }, {});
+
+    expect(args).toBe('($start: Int,$size: Int,$assetId: String!)');
+    expect(filter).toBe('filter: { assetId: { equalTo: $assetId } }');
+  });
+
+  it('should default to a String variable compared with equalTo', () => {
+    const { args, filter } = createArgsAndFilters({ stoId: 1 }, { stoId: 'Int' });
+
+    expect(args).toContain('$stoId: Int!');
+    expect(filter).toBe('filter: { stoId: { equalTo: $stoId } }');
+  });
+
+  it('should accept a comparison other than equalTo', () => {
+    const { args, filter } = createArgsAndFilters(
+      { amount: '0' },
+      { amount: { type: 'BigFloat', operator: 'greaterThan' } }
+    );
+
+    expect(args).toContain('$amount: BigFloat!');
+    expect(filter).toBe('filter: { amount: { greaterThan: $amount } }');
+  });
+
+  it('should emit no filter block when nothing is supplied', () => {
+    expect(createArgsAndFilters({}, {}).filter).toBe('');
   });
 });

--- a/src/middleware/__tests__/queries/multisigs.ts
+++ b/src/middleware/__tests__/queries/multisigs.ts
@@ -38,7 +38,7 @@ describe('multiSigProposalsQuery', () => {
   const multisigId = 'someId';
 
   it('should return correct query and variables when size, start are not provided', () => {
-    const result = multiSigProposalsQuery(multisigId);
+    const result = multiSigProposalsQuery({ multisigId });
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({ size: DEFAULT_GQL_PAGE_SIZE, start: 0, multisigId });
   });
@@ -46,7 +46,7 @@ describe('multiSigProposalsQuery', () => {
   it('should return correct query and variables when size, start are provided', () => {
     const size = new BigNumber(10);
     const start = new BigNumber(0);
-    const result = multiSigProposalsQuery(multisigId, size, start);
+    const result = multiSigProposalsQuery({ multisigId }, size, start);
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual({
       size: size.toNumber(),

--- a/src/middleware/__tests__/queries/ordering.ts
+++ b/src/middleware/__tests__/queries/ordering.ts
@@ -90,8 +90,8 @@ describe('paginated query ordering', () => {
     expect(queryFor(PROPOSALS)).not.toContain(ID_DESC);
   });
 
-  it('should let a caller replace the default order', () => {
-    const withOrder = [
+  it('should keep the unique key behind whatever ordering a caller asks for', () => {
+    const withOrder: [string, string][] = [
       [
         print(
           assetTransactionQuery(
@@ -101,11 +101,11 @@ describe('paginated query ordering', () => {
             AssetTransactionsOrderBy.DatetimeDesc
           ).query
         ),
-        'orderBy: [DATETIME_DESC]',
+        'orderBy: [DATETIME_DESC, ID_ASC]',
       ],
       [
         print(eventsByArgs({}, undefined, undefined, EventsOrderBy.BlockIdDesc).query),
-        'orderBy: [BLOCK_ID_DESC]',
+        'orderBy: [BLOCK_ID_DESC, ID_ASC]',
       ],
       [
         print(
@@ -113,10 +113,10 @@ describe('paginated query ordering', () => {
             { multisigId },
             undefined,
             undefined,
-            MultiSigProposalsOrderBy.ProposalIdAsc
+            MultiSigProposalsOrderBy.StatusAsc
           ).query
         ),
-        'orderBy: [PROPOSAL_ID_ASC]',
+        'orderBy: [STATUS_ASC, PROPOSAL_ID_DESC]',
       ],
       [
         print(
@@ -127,10 +127,40 @@ describe('paginated query ordering', () => {
             InvestmentsOrderBy.DatetimeAsc
           ).query
         ),
-        'orderBy: [DATETIME_ASC]',
+        'orderBy: [DATETIME_ASC, ID_ASC]',
       ],
     ];
 
     withOrder.forEach(([query, order]) => expect(query).toContain(order));
+  });
+
+  it('should order by every key a caller supplies, in the order they supplied them', () => {
+    const query = print(
+      investmentsQuery({ stoId: 1, offeringAssetId: assetId }, undefined, undefined, [
+        InvestmentsOrderBy.OfferingTokenAsc,
+        InvestmentsOrderBy.DatetimeDesc,
+      ]).query
+    );
+
+    expect(query).toContain('orderBy: [OFFERING_TOKEN_ASC, DATETIME_DESC, ID_ASC]');
+  });
+
+  it('should not append a key the caller already orders by, in either direction', () => {
+    // the caller wants the newest first; appending `ID_ASC` behind it would say nothing, and
+    // appending it *ahead* of their key would quietly ignore what they asked for
+    const query = print(
+      investmentsQuery(
+        { stoId: 1, offeringAssetId: assetId },
+        undefined,
+        undefined,
+        InvestmentsOrderBy.IdDesc
+      ).query
+    );
+
+    expect(query).toContain('orderBy: [ID_DESC]');
+  });
+
+  it('should order by the unique key alone when a caller supplies nothing', () => {
+    expect(print(investmentsQuery({ stoId: 1, offeringAssetId: assetId }).query)).toContain(ID_ASC);
   });
 });

--- a/src/middleware/__tests__/queries/ordering.ts
+++ b/src/middleware/__tests__/queries/ordering.ts
@@ -36,7 +36,7 @@ describe('paginated query ordering', () => {
       print(tickerExternalAgentActionsQuery({ assetId: 'someAsset' }).query),
     ],
     ['extrinsicsByArgs', print(extrinsicsByArgs({}).query)],
-    ['multiSigProposalsQuery', print(multiSigProposalsQuery('someAddress').query)],
+    ['multiSigProposalsQuery', print(multiSigProposalsQuery({ multisigId: 'someAddress' }).query)],
     ['polyxTransactionsQuery', print(polyxTransactionsQuery({}).query)],
     [
       'instructionAffirmationsQuery',
@@ -99,7 +99,7 @@ describe('paginated query ordering', () => {
     expect(
       print(
         multiSigProposalsQuery(
-          'someAddress',
+          { multisigId: 'someAddress' },
           undefined,
           undefined,
           MultiSigProposalsOrderBy.ProposalIdAsc

--- a/src/middleware/__tests__/queries/ordering.ts
+++ b/src/middleware/__tests__/queries/ordering.ts
@@ -1,0 +1,86 @@
+import { print } from 'graphql';
+
+import { assetTransactionQuery } from '~/middleware/queries/assets';
+import { customClaimTypeQuery } from '~/middleware/queries/claims';
+import { distributionPaymentsQuery } from '~/middleware/queries/distributions';
+import { eventsByArgs } from '~/middleware/queries/events';
+import { tickerExternalAgentActionsQuery } from '~/middleware/queries/externalAgents';
+import { extrinsicsByArgs } from '~/middleware/queries/extrinsics';
+import { multiSigProposalsQuery } from '~/middleware/queries/multisigs';
+import { polyxTransactionsQuery } from '~/middleware/queries/polyxTransactions';
+import { instructionAffirmationsQuery } from '~/middleware/queries/settlements';
+import { investmentsQuery } from '~/middleware/queries/stos';
+
+/**
+ * A paginated query needs an order that is both defined and unique, or `first`/`offset` can repeat
+ * and skip rows. The indexer zero-pads block-derived ids, so `id` sorts as a number; an id that is
+ * not block-derived is only ever a tiebreaker.
+ */
+describe('paginated query ordering', () => {
+  const cases: [string, string][] = [
+    ['assetTransactionQuery', print(assetTransactionQuery({ assetId: 'someAsset' }).query)],
+    ['customClaimTypeQuery', print(customClaimTypeQuery().query)],
+    [
+      'distributionPaymentsQuery',
+      print(distributionPaymentsQuery({ distributionId: 'someId' }).query),
+    ],
+    ['eventsByArgs', print(eventsByArgs({}).query)],
+    [
+      'tickerExternalAgentActionsQuery',
+      print(tickerExternalAgentActionsQuery({ assetId: 'someAsset' }).query),
+    ],
+    ['extrinsicsByArgs', print(extrinsicsByArgs({}).query)],
+    ['multiSigProposalsQuery', print(multiSigProposalsQuery('someAddress').query)],
+    ['polyxTransactionsQuery', print(polyxTransactionsQuery({}).query)],
+    [
+      'instructionAffirmationsQuery',
+      print(instructionAffirmationsQuery({ instructionId: '1' }).query),
+    ],
+    ['investmentsQuery', print(investmentsQuery({ stoId: 1, offeringAssetId: 'someAsset' }).query)],
+  ];
+
+  it.each(cases)('%s should order its results', (_name, query) => {
+    expect(query).toContain('orderBy:');
+  });
+
+  it('should order by an id that is unique, not by block alone', () => {
+    const byId: Record<string, string> = {
+      assetTransactionQuery: 'orderBy: [ID_ASC]',
+      distributionPaymentsQuery: 'orderBy: [ID_ASC]',
+      eventsByArgs: 'orderBy: [ID_ASC]',
+      extrinsicsByArgs: 'orderBy: [ID_ASC]',
+      investmentsQuery: 'orderBy: [ID_ASC]',
+      polyxTransactionsQuery: 'orderBy: [ID_DESC]',
+      tickerExternalAgentActionsQuery: 'orderBy: [ID_DESC]',
+    };
+
+    cases
+      .filter(([name]) => byId[name])
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      .forEach(([name, query]) => expect(query).toContain(byId[name]!));
+  });
+
+  it('should use a unique tiebreaker where the id is not block derived', () => {
+    const [, customClaimTypes] = cases.find(([name]) => name === 'customClaimTypeQuery')!;
+    const [, affirmations] = cases.find(([name]) => name === 'instructionAffirmationsQuery')!;
+
+    expect(customClaimTypes).toContain('orderBy: [CREATED_BLOCK_ID_ASC, ID_ASC]');
+    expect(affirmations).toContain('orderBy: [CREATED_BLOCK_ID_DESC, ID_DESC]');
+  });
+
+  it('should prefer a composite event id over a block id plus a tiebreaker', () => {
+    // `instructions` and `instructionEvents` already order this way
+    const [, affirmations] = cases.find(([name]) => name === 'instructionAffirmationsQuery')!;
+
+    // `InstructionAffirmation` has no `createdEvent`, so `id` is the only unique column available
+    expect(affirmations).not.toContain('CREATED_EVENT_ID');
+  });
+
+  it('should order MultiSig proposals numerically, since their id embeds an unpadded number', () => {
+    const [, proposals] = cases.find(([name]) => name === 'multiSigProposalsQuery')!;
+
+    expect(proposals).toContain('orderBy: [PROPOSAL_ID_DESC]');
+    // ordering by `id` would place proposal 10 before proposal 9
+    expect(proposals).not.toContain('orderBy: [ID_DESC]');
+  });
+});

--- a/src/middleware/__tests__/queries/ordering.ts
+++ b/src/middleware/__tests__/queries/ordering.ts
@@ -10,6 +10,12 @@ import { multiSigProposalsQuery } from '~/middleware/queries/multisigs';
 import { polyxTransactionsQuery } from '~/middleware/queries/polyxTransactions';
 import { instructionAffirmationsQuery } from '~/middleware/queries/settlements';
 import { investmentsQuery } from '~/middleware/queries/stos';
+import {
+  AssetTransactionsOrderBy,
+  EventsOrderBy,
+  InvestmentsOrderBy,
+  MultiSigProposalsOrderBy,
+} from '~/middleware/types';
 
 /**
  * A paginated query needs an order that is both defined and unique, or `first`/`offset` can repeat
@@ -74,6 +80,42 @@ describe('paginated query ordering', () => {
 
     // `InstructionAffirmation` has no `createdEvent`, so `id` is the only unique column available
     expect(affirmations).not.toContain('CREATED_EVENT_ID');
+  });
+
+  it('should let a caller replace the default order', () => {
+    expect(
+      print(
+        assetTransactionQuery(
+          { assetId: 'someAsset' },
+          undefined,
+          undefined,
+          AssetTransactionsOrderBy.DatetimeDesc
+        ).query
+      )
+    ).toContain('orderBy: [DATETIME_DESC]');
+    expect(
+      print(eventsByArgs({}, undefined, undefined, EventsOrderBy.BlockIdDesc).query)
+    ).toContain('orderBy: [BLOCK_ID_DESC]');
+    expect(
+      print(
+        multiSigProposalsQuery(
+          'someAddress',
+          undefined,
+          undefined,
+          MultiSigProposalsOrderBy.ProposalIdAsc
+        ).query
+      )
+    ).toContain('orderBy: [PROPOSAL_ID_ASC]');
+    expect(
+      print(
+        investmentsQuery(
+          { stoId: 1, offeringAssetId: 'someAsset' },
+          undefined,
+          undefined,
+          InvestmentsOrderBy.DatetimeAsc
+        ).query
+      )
+    ).toContain('orderBy: [DATETIME_ASC]');
   });
 
   it('should order MultiSig proposals numerically, since their id embeds an unpadded number', () => {

--- a/src/middleware/__tests__/queries/ordering.ts
+++ b/src/middleware/__tests__/queries/ordering.ts
@@ -17,6 +17,16 @@ import {
   MultiSigProposalsOrderBy,
 } from '~/middleware/types';
 
+const assetId = 'someAsset';
+const multisigId = 'someAddress';
+
+const ID_ASC = 'orderBy: [ID_ASC]';
+const ID_DESC = 'orderBy: [ID_DESC]';
+
+const AFFIRMATIONS = 'instructionAffirmationsQuery';
+const CUSTOM_CLAIM_TYPES = 'customClaimTypeQuery';
+const PROPOSALS = 'multiSigProposalsQuery';
+
 /**
  * A paginated query needs an order that is both defined and unique, or `first`/`offset` can repeat
  * and skip rows. The indexer zero-pads block-derived ids, so `id` sorts as a number; an id that is
@@ -24,105 +34,103 @@ import {
  */
 describe('paginated query ordering', () => {
   const cases: [string, string][] = [
-    ['assetTransactionQuery', print(assetTransactionQuery({ assetId: 'someAsset' }).query)],
-    ['customClaimTypeQuery', print(customClaimTypeQuery().query)],
-    [
-      'distributionPaymentsQuery',
-      print(distributionPaymentsQuery({ distributionId: 'someId' }).query),
-    ],
+    ['assetTransactionQuery', print(assetTransactionQuery({ assetId }).query)],
+    [CUSTOM_CLAIM_TYPES, print(customClaimTypeQuery().query)],
+    ['distributionPaymentsQuery', print(distributionPaymentsQuery({ distributionId: '1' }).query)],
     ['eventsByArgs', print(eventsByArgs({}).query)],
-    [
-      'tickerExternalAgentActionsQuery',
-      print(tickerExternalAgentActionsQuery({ assetId: 'someAsset' }).query),
-    ],
+    ['tickerExternalAgentActionsQuery', print(tickerExternalAgentActionsQuery({ assetId }).query)],
     ['extrinsicsByArgs', print(extrinsicsByArgs({}).query)],
-    ['multiSigProposalsQuery', print(multiSigProposalsQuery({ multisigId: 'someAddress' }).query)],
+    [PROPOSALS, print(multiSigProposalsQuery({ multisigId }).query)],
     ['polyxTransactionsQuery', print(polyxTransactionsQuery({}).query)],
-    [
-      'instructionAffirmationsQuery',
-      print(instructionAffirmationsQuery({ instructionId: '1' }).query),
-    ],
-    ['investmentsQuery', print(investmentsQuery({ stoId: 1, offeringAssetId: 'someAsset' }).query)],
+    [AFFIRMATIONS, print(instructionAffirmationsQuery({ instructionId: '1' }).query)],
+    ['investmentsQuery', print(investmentsQuery({ stoId: 1, offeringAssetId: assetId }).query)],
   ];
+
+  const queryFor = (name: string): string => {
+    const found = cases.find(([caseName]) => caseName === name);
+
+    if (!found) {
+      throw new Error(`no case named ${name}`);
+    }
+
+    return found[1];
+  };
 
   it.each(cases)('%s should order its results', (_name, query) => {
     expect(query).toContain('orderBy:');
   });
 
   it('should order by an id that is unique, not by block alone', () => {
-    const byId: Record<string, string> = {
-      assetTransactionQuery: 'orderBy: [ID_ASC]',
-      distributionPaymentsQuery: 'orderBy: [ID_ASC]',
-      eventsByArgs: 'orderBy: [ID_ASC]',
-      extrinsicsByArgs: 'orderBy: [ID_ASC]',
-      investmentsQuery: 'orderBy: [ID_ASC]',
-      polyxTransactionsQuery: 'orderBy: [ID_DESC]',
-      tickerExternalAgentActionsQuery: 'orderBy: [ID_DESC]',
+    const expected: Record<string, string> = {
+      assetTransactionQuery: ID_ASC,
+      distributionPaymentsQuery: ID_ASC,
+      eventsByArgs: ID_ASC,
+      extrinsicsByArgs: ID_ASC,
+      investmentsQuery: ID_ASC,
+      polyxTransactionsQuery: ID_DESC,
+      tickerExternalAgentActionsQuery: ID_DESC,
     };
 
-    cases
-      .filter(([name]) => byId[name])
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      .forEach(([name, query]) => expect(query).toContain(byId[name]!));
+    Object.entries(expected).forEach(([name, order]) => expect(queryFor(name)).toContain(order));
   });
 
   it('should use a unique tiebreaker where the id is not block derived', () => {
-    const [, customClaimTypes] = cases.find(([name]) => name === 'customClaimTypeQuery')!;
-    const [, affirmations] = cases.find(([name]) => name === 'instructionAffirmationsQuery')!;
-
-    expect(customClaimTypes).toContain('orderBy: [CREATED_BLOCK_ID_ASC, ID_ASC]');
-    expect(affirmations).toContain('orderBy: [CREATED_BLOCK_ID_DESC, ID_DESC]');
+    expect(queryFor(CUSTOM_CLAIM_TYPES)).toContain('orderBy: [CREATED_BLOCK_ID_ASC, ID_ASC]');
+    expect(queryFor(AFFIRMATIONS)).toContain('orderBy: [CREATED_BLOCK_ID_DESC, ID_DESC]');
   });
 
-  it('should prefer a composite event id over a block id plus a tiebreaker', () => {
-    // `instructions` and `instructionEvents` already order this way
-    const [, affirmations] = cases.find(([name]) => name === 'instructionAffirmationsQuery')!;
-
-    // `InstructionAffirmation` has no `createdEvent`, so `id` is the only unique column available
-    expect(affirmations).not.toContain('CREATED_EVENT_ID');
-  });
-
-  it('should let a caller replace the default order', () => {
-    expect(
-      print(
-        assetTransactionQuery(
-          { assetId: 'someAsset' },
-          undefined,
-          undefined,
-          AssetTransactionsOrderBy.DatetimeDesc
-        ).query
-      )
-    ).toContain('orderBy: [DATETIME_DESC]');
-    expect(
-      print(eventsByArgs({}, undefined, undefined, EventsOrderBy.BlockIdDesc).query)
-    ).toContain('orderBy: [BLOCK_ID_DESC]');
-    expect(
-      print(
-        multiSigProposalsQuery(
-          { multisigId: 'someAddress' },
-          undefined,
-          undefined,
-          MultiSigProposalsOrderBy.ProposalIdAsc
-        ).query
-      )
-    ).toContain('orderBy: [PROPOSAL_ID_ASC]');
-    expect(
-      print(
-        investmentsQuery(
-          { stoId: 1, offeringAssetId: 'someAsset' },
-          undefined,
-          undefined,
-          InvestmentsOrderBy.DatetimeAsc
-        ).query
-      )
-    ).toContain('orderBy: [DATETIME_ASC]');
+  it('should fall back to a tiebreaker only where no composite event id exists', () => {
+    // `instructions` and `instructionEvents` order by `createdEventId`; affirmations have none
+    expect(queryFor(AFFIRMATIONS)).not.toContain('CREATED_EVENT_ID');
   });
 
   it('should order MultiSig proposals numerically, since their id embeds an unpadded number', () => {
-    const [, proposals] = cases.find(([name]) => name === 'multiSigProposalsQuery')!;
-
-    expect(proposals).toContain('orderBy: [PROPOSAL_ID_DESC]');
     // ordering by `id` would place proposal 10 before proposal 9
-    expect(proposals).not.toContain('orderBy: [ID_DESC]');
+    expect(queryFor(PROPOSALS)).toContain('orderBy: [PROPOSAL_ID_DESC]');
+    expect(queryFor(PROPOSALS)).not.toContain(ID_DESC);
+  });
+
+  it('should let a caller replace the default order', () => {
+    const withOrder = [
+      [
+        print(
+          assetTransactionQuery(
+            { assetId },
+            undefined,
+            undefined,
+            AssetTransactionsOrderBy.DatetimeDesc
+          ).query
+        ),
+        'orderBy: [DATETIME_DESC]',
+      ],
+      [
+        print(eventsByArgs({}, undefined, undefined, EventsOrderBy.BlockIdDesc).query),
+        'orderBy: [BLOCK_ID_DESC]',
+      ],
+      [
+        print(
+          multiSigProposalsQuery(
+            { multisigId },
+            undefined,
+            undefined,
+            MultiSigProposalsOrderBy.ProposalIdAsc
+          ).query
+        ),
+        'orderBy: [PROPOSAL_ID_ASC]',
+      ],
+      [
+        print(
+          investmentsQuery(
+            { stoId: 1, offeringAssetId: assetId },
+            undefined,
+            undefined,
+            InvestmentsOrderBy.DatetimeAsc
+          ).query
+        ),
+        'orderBy: [DATETIME_ASC]',
+      ],
+    ];
+
+    withOrder.forEach(([query, order]) => expect(query).toContain(order));
   });
 });

--- a/src/middleware/__tests__/queries/polyxTransactions.ts
+++ b/src/middleware/__tests__/queries/polyxTransactions.ts
@@ -34,7 +34,7 @@ describe('polyxTransactionsQuery', () => {
     expect(print(query)).toContain('orderBy: [ID_DESC]');
   });
 
-  it('should pass a requested ordering straight through', () => {
+  it('should put a requested ordering first, ahead of the key that makes it unique', () => {
     const { query } = polyxTransactionsQuery(
       {},
       undefined,
@@ -42,7 +42,7 @@ describe('polyxTransactionsQuery', () => {
       PolyxTransactionsOrderBy.CreatedBlockIdAsc
     );
 
-    expect(print(query)).toContain('orderBy: [CREATED_BLOCK_ID_ASC]');
+    expect(print(query)).toContain('orderBy: [CREATED_BLOCK_ID_ASC, ID_DESC]');
   });
 
   it('should request totalCount, which the ResultSet count is built from', () => {

--- a/src/middleware/queries/assets.ts
+++ b/src/middleware/queries/assets.ts
@@ -144,7 +144,8 @@ export function assetTransactionQuery(
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<AssetTransaction, 'assetId'>>> {
-  const orderBy = `${AssetTransactionsOrderBy.CreatedBlockIdAsc}`;
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const orderBy = `${AssetTransactionsOrderBy.IdAsc}`;
 
   const query = gql`
     query AssetTransactionQuery($assetId: String!, $size: Int, $start: Int) {

--- a/src/middleware/queries/assets.ts
+++ b/src/middleware/queries/assets.ts
@@ -9,7 +9,6 @@ import {
   AssetHoldersOrderBy,
   AssetTransaction,
   AssetTransactionsOrderBy,
-  DistributionPayment,
   NftHolder,
   NftHoldersOrderBy,
 } from '~/middleware/types';
@@ -50,11 +49,11 @@ export function assetQuery(
  * Get asset held by a DID
  */
 export function assetHoldersQuery(
-  filters: QueryArgs<AssetHolder, 'identityId'>,
+  filters: QueryArgs<AssetHolder, 'identityId'> & { amount?: string },
   size?: BigNumber,
   start?: BigNumber,
   orderBy = AssetHoldersOrderBy.AssetIdAsc
-): QueryOptions<PaginatedQueryArgs<QueryArgs<DistributionPayment, 'distributionId'>>> {
+): QueryOptions<PaginatedQueryArgs<QueryArgs<AssetHolder, 'identityId'> & { amount?: string }>> {
   if (orderBy === AssetHoldersOrderBy.CreatedAtAsc) {
     orderBy = AssetHoldersOrderBy.CreatedBlockIdAsc;
   }
@@ -62,7 +61,11 @@ export function assetHoldersQuery(
     orderBy = AssetHoldersOrderBy.CreatedBlockIdDesc;
   }
 
-  const { args, filter } = createArgsAndFilters(filters, {});
+  // a holding is kept once created, so excluding zero balances has to happen in the query —
+  // filtering client side would leave `totalCount` and the cursor describing the unfiltered set
+  const { args, filter } = createArgsAndFilters(filters, {
+    amount: { type: 'BigFloat', operator: 'greaterThan' },
+  });
 
   const query = gql`
     query AssetHoldersQuery
@@ -76,6 +79,7 @@ export function assetHoldersQuery(
       ) {
         totalCount
         nodes {
+          amount
           asset {
             id
             ticker
@@ -100,11 +104,11 @@ export function assetHoldersQuery(
  * Get NFTs held by a DID
  */
 export function nftHoldersQuery(
-  filters: QueryArgs<NftHolder, 'identityId'>,
+  filters: QueryArgs<NftHolder, 'identityId'> & { nftIds?: number[] },
   size?: BigNumber,
   start?: BigNumber,
   orderBy = NftHoldersOrderBy.AssetIdAsc
-): QueryOptions<PaginatedQueryArgs<QueryArgs<NftHolder, 'identityId'>>> {
+): QueryOptions<PaginatedQueryArgs<QueryArgs<NftHolder, 'identityId'> & { nftIds?: number[] }>> {
   if (orderBy === NftHoldersOrderBy.CreatedAtAsc) {
     orderBy = NftHoldersOrderBy.CreatedBlockIdAsc;
   }
@@ -112,7 +116,11 @@ export function nftHoldersQuery(
     orderBy = NftHoldersOrderBy.CreatedBlockIdDesc;
   }
 
-  const { args, filter } = createArgsAndFilters(filters, {});
+  // a holding is kept once created, so excluding collections the Identity no longer holds any of
+  // has to happen in the query, or `totalCount` and the cursor describe the unfiltered set
+  const { args, filter } = createArgsAndFilters(filters, {
+    nftIds: { type: 'JSON', operator: 'notEqualTo' },
+  });
 
   const query = gql`
     query NftHolderQuery

--- a/src/middleware/queries/assets.ts
+++ b/src/middleware/queries/assets.ts
@@ -142,11 +142,10 @@ export function nftHoldersQuery(
 export function assetTransactionQuery(
   filters: QueryArgs<AssetTransaction, 'assetId'>,
   size?: BigNumber,
-  start?: BigNumber
-): QueryOptions<PaginatedQueryArgs<QueryArgs<AssetTransaction, 'assetId'>>> {
+  start?: BigNumber,
   // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  const orderBy = `${AssetTransactionsOrderBy.IdAsc}`;
-
+  orderBy: AssetTransactionsOrderBy = AssetTransactionsOrderBy.IdAsc
+): QueryOptions<PaginatedQueryArgs<QueryArgs<AssetTransaction, 'assetId'>>> {
   const query = gql`
     query AssetTransactionQuery($assetId: String!, $size: Int, $start: Int) {
       assetTransactions(
@@ -200,7 +199,8 @@ export function assetTransactionQuery(
 export function nftCollectionHolders(
   assetId: string,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  orderBy: NftHoldersOrderBy = NftHoldersOrderBy.IdentityIdDesc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<NftHolder, 'assetId'>>> {
   const query = gql`
     query NftCollectionHolders($assetId: String!, $size: Int, $start: Int) {
@@ -208,7 +208,7 @@ export function nftCollectionHolders(
         first: $size
         offset: $start
         filter: { assetId: { equalTo: $assetId }, nftIds: { notEqualTo: [] } }
-        orderBy: IDENTITY_ID_DESC
+        orderBy: [${orderBy}]
       ) {
         nodes {
           identityId

--- a/src/middleware/queries/assets.ts
+++ b/src/middleware/queries/assets.ts
@@ -2,7 +2,12 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
+import {
+  createArgsAndFilters,
+  getSizeAndOffset,
+  orderByClause,
+  toOrderByList,
+} from '~/middleware/queries/common';
 import {
   Asset,
   AssetHolder,
@@ -52,14 +57,22 @@ export function assetHoldersQuery(
   filters: QueryArgs<AssetHolder, 'identityId'> & { amount?: string },
   size?: BigNumber,
   start?: BigNumber,
-  orderBy = AssetHoldersOrderBy.AssetIdAsc
+  orderBy?: AssetHoldersOrderBy | AssetHoldersOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<AssetHolder, 'identityId'> & { amount?: string }>> {
-  if (orderBy === AssetHoldersOrderBy.CreatedAtAsc) {
-    orderBy = AssetHoldersOrderBy.CreatedBlockIdAsc;
-  }
-  if (orderBy === AssetHoldersOrderBy.CreatedAtDesc) {
-    orderBy = AssetHoldersOrderBy.CreatedBlockIdDesc;
-  }
+  // the indexer exposes no `createdAt` ordering; both map onto block order
+  const supplied = toOrderByList(orderBy).map(key => {
+    if (key === AssetHoldersOrderBy.CreatedAtAsc) {
+      return AssetHoldersOrderBy.CreatedBlockIdAsc;
+    }
+    if (key === AssetHoldersOrderBy.CreatedAtDesc) {
+      return AssetHoldersOrderBy.CreatedBlockIdDesc;
+    }
+
+    return key;
+  });
+
+  // a holding is unique per Asset given the Identity this always filters by
+  const ordering = orderByClause(supplied, [AssetHoldersOrderBy.AssetIdAsc]);
 
   // a holding is kept once created, so excluding zero balances has to happen in the query —
   // filtering client side would leave `totalCount` and the cursor describing the unfiltered set
@@ -75,7 +88,7 @@ export function assetHoldersQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {
@@ -107,14 +120,22 @@ export function nftHoldersQuery(
   filters: QueryArgs<NftHolder, 'identityId'> & { nftIds?: number[] },
   size?: BigNumber,
   start?: BigNumber,
-  orderBy = NftHoldersOrderBy.AssetIdAsc
+  orderBy?: NftHoldersOrderBy | NftHoldersOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<NftHolder, 'identityId'> & { nftIds?: number[] }>> {
-  if (orderBy === NftHoldersOrderBy.CreatedAtAsc) {
-    orderBy = NftHoldersOrderBy.CreatedBlockIdAsc;
-  }
-  if (orderBy === NftHoldersOrderBy.CreatedAtDesc) {
-    orderBy = NftHoldersOrderBy.CreatedBlockIdDesc;
-  }
+  // the indexer exposes no `createdAt` ordering; both map onto block order
+  const supplied = toOrderByList(orderBy).map(key => {
+    if (key === NftHoldersOrderBy.CreatedAtAsc) {
+      return NftHoldersOrderBy.CreatedBlockIdAsc;
+    }
+    if (key === NftHoldersOrderBy.CreatedAtDesc) {
+      return NftHoldersOrderBy.CreatedBlockIdDesc;
+    }
+
+    return key;
+  });
+
+  // a holding is unique per Asset given the Identity this always filters by
+  const ordering = orderByClause(supplied, [NftHoldersOrderBy.AssetIdAsc]);
 
   // a holding is kept once created, so excluding collections the Identity no longer holds any of
   // has to happen in the query, or `totalCount` and the cursor describe the unfiltered set
@@ -130,7 +151,7 @@ export function nftHoldersQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {
@@ -159,10 +180,12 @@ export function assetTransactionQuery(
   filters: QueryArgs<AssetTransaction, 'assetId'>,
   size?: BigNumber,
   start?: BigNumber,
-  // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  orderBy: AssetTransactionsOrderBy = AssetTransactionsOrderBy.IdAsc
+  orderBy?: AssetTransactionsOrderBy | AssetTransactionsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<AssetTransaction, 'assetId'>>> {
   const { args, filter } = createArgsAndFilters(filters, {});
+
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const ordering = orderByClause(orderBy, [AssetTransactionsOrderBy.IdAsc]);
 
   const query = gql`
     query AssetTransactionQuery
@@ -172,7 +195,7 @@ export function assetTransactionQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy:  [${orderBy}]
+        orderBy:  [${ordering}]
       ) {
         totalCount
         nodes {
@@ -220,15 +243,18 @@ export function nftCollectionHolders(
   assetId: string,
   size?: BigNumber,
   start?: BigNumber,
-  orderBy: NftHoldersOrderBy = NftHoldersOrderBy.IdentityIdDesc
+  orderBy?: NftHoldersOrderBy | NftHoldersOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<NftHolder, 'assetId'>>> {
+  // a holder appears once per collection, which this always filters by
+  const ordering = orderByClause(orderBy, [NftHoldersOrderBy.IdentityIdDesc]);
+
   const query = gql`
     query NftCollectionHolders($assetId: String!, $size: Int, $start: Int) {
       nftHolders(
         first: $size
         offset: $start
         filter: { assetId: { equalTo: $assetId }, nftIds: { notEqualTo: [] } }
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         nodes {
           identityId

--- a/src/middleware/queries/assets.ts
+++ b/src/middleware/queries/assets.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
 import {
   Asset,
   AssetHolder,
@@ -62,10 +62,14 @@ export function assetHoldersQuery(
     orderBy = AssetHoldersOrderBy.CreatedBlockIdDesc;
   }
 
+  const { args, filter } = createArgsAndFilters(filters, {});
+
   const query = gql`
-    query AssetHoldersQuery($identityId: String!, $size: Int, $start: Int) {
+    query AssetHoldersQuery
+      ${args}
+     {
       assetHolders(
-        filter: { identityId: { equalTo: $identityId } }
+        ${filter}
         first: $size
         offset: $start
         orderBy: [${orderBy}]
@@ -108,10 +112,14 @@ export function nftHoldersQuery(
     orderBy = NftHoldersOrderBy.CreatedBlockIdDesc;
   }
 
+  const { args, filter } = createArgsAndFilters(filters, {});
+
   const query = gql`
-    query NftHolderQuery($identityId: String!, $size: Int, $start: Int) {
+    query NftHolderQuery
+      ${args}
+     {
       nftHolders(
-        filter: { identityId: { equalTo: $identityId } }
+        ${filter}
         first: $size
         offset: $start
         orderBy: [${orderBy}]
@@ -146,10 +154,14 @@ export function assetTransactionQuery(
   // `id` is `<block>/<event index>`, zero padded: block order, and unique
   orderBy: AssetTransactionsOrderBy = AssetTransactionsOrderBy.IdAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<AssetTransaction, 'assetId'>>> {
+  const { args, filter } = createArgsAndFilters(filters, {});
+
   const query = gql`
-    query AssetTransactionQuery($assetId: String!, $size: Int, $start: Int) {
+    query AssetTransactionQuery
+      ${args}
+     {
       assetTransactions(
-        filter: { assetId: { equalTo: $assetId } }
+        ${filter}
         first: $size
         offset: $start
         orderBy:  [${orderBy}]

--- a/src/middleware/queries/authorizations.ts
+++ b/src/middleware/queries/authorizations.ts
@@ -54,11 +54,10 @@ function createAuthorizationFilters(variables: QueryArgs<Authorization, Authoriz
 export function authorizationsQuery(
   filters: QueryArgs<Authorization, AuthorizationArgs>,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  orderBy: AuthorizationsOrderBy = AuthorizationsOrderBy.CreatedEventIdAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Authorization, AuthorizationArgs>>> {
   const { args, filter } = createAuthorizationFilters(filters);
-
-  const orderBy = `${AuthorizationsOrderBy.CreatedEventIdAsc}`;
 
   const query = gql`
     query AuthorizationsQuery

--- a/src/middleware/queries/authorizations.ts
+++ b/src/middleware/queries/authorizations.ts
@@ -2,7 +2,11 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { getSizeAndOffset, removeUndefinedValues } from '~/middleware/queries/common';
+import {
+  getSizeAndOffset,
+  orderByClause,
+  removeUndefinedValues,
+} from '~/middleware/queries/common';
 import { Authorization, AuthorizationsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
 
@@ -55,9 +59,12 @@ export function authorizationsQuery(
   filters: QueryArgs<Authorization, AuthorizationArgs>,
   size?: BigNumber,
   start?: BigNumber,
-  orderBy: AuthorizationsOrderBy = AuthorizationsOrderBy.CreatedEventIdAsc
+  orderBy?: AuthorizationsOrderBy | AuthorizationsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Authorization, AuthorizationArgs>>> {
   const { args, filter } = createAuthorizationFilters(filters);
+
+  // `createdEventId` is the composite of block and event index, and unique
+  const ordering = orderByClause(orderBy, [AuthorizationsOrderBy.CreatedEventIdAsc]);
 
   const query = gql`
     query AuthorizationsQuery
@@ -67,7 +74,7 @@ export function authorizationsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {

--- a/src/middleware/queries/claims.ts
+++ b/src/middleware/queries/claims.ts
@@ -115,11 +115,11 @@ export function claimsGroupingQuery(
 export function claimsQuery(
   filters: ClaimsQueryFilter,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  // block and event index together are unique, so this is a total order per target
+  orderBy = `${ClaimsOrderBy.TargetIdAsc}, ${ClaimsOrderBy.CreatedBlockIdAsc}, ${ClaimsOrderBy.EventIdxAsc}`
 ): QueryOptions<PaginatedQueryArgs<ClaimsQueryFilter>> {
   const { args, filter } = createClaimsFilters(filters);
-
-  const orderBy = `${ClaimsOrderBy.TargetIdAsc}, ${ClaimsOrderBy.CreatedBlockIdAsc}, ${ClaimsOrderBy.EventIdxAsc}`;
 
   const query = gql`
     query ClaimsQuery
@@ -256,12 +256,11 @@ export interface CustomClaimTypesQuery {
 export function customClaimTypeQuery(
   size?: BigNumber,
   start?: BigNumber,
-  dids?: string[]
+  dids?: string[],
+  // a custom claim type's `id` is the chain's numeric id, unpadded, so it serves only as a tiebreaker
+  orderBy = `${CustomClaimTypesOrderBy.CreatedBlockIdAsc}, ${CustomClaimTypesOrderBy.IdAsc}`
 ): QueryOptions<PaginatedQueryArgs<CustomClaimTypesQuery>> {
   const { args, filter } = createCustomClaimTypeQueryFilters({ ...(dids && { dids }) });
-
-  // a custom claim type's `id` is the chain's numeric id, unpadded, so it serves only as a tiebreaker
-  const orderBy = `${CustomClaimTypesOrderBy.CreatedBlockIdAsc}, ${CustomClaimTypesOrderBy.IdAsc}`;
 
   const query = gql`
   query CustomClaimTypesQuery

--- a/src/middleware/queries/claims.ts
+++ b/src/middleware/queries/claims.ts
@@ -2,7 +2,11 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { getSizeAndOffset, removeUndefinedValues } from '~/middleware/queries/common';
+import {
+  getSizeAndOffset,
+  orderByClause,
+  removeUndefinedValues,
+} from '~/middleware/queries/common';
 import {
   ClaimsOrderBy,
   ClaimTypeEnum,
@@ -79,10 +83,12 @@ export interface ClaimsQueryFilter {
  */
 export function claimsGroupingQuery(
   variables: ClaimsQueryFilter,
-  orderBy = ClaimsOrderBy.TargetIdAsc,
+  orderBy?: ClaimsOrderBy | ClaimsOrderBy[],
   groupBy = 'TARGET_ID'
 ): QueryOptions<PaginatedQueryArgs<ClaimsQueryFilter>> {
   const { args, filter } = createClaimsFilters(variables);
+
+  const ordering = orderByClause(orderBy, [ClaimsOrderBy.TargetIdAsc]);
 
   const query = gql`
     query claimsGroupingQuery
@@ -90,7 +96,7 @@ export function claimsGroupingQuery(
      {
       claims(
         ${filter}
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
         first: $size
         offset: $start
       ) {
@@ -116,10 +122,16 @@ export function claimsQuery(
   filters: ClaimsQueryFilter,
   size?: BigNumber,
   start?: BigNumber,
-  // block and event index together are unique, so this is a total order per target
-  orderBy = `${ClaimsOrderBy.TargetIdAsc}, ${ClaimsOrderBy.CreatedBlockIdAsc}, ${ClaimsOrderBy.EventIdxAsc}`
+  orderBy?: ClaimsOrderBy | ClaimsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<ClaimsQueryFilter>> {
   const { args, filter } = createClaimsFilters(filters);
+
+  // block and event index together are unique, so this is a total order per target
+  const ordering = orderByClause(orderBy, [
+    ClaimsOrderBy.TargetIdAsc,
+    ClaimsOrderBy.CreatedBlockIdAsc,
+    ClaimsOrderBy.EventIdxAsc,
+  ]);
 
   const query = gql`
     query ClaimsQuery
@@ -127,7 +139,7 @@ export function claimsQuery(
       {
         claims(
           ${filter}
-          orderBy: [${orderBy}]
+          orderBy: [${ordering}]
           first: $size
           offset: $start
         ) {
@@ -257,10 +269,15 @@ export function customClaimTypeQuery(
   size?: BigNumber,
   start?: BigNumber,
   dids?: string[],
-  // a custom claim type's `id` is the chain's numeric id, unpadded, so it serves only as a tiebreaker
-  orderBy = `${CustomClaimTypesOrderBy.CreatedBlockIdAsc}, ${CustomClaimTypesOrderBy.IdAsc}`
+  orderBy?: CustomClaimTypesOrderBy | CustomClaimTypesOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<CustomClaimTypesQuery>> {
   const { args, filter } = createCustomClaimTypeQueryFilters({ ...(dids && { dids }) });
+
+  // a custom claim type's `id` is the chain's numeric id, unpadded, so it serves only as a tiebreaker
+  const ordering = orderByClause(orderBy, [
+    CustomClaimTypesOrderBy.CreatedBlockIdAsc,
+    CustomClaimTypesOrderBy.IdAsc,
+  ]);
 
   const query = gql`
   query CustomClaimTypesQuery
@@ -270,7 +287,7 @@ export function customClaimTypeQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ){
         nodes {
           id

--- a/src/middleware/queries/claims.ts
+++ b/src/middleware/queries/claims.ts
@@ -6,6 +6,7 @@ import { getSizeAndOffset, removeUndefinedValues } from '~/middleware/queries/co
 import {
   ClaimsOrderBy,
   ClaimTypeEnum,
+  CustomClaimTypesOrderBy,
   TrustedClaimIssuer,
   TrustedClaimIssuersOrderBy,
 } from '~/middleware/types';
@@ -259,6 +260,9 @@ export function customClaimTypeQuery(
 ): QueryOptions<PaginatedQueryArgs<CustomClaimTypesQuery>> {
   const { args, filter } = createCustomClaimTypeQueryFilters({ ...(dids && { dids }) });
 
+  // a custom claim type's `id` is the chain's numeric id, unpadded, so it serves only as a tiebreaker
+  const orderBy = `${CustomClaimTypesOrderBy.CreatedBlockIdAsc}, ${CustomClaimTypesOrderBy.IdAsc}`;
+
   const query = gql`
   query CustomClaimTypesQuery
     ${args}
@@ -267,6 +271,7 @@ export function customClaimTypeQuery(
         ${filter}
         first: $size
         offset: $start
+        orderBy: [${orderBy}]
       ){
         nodes {
           id

--- a/src/middleware/queries/common.ts
+++ b/src/middleware/queries/common.ts
@@ -105,9 +105,30 @@ export function latestSqVersionQuery(): QueryOptions {
  *
  * @hidden
  */
+/**
+ * @hidden
+ *
+ * How a filter attribute is turned into a GQL variable and comparison
+ */
+export interface FilterSpec {
+  /**
+   * GQL type of the variable. Defaults to `String`
+   */
+  type?: string;
+  /**
+   * GQL comparison to apply. Defaults to `equalTo`
+   */
+  operator?: string;
+}
+
+/**
+ * @hidden
+ *
+ * Build the GQL argument list and `filter:` block for the attributes actually supplied
+ */
 export function createArgsAndFilters(
   filters: Record<string, unknown>,
-  typeMap: Record<string, string>
+  typeMap: Record<string, string | FilterSpec>
 ): {
   args: string;
   filter: string;
@@ -117,9 +138,12 @@ export function createArgsAndFilters(
 
   Object.keys(filters).forEach(attribute => {
     if (filters[attribute]) {
-      const type = typeMap[attribute] ?? 'String';
+      const spec = typeMap[attribute];
+      const { type = 'String', operator = 'equalTo' } =
+        typeof spec === 'string' ? { type: spec } : spec ?? {};
+
       args.push(`$${attribute}: ${type}!`);
-      gqlFilters.push(`${attribute}: { equalTo: $${attribute} }`);
+      gqlFilters.push(`${attribute}: { ${operator}: $${attribute} }`);
     }
   });
 

--- a/src/middleware/queries/common.ts
+++ b/src/middleware/queries/common.ts
@@ -137,14 +137,20 @@ export function createArgsAndFilters(
   const gqlFilters: string[] = [];
 
   Object.keys(filters).forEach(attribute => {
-    if (filters[attribute]) {
-      const spec = typeMap[attribute];
-      const { type = 'String', operator = 'equalTo' } =
-        typeof spec === 'string' ? { type: spec } : spec ?? {};
-
-      args.push(`$${attribute}: ${type}!`);
-      gqlFilters.push(`${attribute}: { ${operator}: $${attribute} }`);
+    /*
+     * a supplied value is filtered on even when it is falsy: `success: 0` means "only the failed
+     * ones", and dropping it returned everything instead
+     */
+    if (filters[attribute] === undefined || filters[attribute] === null) {
+      return;
     }
+
+    const spec = typeMap[attribute] ?? {};
+    const { type = 'String', operator = 'equalTo' } =
+      typeof spec === 'string' ? { type: spec } : spec;
+
+    args.push(`$${attribute}: ${type}!`);
+    gqlFilters.push(`${attribute}: { ${operator}: $${attribute} }`);
   });
 
   return {

--- a/src/middleware/queries/common.ts
+++ b/src/middleware/queries/common.ts
@@ -160,6 +160,53 @@ export function createArgsAndFilters(
 }
 
 /**
+ * @hidden
+ *
+ * The column an ordering key names, without its direction
+ */
+function orderByColumn(key: string): string {
+  return key.replace(/_(ASC|DESC)$/, '');
+}
+
+/**
+ * @hidden
+ *
+ * Read an ordering the caller may have given as one key or as several
+ */
+export function toOrderByList<Key>(orderBy?: Key | Key[]): Key[] {
+  if (orderBy === undefined) {
+    return [];
+  }
+
+  return Array.isArray(orderBy) ? orderBy : [orderBy];
+}
+
+/**
+ * @hidden
+ *
+ * Build a paginated query's `orderBy` list from the ordering the caller supplied.
+ *
+ * What a caller asks for comes first, and the query's own ordering follows it, rather than being
+ * replaced by it: `first`/`offset` paging over an order that does not decide every row repeats and
+ * skips rows, so the keys that make the order unique are appended, except where the caller already
+ * orders by that column and has said which direction they want it in
+ *
+ * @param orderBy - ordering the caller supplied, if any
+ * @param tiebreaker - the keys that make this query's order unique, which are also its default
+ */
+export function orderByClause<Key extends string>(
+  orderBy: Key | Key[] | undefined,
+  tiebreaker: Key[]
+): string {
+  const supplied = toOrderByList(orderBy);
+  const orderedColumns = new Set(supplied.map(orderByColumn));
+
+  return [...supplied, ...tiebreaker.filter(key => !orderedColumns.has(orderByColumn(key)))].join(
+    ', '
+  );
+}
+
+/**
  * Create args and filters to be supplied to GQL query
  *
  * @param size - size of the page

--- a/src/middleware/queries/distributions.ts
+++ b/src/middleware/queries/distributions.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
 import { Distribution, DistributionPayment, DistributionPaymentsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
 
@@ -42,10 +42,14 @@ export function distributionPaymentsQuery(
   // `id` is `<block>/<event index>`, zero padded: chronological, and unique
   orderBy: DistributionPaymentsOrderBy = DistributionPaymentsOrderBy.IdAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<DistributionPayment, 'distributionId'>>> {
+  const { args, filter } = createArgsAndFilters(filters, {});
+
   const query = gql`
-    query DistributionPaymentQuery($distributionId: String!, $size: Int, $start: Int) {
+    query DistributionPaymentQuery
+      ${args}
+     {
       distributionPayments(
-        filter: { distributionId: { equalTo: $distributionId } }
+        ${filter}
         first: $size
         offset: $start
         orderBy: [${orderBy}]

--- a/src/middleware/queries/distributions.ts
+++ b/src/middleware/queries/distributions.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset, orderByClause } from '~/middleware/queries/common';
 import { Distribution, DistributionPayment, DistributionPaymentsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
 
@@ -39,10 +39,12 @@ export function distributionPaymentsQuery(
   filters: QueryArgs<DistributionPayment, 'distributionId'>,
   size?: BigNumber,
   start?: BigNumber,
-  // `id` is `<block>/<event index>`, zero padded: chronological, and unique
-  orderBy: DistributionPaymentsOrderBy = DistributionPaymentsOrderBy.IdAsc
+  orderBy?: DistributionPaymentsOrderBy | DistributionPaymentsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<DistributionPayment, 'distributionId'>>> {
   const { args, filter } = createArgsAndFilters(filters, {});
+
+  // `id` is `<block>/<event index>`, zero padded: chronological, and unique
+  const ordering = orderByClause(orderBy, [DistributionPaymentsOrderBy.IdAsc]);
 
   const query = gql`
     query DistributionPaymentQuery
@@ -52,7 +54,7 @@ export function distributionPaymentsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {

--- a/src/middleware/queries/distributions.ts
+++ b/src/middleware/queries/distributions.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
 import { getSizeAndOffset } from '~/middleware/queries/common';
-import { Distribution, DistributionPayment } from '~/middleware/types';
+import { Distribution, DistributionPayment, DistributionPaymentsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
 
 /**
@@ -40,12 +40,16 @@ export function distributionPaymentsQuery(
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<DistributionPayment, 'distributionId'>>> {
+  // `id` is `<block>/<event index>`, zero padded: chronological, and unique
+  const orderBy = `${DistributionPaymentsOrderBy.IdAsc}`;
+
   const query = gql`
     query DistributionPaymentQuery($distributionId: String!, $size: Int, $start: Int) {
       distributionPayments(
         filter: { distributionId: { equalTo: $distributionId } }
         first: $size
         offset: $start
+        orderBy: [${orderBy}]
       ) {
         totalCount
         nodes {

--- a/src/middleware/queries/distributions.ts
+++ b/src/middleware/queries/distributions.ts
@@ -38,11 +38,10 @@ export function distributionQuery(
 export function distributionPaymentsQuery(
   filters: QueryArgs<DistributionPayment, 'distributionId'>,
   size?: BigNumber,
-  start?: BigNumber
-): QueryOptions<PaginatedQueryArgs<QueryArgs<DistributionPayment, 'distributionId'>>> {
+  start?: BigNumber,
   // `id` is `<block>/<event index>`, zero padded: chronological, and unique
-  const orderBy = `${DistributionPaymentsOrderBy.IdAsc}`;
-
+  orderBy: DistributionPaymentsOrderBy = DistributionPaymentsOrderBy.IdAsc
+): QueryOptions<PaginatedQueryArgs<QueryArgs<DistributionPayment, 'distributionId'>>> {
   const query = gql`
     query DistributionPaymentQuery($distributionId: String!, $size: Int, $start: Int) {
       distributionPayments(

--- a/src/middleware/queries/events.ts
+++ b/src/middleware/queries/events.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset, orderByClause } from '~/middleware/queries/common';
 import { Event, EventsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
 
@@ -17,13 +17,15 @@ export function eventsByArgs(
   filters: QueryArgs<Event, EventArgs>,
   size?: BigNumber,
   start?: BigNumber,
-  // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  orderBy: EventsOrderBy = EventsOrderBy.IdAsc
+  orderBy?: EventsOrderBy | EventsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Event, EventArgs>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     moduleId: 'ModuleIdEnum',
     eventId: 'EventIdEnum',
   });
+
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const ordering = orderByClause(orderBy, [EventsOrderBy.IdAsc]);
 
   const query = gql`
     query EventsQuery
@@ -31,7 +33,7 @@ export function eventsByArgs(
      {
       events(
         ${filter}
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
         first: $size
         offset: $start
       ) {

--- a/src/middleware/queries/events.ts
+++ b/src/middleware/queries/events.ts
@@ -23,7 +23,8 @@ export function eventsByArgs(
     eventId: 'EventIdEnum',
   });
 
-  const orderBy = `${EventsOrderBy.BlockIdAsc}`;
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const orderBy = `${EventsOrderBy.IdAsc}`;
 
   const query = gql`
     query EventsQuery

--- a/src/middleware/queries/events.ts
+++ b/src/middleware/queries/events.ts
@@ -16,15 +16,14 @@ type EventArgs = 'moduleId' | 'eventId' | 'eventArg0' | 'eventArg1' | 'eventArg2
 export function eventsByArgs(
   filters: QueryArgs<Event, EventArgs>,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  orderBy: EventsOrderBy = EventsOrderBy.IdAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Event, EventArgs>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     moduleId: 'ModuleIdEnum',
     eventId: 'EventIdEnum',
   });
-
-  // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  const orderBy = `${EventsOrderBy.IdAsc}`;
 
   const query = gql`
     query EventsQuery

--- a/src/middleware/queries/externalAgents.ts
+++ b/src/middleware/queries/externalAgents.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset, orderByClause } from '~/middleware/queries/common';
 import {
   TickerExternalAgent,
   TickerExternalAgentAction,
@@ -94,12 +94,15 @@ export function tickerExternalAgentActionsQuery(
   filters: QueryArgs<TickerExternalAgentAction, TickerExternalAgentActionArgs>,
   size?: BigNumber,
   start?: BigNumber,
-  // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  orderBy: TickerExternalAgentActionsOrderBy = TickerExternalAgentActionsOrderBy.IdDesc
+  orderBy?: TickerExternalAgentActionsOrderBy | TickerExternalAgentActionsOrderBy[]
 ): QueryOptions<
   PaginatedQueryArgs<QueryArgs<TickerExternalAgentAction, TickerExternalAgentActionArgs>>
 > {
   const { args, filter } = createArgsAndFilters(filters, { eventId: 'EventIdEnum' });
+
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const ordering = orderByClause(orderBy, [TickerExternalAgentActionsOrderBy.IdDesc]);
+
   const query = gql`
     query TickerExternalAgentActionsQuery
       ${args}
@@ -108,7 +111,7 @@ export function tickerExternalAgentActionsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {

--- a/src/middleware/queries/externalAgents.ts
+++ b/src/middleware/queries/externalAgents.ts
@@ -98,7 +98,8 @@ export function tickerExternalAgentActionsQuery(
   PaginatedQueryArgs<QueryArgs<TickerExternalAgentAction, TickerExternalAgentActionArgs>>
 > {
   const { args, filter } = createArgsAndFilters(filters, { eventId: 'EventIdEnum' });
-  const orderBy = `${TickerExternalAgentActionsOrderBy.CreatedBlockIdDesc}`;
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const orderBy = `${TickerExternalAgentActionsOrderBy.IdDesc}`;
   const query = gql`
     query TickerExternalAgentActionsQuery
       ${args}

--- a/src/middleware/queries/externalAgents.ts
+++ b/src/middleware/queries/externalAgents.ts
@@ -93,13 +93,13 @@ type TickerExternalAgentActionArgs = 'assetId' | 'callerId' | 'palletName' | 'ev
 export function tickerExternalAgentActionsQuery(
   filters: QueryArgs<TickerExternalAgentAction, TickerExternalAgentActionArgs>,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  orderBy: TickerExternalAgentActionsOrderBy = TickerExternalAgentActionsOrderBy.IdDesc
 ): QueryOptions<
   PaginatedQueryArgs<QueryArgs<TickerExternalAgentAction, TickerExternalAgentActionArgs>>
 > {
   const { args, filter } = createArgsAndFilters(filters, { eventId: 'EventIdEnum' });
-  // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  const orderBy = `${TickerExternalAgentActionsOrderBy.IdDesc}`;
   const query = gql`
     query TickerExternalAgentActionsQuery
       ${args}

--- a/src/middleware/queries/extrinsics.ts
+++ b/src/middleware/queries/extrinsics.ts
@@ -5,7 +5,9 @@ import gql from 'graphql-tag';
 import {
   createArgsAndFilters,
   getSizeAndOffset,
+  orderByClause,
   removeUndefinedValues,
+  toOrderByList,
 } from '~/middleware/queries/common';
 import { Extrinsic, ExtrinsicsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
@@ -58,8 +60,7 @@ export function extrinsicsByArgs(
   filters: QueryArgs<Extrinsic, ExtrinsicArgs>,
   size?: BigNumber,
   start?: BigNumber,
-  // `id` is `<block>/<extrinsic index>`, zero padded: block order, and unique
-  orderBy: ExtrinsicsOrderBy = ExtrinsicsOrderBy.IdAsc
+  orderBy?: ExtrinsicsOrderBy | ExtrinsicsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Extrinsic, ExtrinsicArgs>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     moduleId: 'ModuleIdEnum',
@@ -68,12 +69,19 @@ export function extrinsicsByArgs(
   });
 
   // the indexer exposes no `createdAt` ordering; both map onto block order
-  if (orderBy === ExtrinsicsOrderBy.CreatedAtAsc) {
-    orderBy = ExtrinsicsOrderBy.IdAsc;
-  }
-  if (orderBy === ExtrinsicsOrderBy.CreatedAtDesc) {
-    orderBy = ExtrinsicsOrderBy.IdDesc;
-  }
+  const supplied = toOrderByList(orderBy).map(key => {
+    if (key === ExtrinsicsOrderBy.CreatedAtAsc) {
+      return ExtrinsicsOrderBy.IdAsc;
+    }
+    if (key === ExtrinsicsOrderBy.CreatedAtDesc) {
+      return ExtrinsicsOrderBy.IdDesc;
+    }
+
+    return key;
+  });
+
+  // `id` is `<block>/<extrinsic index>`, zero padded: block order, and unique
+  const ordering = orderByClause(supplied, [ExtrinsicsOrderBy.IdAsc]);
 
   const query = gql`
     query TransactionsQuery
@@ -81,7 +89,7 @@ export function extrinsicsByArgs(
      {
       extrinsics(
         ${filter}
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
         first: $size
         offset: $start
       ) {

--- a/src/middleware/queries/extrinsics.ts
+++ b/src/middleware/queries/extrinsics.ts
@@ -58,7 +58,8 @@ export function extrinsicsByArgs(
   filters: QueryArgs<Extrinsic, ExtrinsicArgs>,
   size?: BigNumber,
   start?: BigNumber,
-  orderBy: ExtrinsicsOrderBy = ExtrinsicsOrderBy.BlockIdAsc
+  // `id` is `<block>/<extrinsic index>`, zero padded: block order, and unique
+  orderBy: ExtrinsicsOrderBy = ExtrinsicsOrderBy.IdAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Extrinsic, ExtrinsicArgs>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     moduleId: 'ModuleIdEnum',
@@ -66,11 +67,12 @@ export function extrinsicsByArgs(
     success: 'Int',
   });
 
+  // the indexer exposes no `createdAt` ordering; both map onto block order
   if (orderBy === ExtrinsicsOrderBy.CreatedAtAsc) {
-    orderBy = ExtrinsicsOrderBy.BlockIdAsc;
+    orderBy = ExtrinsicsOrderBy.IdAsc;
   }
   if (orderBy === ExtrinsicsOrderBy.CreatedAtDesc) {
-    orderBy = ExtrinsicsOrderBy.BlockIdDesc;
+    orderBy = ExtrinsicsOrderBy.IdDesc;
   }
 
   const query = gql`

--- a/src/middleware/queries/multisigs.ts
+++ b/src/middleware/queries/multisigs.ts
@@ -112,11 +112,10 @@ type MultiSigProposalQueryParameters = {
 export function multiSigProposalsQuery(
   multisigId: string,
   size?: BigNumber,
-  start?: BigNumber
-): QueryOptions<PaginatedQueryArgs<MultiSigProposalQueryParameters>> {
+  start?: BigNumber,
   // `id` embeds an unpadded proposal number; `proposalId` is an Int, and unique per multisig
-  const orderBy = `${MultiSigProposalsOrderBy.ProposalIdDesc}`;
-
+  orderBy: MultiSigProposalsOrderBy = MultiSigProposalsOrderBy.ProposalIdDesc
+): QueryOptions<PaginatedQueryArgs<MultiSigProposalQueryParameters>> {
   const query = gql`
     query MultiSigProposalsQuery($size: Int, $start: Int, $multisigId: String!) {
       multiSigProposals(

--- a/src/middleware/queries/multisigs.ts
+++ b/src/middleware/queries/multisigs.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset, orderByClause } from '~/middleware/queries/common';
 import {
   MultiSigProposal,
   MultiSigProposalsOrderBy,
@@ -109,10 +109,12 @@ export function multiSigProposalsQuery(
   filters: QueryArgs<MultiSigProposal, 'multisigId' | 'status'>,
   size?: BigNumber,
   start?: BigNumber,
-  // `id` embeds an unpadded proposal number; `proposalId` is an Int, and unique per multisig
-  orderBy: MultiSigProposalsOrderBy = MultiSigProposalsOrderBy.ProposalIdDesc
+  orderBy?: MultiSigProposalsOrderBy | MultiSigProposalsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<MultiSigProposal, 'multisigId' | 'status'>>> {
   const { args, filter } = createArgsAndFilters(filters, {});
+
+  // `id` embeds an unpadded proposal number; `proposalId` is an Int, and unique per multisig
+  const ordering = orderByClause(orderBy, [MultiSigProposalsOrderBy.ProposalIdDesc]);
 
   const query = gql`
     query MultiSigProposalsQuery
@@ -122,7 +124,7 @@ export function multiSigProposalsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         nodes {
           id

--- a/src/middleware/queries/multisigs.ts
+++ b/src/middleware/queries/multisigs.ts
@@ -5,6 +5,7 @@ import gql from 'graphql-tag';
 import { getSizeAndOffset } from '~/middleware/queries/common';
 import {
   MultiSigProposal,
+  MultiSigProposalsOrderBy,
   MultiSigProposalVote,
   MultiSigProposalVotesOrderBy,
 } from '~/middleware/types';
@@ -113,12 +114,16 @@ export function multiSigProposalsQuery(
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<MultiSigProposalQueryParameters>> {
+  // `id` embeds an unpadded proposal number; `proposalId` is an Int, and unique per multisig
+  const orderBy = `${MultiSigProposalsOrderBy.ProposalIdDesc}`;
+
   const query = gql`
     query MultiSigProposalsQuery($size: Int, $start: Int, $multisigId: String!) {
       multiSigProposals(
         filter: { multisigId: { equalTo: $multisigId } }
         first: $size
         offset: $start
+        orderBy: [${orderBy}]
       ) {
         nodes {
           id

--- a/src/middleware/queries/multisigs.ts
+++ b/src/middleware/queries/multisigs.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
 import {
   MultiSigProposal,
   MultiSigProposalsOrderBy,
@@ -100,26 +100,26 @@ export function multiSigProposalVotesQuery(
   };
 }
 
-type MultiSigProposalQueryParameters = {
-  multisigId: string;
-};
-
 /**
  * @hidden
  *
  * Get MultiSig Proposals history for a given MultiSig address
  */
 export function multiSigProposalsQuery(
-  multisigId: string,
+  filters: QueryArgs<MultiSigProposal, 'multisigId' | 'status'>,
   size?: BigNumber,
   start?: BigNumber,
   // `id` embeds an unpadded proposal number; `proposalId` is an Int, and unique per multisig
   orderBy: MultiSigProposalsOrderBy = MultiSigProposalsOrderBy.ProposalIdDesc
-): QueryOptions<PaginatedQueryArgs<MultiSigProposalQueryParameters>> {
+): QueryOptions<PaginatedQueryArgs<QueryArgs<MultiSigProposal, 'multisigId' | 'status'>>> {
+  const { args, filter } = createArgsAndFilters(filters, {});
+
   const query = gql`
-    query MultiSigProposalsQuery($size: Int, $start: Int, $multisigId: String!) {
+    query MultiSigProposalsQuery
+      ${args}
+     {
       multiSigProposals(
-        filter: { multisigId: { equalTo: $multisigId } }
+        ${filter}
         first: $size
         offset: $start
         orderBy: [${orderBy}]
@@ -140,6 +140,6 @@ export function multiSigProposalsQuery(
 
   return {
     query,
-    variables: { ...getSizeAndOffset(size, start), multisigId },
+    variables: { ...filters, ...getSizeAndOffset(size, start) },
   };
 }

--- a/src/middleware/queries/polyxTransactions.ts
+++ b/src/middleware/queries/polyxTransactions.ts
@@ -57,12 +57,7 @@ export function polyxTransactionsQuery(
   filters: QueryPolyxTransactionFilters,
   size?: BigNumber,
   start?: BigNumber,
-  /*
-   * `id` is the indexer's `<block number>/<event index>`, both zero padded, so it is unique and
-   * ordering it as a string orders by block and then by position within the block. Ordering by
-   * `createdBlockId` alone leaves transactions in the same block in no defined order, which makes
-   * pages repeat or skip entries
-   */
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
   orderBy: PolyxTransactionsOrderBy = PolyxTransactionsOrderBy.IdDesc
 ): QueryOptions<PaginatedQueryArgs<QueryPolyxTransactionFilters>> {
   const { args, filter, variables } = createPolyxTransactionFilters(filters);

--- a/src/middleware/queries/polyxTransactions.ts
+++ b/src/middleware/queries/polyxTransactions.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { getSizeAndOffset } from '~/middleware/queries/common';
+import { getSizeAndOffset, orderByClause } from '~/middleware/queries/common';
 import { PolyxTransactionsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs } from '~/types/utils';
 
@@ -57,10 +57,12 @@ export function polyxTransactionsQuery(
   filters: QueryPolyxTransactionFilters,
   size?: BigNumber,
   start?: BigNumber,
-  // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  orderBy: PolyxTransactionsOrderBy = PolyxTransactionsOrderBy.IdDesc
+  orderBy?: PolyxTransactionsOrderBy | PolyxTransactionsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryPolyxTransactionFilters>> {
   const { args, filter, variables } = createPolyxTransactionFilters(filters);
+
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const ordering = orderByClause(orderBy, [PolyxTransactionsOrderBy.IdDesc]);
 
   const query = gql`
     query PolyxTransactionsQuery
@@ -70,7 +72,7 @@ export function polyxTransactionsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {

--- a/src/middleware/queries/settlements.ts
+++ b/src/middleware/queries/settlements.ts
@@ -215,7 +215,8 @@ export function instructionAffirmationsQuery(
     isMediator: 'Boolean',
   });
 
-  const orderBy = `[${InstructionAffirmationsOrderBy.CreatedBlockIdDesc}]`;
+  // an affirmation's `id` is not time ordered, so it serves only as a tiebreaker
+  const orderBy = `[${InstructionAffirmationsOrderBy.CreatedBlockIdDesc}, ${InstructionAffirmationsOrderBy.IdDesc}]`;
 
   const query = gql`
     query InstructionAffirmationsQuery
@@ -420,7 +421,8 @@ export async function historicalInstructionsQuery(
     context
   );
 
-  const orderBy = `[${InstructionsOrderBy.CreatedBlockIdAsc}]`;
+  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
+  const orderBy = `[${InstructionsOrderBy.CreatedEventIdAsc}]`;
 
   const query = gql`
     query InstructionsQuery

--- a/src/middleware/queries/settlements.ts
+++ b/src/middleware/queries/settlements.ts
@@ -92,7 +92,11 @@ const instructionAffirmationAttributes = `
 type InstructionArgs = 'id' | 'venueId' | 'status';
 
 type InstructionPartiesVariables = Partial<
-  Record<keyof Omit<HistoricalInstructionFilters, 'status' | 'size' | 'start'>, string> & {
+  // `orderBy` is interpolated into the query, not sent as a variable, like `size` and `start`
+  Record<
+    keyof Omit<HistoricalInstructionFilters, 'status' | 'size' | 'start' | 'orderBy'>,
+    string
+  > & {
     status?: InstructionStatusEnum;
     size?: number;
     start?: number;
@@ -105,13 +109,13 @@ type InstructionPartiesVariables = Partial<
 export function instructionEventsQuery(
   filters: QueryArgs<InstructionEvent, 'event' | 'instructionId'>,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
+  orderBy: InstructionEventsOrderBy = InstructionEventsOrderBy.CreatedEventIdDesc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<InstructionEvent, 'event' | 'instructionId'>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     event: 'InstructionEventEnum',
   });
-
-  const orderBy = `[${InstructionEventsOrderBy.CreatedEventIdDesc}]`;
 
   const query = gql`
     query InstructionEventsQuery
@@ -121,7 +125,7 @@ export function instructionEventsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: ${orderBy}
+        orderBy: [${orderBy}]
       ) {
         totalCount
         nodes {
@@ -166,13 +170,13 @@ export function instructionEventsQuery(
 export function instructionsQuery(
   filters: QueryArgs<Instruction, InstructionArgs>,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
+  orderBy: InstructionsOrderBy = InstructionsOrderBy.CreatedEventIdDesc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Instruction, InstructionArgs>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     status: 'InstructionStatusEnum',
   });
-
-  const orderBy = `[${InstructionsOrderBy.CreatedEventIdDesc}]`;
 
   const query = gql`
     query InstructionsQuery
@@ -182,7 +186,7 @@ export function instructionsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: ${orderBy}
+        orderBy: [${orderBy}]
       ) {
         totalCount
         nodes {
@@ -208,15 +212,14 @@ type InstructionAffirmationArgs = 'instructionId' | 'status' | 'identity' | 'isM
 export function instructionAffirmationsQuery(
   filters: QueryArgs<InstructionAffirmation, InstructionAffirmationArgs>,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  // an affirmation's `id` is not time ordered, so it serves only as a tiebreaker
+  orderBy = `${InstructionAffirmationsOrderBy.CreatedBlockIdDesc}, ${InstructionAffirmationsOrderBy.IdDesc}`
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<InstructionAffirmation, InstructionAffirmationArgs>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     status: 'AffirmStatusEnum',
     isMediator: 'Boolean',
   });
-
-  // an affirmation's `id` is not time ordered, so it serves only as a tiebreaker
-  const orderBy = `[${InstructionAffirmationsOrderBy.CreatedBlockIdDesc}, ${InstructionAffirmationsOrderBy.IdDesc}]`;
 
   const query = gql`
     query InstructionAffirmationsQuery
@@ -226,7 +229,7 @@ export function instructionAffirmationsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: ${orderBy}
+        orderBy: [${orderBy}]
       ) {
         totalCount
         nodes {
@@ -286,7 +289,9 @@ export function offChainAffirmationsQuery(
 export function legsQuery(
   filters: QueryArgs<Leg, 'instructionId' | 'legType' | 'legIndex'>,
   size?: BigNumber,
-  start?: BigNumber
+  start?: BigNumber,
+  // `legIndex` is unique within the instruction this query always filters by
+  orderBy: LegsOrderBy = LegsOrderBy.LegIndexAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Leg, 'instructionId' | 'legType'>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     legType: 'LegTypeEnum',
@@ -300,7 +305,7 @@ export function legsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${LegsOrderBy.LegIndexAsc}]
+        orderBy: [${orderBy}]
       ) {
         totalCount
         nodes {
@@ -414,15 +419,16 @@ export const buildHistoricalInstructionsQueryFilter = async (
  */
 export async function historicalInstructionsQuery(
   filters: HistoricalInstructionFilters,
-  context: Context
-): Promise<QueryOptions<PaginatedQueryArgs<Omit<HistoricalInstructionFilters, 'size' | 'start'>>>> {
+  context: Context,
+  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
+  orderBy: InstructionsOrderBy = InstructionsOrderBy.CreatedEventIdAsc
+): Promise<
+  QueryOptions<PaginatedQueryArgs<Omit<HistoricalInstructionFilters, 'size' | 'start' | 'orderBy'>>>
+> {
   const { args, filter, variables } = await buildHistoricalInstructionsQueryFilter(
     filters,
     context
   );
-
-  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
-  const orderBy = `[${InstructionsOrderBy.CreatedEventIdAsc}]`;
 
   const query = gql`
     query InstructionsQuery
@@ -430,7 +436,7 @@ export async function historicalInstructionsQuery(
      {
       instructions(
         ${filter}
-        orderBy: ${orderBy}
+        orderBy: [${orderBy}]
         first: $size
         offset: $start
       ) {

--- a/src/middleware/queries/settlements.ts
+++ b/src/middleware/queries/settlements.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
 import { Context } from '~/internal';
-import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset, orderByClause } from '~/middleware/queries/common';
 import {
   Instruction,
   InstructionAffirmation,
@@ -110,12 +110,14 @@ export function instructionEventsQuery(
   filters: QueryArgs<InstructionEvent, 'event' | 'instructionId'>,
   size?: BigNumber,
   start?: BigNumber,
-  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
-  orderBy: InstructionEventsOrderBy = InstructionEventsOrderBy.CreatedEventIdDesc
+  orderBy?: InstructionEventsOrderBy | InstructionEventsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<InstructionEvent, 'event' | 'instructionId'>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     event: 'InstructionEventEnum',
   });
+
+  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
+  const ordering = orderByClause(orderBy, [InstructionEventsOrderBy.CreatedEventIdDesc]);
 
   const query = gql`
     query InstructionEventsQuery
@@ -125,7 +127,7 @@ export function instructionEventsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {
@@ -171,12 +173,14 @@ export function instructionsQuery(
   filters: QueryArgs<Instruction, InstructionArgs>,
   size?: BigNumber,
   start?: BigNumber,
-  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
-  orderBy: InstructionsOrderBy = InstructionsOrderBy.CreatedEventIdDesc
+  orderBy?: InstructionsOrderBy | InstructionsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Instruction, InstructionArgs>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     status: 'InstructionStatusEnum',
   });
+
+  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
+  const ordering = orderByClause(orderBy, [InstructionsOrderBy.CreatedEventIdDesc]);
 
   const query = gql`
     query InstructionsQuery
@@ -186,7 +190,7 @@ export function instructionsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {
@@ -213,13 +217,18 @@ export function instructionAffirmationsQuery(
   filters: QueryArgs<InstructionAffirmation, InstructionAffirmationArgs>,
   size?: BigNumber,
   start?: BigNumber,
-  // an affirmation's `id` is not time ordered, so it serves only as a tiebreaker
-  orderBy = `${InstructionAffirmationsOrderBy.CreatedBlockIdDesc}, ${InstructionAffirmationsOrderBy.IdDesc}`
+  orderBy?: InstructionAffirmationsOrderBy | InstructionAffirmationsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<InstructionAffirmation, InstructionAffirmationArgs>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     status: 'AffirmStatusEnum',
     isMediator: 'Boolean',
   });
+
+  // an affirmation's `id` is not time ordered, so it serves only as a tiebreaker
+  const ordering = orderByClause(orderBy, [
+    InstructionAffirmationsOrderBy.CreatedBlockIdDesc,
+    InstructionAffirmationsOrderBy.IdDesc,
+  ]);
 
   const query = gql`
     query InstructionAffirmationsQuery
@@ -229,7 +238,7 @@ export function instructionAffirmationsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {
@@ -290,13 +299,15 @@ export function legsQuery(
   filters: QueryArgs<Leg, 'instructionId' | 'legType' | 'legIndex'>,
   size?: BigNumber,
   start?: BigNumber,
-  // `legIndex` is unique within the instruction this query always filters by
-  orderBy: LegsOrderBy = LegsOrderBy.LegIndexAsc
+  orderBy?: LegsOrderBy | LegsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Leg, 'instructionId' | 'legType'>>> {
   const { args, filter } = createArgsAndFilters(filters, {
     legType: 'LegTypeEnum',
     legIndex: 'Int',
   });
+
+  // `legIndex` is unique within the instruction this query always filters by
+  const ordering = orderByClause(orderBy, [LegsOrderBy.LegIndexAsc]);
   const query = gql`
     query LegsQuery
       ${args}
@@ -305,7 +316,7 @@ export function legsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {
@@ -420,8 +431,7 @@ export const buildHistoricalInstructionsQueryFilter = async (
 export async function historicalInstructionsQuery(
   filters: HistoricalInstructionFilters,
   context: Context,
-  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
-  orderBy: InstructionsOrderBy = InstructionsOrderBy.CreatedEventIdAsc
+  orderBy?: InstructionsOrderBy | InstructionsOrderBy[]
 ): Promise<
   QueryOptions<PaginatedQueryArgs<Omit<HistoricalInstructionFilters, 'size' | 'start' | 'orderBy'>>>
 > {
@@ -430,13 +440,16 @@ export async function historicalInstructionsQuery(
     context
   );
 
+  // `createdEventId` is `<block>/<event index>`, zero padded: block order, and unique
+  const ordering = orderByClause(orderBy, [InstructionsOrderBy.CreatedEventIdAsc]);
+
   const query = gql`
     query InstructionsQuery
     ${args}
      {
       instructions(
         ${filter}
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
         first: $size
         offset: $start
       ) {

--- a/src/middleware/queries/stos.ts
+++ b/src/middleware/queries/stos.ts
@@ -16,7 +16,8 @@ export function investmentsQuery(
   size?: BigNumber,
   start?: BigNumber
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Investment, 'stoId' | 'offeringAssetId'>>> {
-  const orderBy = `${InvestmentsOrderBy.CreatedBlockIdAsc}`;
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const orderBy = `${InvestmentsOrderBy.IdAsc}`;
 
   const query = gql`
     query InvestmentsQuery($stoId: Int!, $offeringAssetId: String!, $size: Int, $start: Int) {

--- a/src/middleware/queries/stos.ts
+++ b/src/middleware/queries/stos.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset, orderByClause } from '~/middleware/queries/common';
 import { Investment, InvestmentsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
 
@@ -15,10 +15,12 @@ export function investmentsQuery(
   filters: QueryArgs<Investment, 'stoId' | 'offeringAssetId'>,
   size?: BigNumber,
   start?: BigNumber,
-  // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  orderBy: InvestmentsOrderBy = InvestmentsOrderBy.IdAsc
+  orderBy?: InvestmentsOrderBy | InvestmentsOrderBy[]
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Investment, 'stoId' | 'offeringAssetId'>>> {
   const { args, filter } = createArgsAndFilters(filters, { stoId: 'Int' });
+
+  // `id` is `<block>/<event index>`, zero padded: block order, and unique
+  const ordering = orderByClause(orderBy, [InvestmentsOrderBy.IdAsc]);
 
   const query = gql`
     query InvestmentsQuery
@@ -28,7 +30,7 @@ export function investmentsQuery(
         ${filter}
         first: $size
         offset: $start
-        orderBy: [${orderBy}]
+        orderBy: [${ordering}]
       ) {
         totalCount
         nodes {

--- a/src/middleware/queries/stos.ts
+++ b/src/middleware/queries/stos.ts
@@ -14,11 +14,10 @@ import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
 export function investmentsQuery(
   filters: QueryArgs<Investment, 'stoId' | 'offeringAssetId'>,
   size?: BigNumber,
-  start?: BigNumber
-): QueryOptions<PaginatedQueryArgs<QueryArgs<Investment, 'stoId' | 'offeringAssetId'>>> {
+  start?: BigNumber,
   // `id` is `<block>/<event index>`, zero padded: block order, and unique
-  const orderBy = `${InvestmentsOrderBy.IdAsc}`;
-
+  orderBy: InvestmentsOrderBy = InvestmentsOrderBy.IdAsc
+): QueryOptions<PaginatedQueryArgs<QueryArgs<Investment, 'stoId' | 'offeringAssetId'>>> {
   const query = gql`
     query InvestmentsQuery($stoId: Int!, $offeringAssetId: String!, $size: Int, $start: Int) {
       investments(

--- a/src/middleware/queries/stos.ts
+++ b/src/middleware/queries/stos.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '@apollo/client/core';
 import BigNumber from 'bignumber.js';
 import gql from 'graphql-tag';
 
-import { getSizeAndOffset } from '~/middleware/queries/common';
+import { createArgsAndFilters, getSizeAndOffset } from '~/middleware/queries/common';
 import { Investment, InvestmentsOrderBy } from '~/middleware/types';
 import { PaginatedQueryArgs, QueryArgs } from '~/types/utils';
 
@@ -18,10 +18,14 @@ export function investmentsQuery(
   // `id` is `<block>/<event index>`, zero padded: block order, and unique
   orderBy: InvestmentsOrderBy = InvestmentsOrderBy.IdAsc
 ): QueryOptions<PaginatedQueryArgs<QueryArgs<Investment, 'stoId' | 'offeringAssetId'>>> {
+  const { args, filter } = createArgsAndFilters(filters, { stoId: 'Int' });
+
   const query = gql`
-    query InvestmentsQuery($stoId: Int!, $offeringAssetId: String!, $size: Int, $start: Int) {
+    query InvestmentsQuery
+      ${args}
+     {
       investments(
-        filter: { stoId: { equalTo: $stoId }, offeringAssetId: { equalTo: $offeringAssetId } }
+        ${filter}
         first: $size
         offset: $start
         orderBy: [${orderBy}]


### PR DESCRIPTION
### Description

Ordering, filtering and paging fixes for indexer-backed reads. Five commits, each self-contained and green on its own.

**Ten paginated queries had no order that was both defined and unique.** Three had no `orderBy` at all — behind `Claims.getAllCustomClaimTypes`, `DividendDistribution.getPaymentHistory` and `MultiSig.getHistoricalProposals` — so the database was free to return rows in any order. Seven more ordered by a block-level field only, which leaves rows sharing a block undefined relative to each other. `first`/`offset` paging over an undefined order can show one row twice and never show another.

They now order by something unique. Where the indexer's `id` is block-derived it is used directly: it is `<block number>/<event index>` with both parts zero-padded, so ordering it as a string orders by block and then by position within the block. Where an id is *not* block-derived it is only a tiebreaker — a custom claim type's id is the chain's numeric id, and a MultiSig proposal's embeds an unpadded proposal number, so proposals order by `proposalId` instead. Sort direction is unchanged wherever one was defined.

**Falsy filter values were dropped.** The filter builder skipped any value failing a truthiness check, so `Account.getTransactionHistory({ success: false })` sent no `success` filter and returned *all* transactions rather than only the failed ones. `undefined` and `null` are now skipped; `0`, `''` and `false` are honoured.

**`orderBy` on every paginated query**, exposed on nine public reads: asset and NFT transaction history, distribution payments, MultiSig proposals, operation history, investments, custom claim types, historical authorizations, historical instructions and indexed events. Defaults are unchanged, so omitting it behaves exactly as before. Note a supplied ordering *replaces* the default outright, tiebreaker included.

**Filters are built from the attributes supplied.** Six queries wrote their `filter:` block by hand, so the set of filter fields was fixed and adding one meant editing the GraphQL. They now share the existing helper, which also gained comparisons beyond `equalTo`.

**`Identity.getAssetHoldings()`** returns each fungible Asset with the amount held, and takes `heldNow` to exclude holdings transferred away in full — the indexer keeps a holding record once it exists, so those otherwise come back at zero. The exclusion is applied **in the query**; filtering client-side would leave `count` and `next` describing the unfiltered set, so paging would give short pages against a cursor that never ends. `getHeldNfts` gains the same option. `getHeldAssets` is deprecated in favour of it.

### Breaking Changes

Each replaces silently wrong output with correct output. All listed in `changelogs/v31.0.0-next.md` under **Behaviour changes**.

- Ten paginated queries changed the relative order of rows that were previously tied. Sort direction is unchanged wherever one was defined.
- `Identity.getHeldAssets()` is deprecated, for removal in the next major. Otherwise unchanged.
- `multiSigProposalsQuery` takes a filters object rather than a bare address — internal only, one caller updated.

### Worth passing to the indexer team

- Ids are padded inconsistently. Event-derived ids are zero-padded so lexical order equals numeric, but `CustomClaimType`, `Instruction` and `MultiSigProposal` are not — ordering those by `id` puts proposal 10 before 9.
- `createdBlock` is unindexed on 8 of the 10 entities we order by. Moving to `id` sidesteps it (primary key), but `CREATED_BLOCK_ID_*` orderings want an index if they are to stay usable.
- `schema.graphql` and the served API disagree on scalars: every SubQuery `BigInt!` surfaces as `BigFloat`, so `schema.graphql` is not safe to write queries against — `src/middleware/types.ts` is.

### Follow-up

Left out deliberately, since each adds pagination surface and touches the shared `MiddlewarePaginationOptions` — better designed together than piecemeal:

- Paging the reads that still have none. `Portfolio.getTransactionHistory` and `Portfolios.getTransactionHistory` fetch every movement ever recorded.
- `PaginationOptions` on `Account`/`Portfolio.getAssetBalances` and `getCollections`.
- Adopting `MiddlewarePaginationOptions` across the indexer reads, which is also what unblocks `orderBy` on `Instruction.getAffirmations`, `getMediators` and `getLegs`.

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [x] Updated the Readme.md (if required) ?