### PR TITLE
fix: 🐛 read every options bag the same way in the API snapshot

### DIFF
--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -82,9 +82,12 @@ jobs:
           yarn api-snapshot:generate
           mv api-snapshot.json pr-api-snapshot.json
 
-      # # Checkout and build develop snapshot
-      # - name: Stash changes
-      #   run: git stash --include-untracked
+      # Checking out develop takes its scripts too, so keep the PR's. Both sides have to be
+      # described by the same tool for the comparison to read as one description of the API against
+      # another, rather than as one tool's output against another tool's — and without this, a fix
+      # to these scripts could never take effect on the PR that makes it
+      - name: Keep PR snapshot scripts
+        run: cp -r scripts "$RUNNER_TEMP/pr-scripts"
 
       - name: Checkout develop branch
         run: git checkout origin/develop
@@ -93,7 +96,12 @@ jobs:
         run: yarn install --immutable
 
       - name: Build develop declaration files
-        run: yarn build:declaration-only
+        run: |
+          rm -rf dist
+          yarn build:declaration-only
+
+      - name: Restore PR snapshot scripts
+        run: cp -r "$RUNNER_TEMP/pr-scripts/." scripts/
 
       - name: Generate develop API snapshot
         run: |

--- a/scripts/compareApiSnapshot.ts
+++ b/scripts/compareApiSnapshot.ts
@@ -77,7 +77,8 @@ const MEMBER_REGEX =
  * anything else — a named type, a union, an intersection — or holds a member we can't read
  */
 function parseObjectType(type: string): Map<string, ObjectMember> | null {
-  const trimmed = type.trim();
+  // an optional parameter prints as `T | undefined`; the `optional` flag already records that
+  const trimmed = type.trim().replace(/\s*\|\s*undefined$/, '');
 
   if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
 
@@ -192,7 +193,11 @@ function compareOverloads(
       const location = `${filePath} > ${parentName}.${methodName}: Param ${j + 1}`;
 
       if (bp?.name !== cp?.name || bp?.optional !== cp?.optional) {
-        logBreak(`${location} mismatch in overload #${i + 1}`);
+        logBreak(
+          `${location} mismatch in overload #${i + 1}: was '${bp.name}${
+            bp.optional ? '?' : ''
+          }', is now '${cp.name}${cp.optional ? '?' : ''}'`
+        );
         continue;
       }
 
@@ -200,7 +205,10 @@ function compareOverloads(
         const objectBreaks = compareObjectTypes(bp!.type, cp!.type);
 
         if (!objectBreaks) {
-          logBreak(`${location} mismatch in overload #${i + 1}`);
+          // say what moved: a type the members can't be read from is the hardest one to place
+          logBreak(
+            `${location} in overload #${i + 1}: type changed from '${bp!.type}' to '${cp!.type}'`
+          );
         } else {
           objectBreaks.forEach(reason => logBreak(`${location} in overload #${i + 1}: ${reason}`));
         }
@@ -209,7 +217,9 @@ function compareOverloads(
 
     if (baseSig.returnType !== currSig.returnType) {
       logBreak(
-        `${filePath} > ${parentName}.${methodName}: Return type changed in overload #${i + 1}`
+        `${filePath} > ${parentName}.${methodName}: Return type changed in overload #${
+          i + 1
+        }: from '${baseSig.returnType}' to '${currSig.returnType}'`
       );
     }
   });

--- a/scripts/generateApiSnapshot.ts
+++ b/scripts/generateApiSnapshot.ts
@@ -7,6 +7,8 @@ import {
   MethodDeclaration,
   ClassDeclaration,
   InterfaceDeclaration,
+  Type,
+  SymbolFlags,
 } from 'ts-morph';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -42,6 +44,134 @@ const files = project.getSourceFiles().filter(file => {
   );
 });
 
+/**
+ * Split a type's text on its top-level union bars, so that a bar inside an object, a generic or a
+ * parameter list stays where it is
+ */
+function splitTopLevelUnion(text: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!;
+
+    if ('{([<'.includes(char)) depth++;
+    // the `>` of an arrow closes nothing
+    else if (')]}'.includes(char) || (char === '>' && text[i - 1] !== '=')) depth--;
+
+    if (char === '|' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  parts.push(current);
+
+  return parts.map(part => part.trim()).filter(part => part.length > 0);
+}
+
+/**
+ * Put a type's text in a canonical form, so that the same type records the same text however the
+ * compiler happened to print it.
+ *
+ * A symbol the compiler can't reach from the node it is printing at comes out as
+ * `import("/abs/path").Name`, which makes the text depend on where the build ran. And the order of
+ * a union's members is the compiler's, not the source's, so it moves when an unrelated type
+ * changes.
+ *
+ * `dropUndefined` drops an `undefined` union member, for a position where the `optional` flag
+ * already records it. A return type keeps its own, where gaining `undefined` is a change callers
+ * feel
+ */
+function normalizeTypeText(text: string, { dropUndefined = false } = {}): string {
+  const withoutPaths = text.replace(/import\("[^"]*"\)\./g, '');
+  const members = splitTopLevelUnion(withoutPaths).filter(
+    member => !dropUndefined || member !== 'undefined'
+  );
+
+  if (members.length <= 1) {
+    return members[0] ?? withoutPaths.trim();
+  }
+
+  return members.sort().join(' | ');
+}
+
+/**
+ * Whether a type is an options bag — an object whose members a caller writes out one by one,
+ * however the type is spelled: an object literal, a named interface, or an intersection of both.
+ *
+ * Anything else records the name a caller knows it by, rather than being pulled apart: a class
+ * (`Identity`, `BigNumber`) or an interface with methods carries members no caller passes, and an
+ * array, a function or a primitive has no members to read
+ */
+function isOptionsBag(type: Type): boolean {
+  if (!type.isObject() && !type.isIntersection()) return false;
+
+  if (type.isArray() || type.isTuple()) return false;
+
+  if (type.getCallSignatures().length || type.getConstructSignatures().length) return false;
+
+  // a dependency's shape is not ours to describe, and the name is what a caller writes anyway
+  const declaredInDependency = type
+    .getSymbol()
+    ?.getDeclarations()
+    .some(declaration => declaration.getSourceFile().getFilePath().includes('/node_modules/'));
+
+  if (declaredInDependency) return false;
+
+  const properties = type.getProperties();
+
+  if (!properties.length) return false;
+
+  return properties.every(property =>
+    property.getDeclarations().every(declaration => Node.isPropertySignature(declaration))
+  );
+}
+
+/**
+ * Describe a parameter's type as the shape a caller sees, so that two spellings of the same shape
+ * record the same text and the comparison can read them member by member.
+ *
+ * Every options bag is read the same way, whether it is spelled out, named
+ * (`MiddlewarePaginationOptions`) or part-named (`MiddlewarePaginationOptions & { orderBy?: X }`),
+ * so that moving members behind a name records what spelling them out records. Reading them all
+ * the same way matters as much as flattening does: a member's own type is printed as the compiler
+ * resolves it, so a bag read one way and a bag read the other disagree over an alias
+ * (`ClaimTypeInput` for `TrustedFor`) that means nothing to a caller
+ */
+function describeType(type: Type, node: Node): string {
+  let described = type;
+
+  if (described.isUnion()) {
+    const defined = described.getUnionTypes().filter(member => !member.isUndefined());
+
+    if (defined.length !== 1) {
+      return normalizeTypeText(described.getText(node), { dropUndefined: true });
+    }
+
+    described = defined[0]!;
+  }
+
+  if (!isOptionsBag(described)) {
+    return normalizeTypeText(described.getText(node), { dropUndefined: true });
+  }
+
+  const members = described.getProperties().map(property => {
+    const optional = property.hasFlags(SymbolFlags.Optional) ? '?' : '';
+    const memberType = normalizeTypeText(property.getTypeAtLocation(node).getText(node), {
+      dropUndefined: optional === '?',
+    });
+
+    return `${property.getName()}${optional}: ${memberType};`;
+  });
+
+  // the compiler's member order is not the source's, so sort to keep an unrelated edit out of here
+  return `{ ${members.sort().join(' ')} }`;
+}
+
 function extractMethodOverloads(decl: ClassDeclaration | InterfaceDeclaration) {
   const methodsByName = new Map<string, MethodDeclaration[]>();
 
@@ -56,7 +186,7 @@ function extractMethodOverloads(decl: ClassDeclaration | InterfaceDeclaration) {
   return Array.from(methodsByName.entries()).map(([name, overloads]) => {
     const signatures = overloads.map(method => {
       const params = method.getParameters().map(param => {
-        const type = param.getType().getText(param);
+        const type = describeType(param.getType(), param);
         return {
           name: param.getName(),
           type,
@@ -64,7 +194,7 @@ function extractMethodOverloads(decl: ClassDeclaration | InterfaceDeclaration) {
         };
       });
 
-      const returnType = method.getReturnType().getText(method);
+      const returnType = normalizeTypeText(method.getReturnType().getText(method));
       return { parameters: params, returnType };
     });
 


### PR DESCRIPTION
### Description

The API snapshot flagged breaking changes where none had happened.

`describeType` read an options bag two different ways: an intersection was described by its **resolved members**, every other parameter by its **declared text**. Two descriptions of one shape disagree over things a caller never sees — an alias spelling (`ClaimTypeInput` for `TrustedFor`), a union's order (`string | Identity` vs `Identity | string`) — so moving members behind a shared name read as a break. A parameter typed as a bare name held no members to compare at all.

Now every options bag is read member by member, however it is spelled: an object literal, a named interface, or an intersection of both. Everything else keeps the name a caller knows it by — a class (`Identity`, `BigNumber`), an interface with methods, an array, a primitive, or a type a dependency declares, whose shape is not ours to describe (without that last one, `Context.queryMiddleware` pulled Apollo's `QueryOptions` into the snapshot and an Apollo bump would read as an API break).

Two smaller fixes:

- return types now run through the normalizer, so an absolute `import("/abs/path")` in a type can't make the result depend on where the build ran
- the two opaque `Param N mismatch` messages now say what actually changed

The workflow needed a fix as well. `git checkout origin/develop` took develop's `scripts/` along with develop's sources, so the base snapshot and the comparison both ran develop's tooling — the comparison read one tool's description against another tool's, and a fix to these scripts could never take effect on the PR that made it. The PR's `scripts/` are now kept across that checkout, so one tool describes both sides. `dist` is also cleared before the develop build, which was writing over the PR's and leaving stale files behind.

### Breaking Changes

None. Tooling only.

### Verification

Built `origin/develop` alongside a branch that moves pagination options behind a shared `MiddlewarePaginationOptions` type — the change that surfaced this:

- clean run, both sides described by the new generator: no findings (was 6+ false positives)
- five real breaks injected into develop's sources and rebuilt — member removed, member retyped, optional member made required (through a named interface, correctly cascading to 9 call sites), param renamed, method removed — all five still flagged
- an added **optional** member correctly ignored

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [x] Updated the Readme.md (if required) ?
