### PR TITLE
Staking: election schedule, nomination quota, and preconditions that match the chain

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -454,6 +454,12 @@ Sort direction is unchanged everywhere one was already defined, so only the rela
 
 `polyxTransactionsQuery` never selected `totalCount`, so the `count` on every `getPolyxTransactions` result was `NaN`. `next` is derived from it by `totalCount.gt(next) ? next : null`, and a `NaN` comparison is always false — so `next` was always `null` and a caller paging through history stopped after the first page, with no error to say why.
 
+### Rebonding with nothing unbonding
+
+`staking.rebond()` compared the amount against the total across the unlocking chunks, which nothing is not less than — so a rebond with nothing unbonding passed the check and was refused by the chain as `NoUnlockChunk`. That case is now its own error.
+
+Two behaviours of the chain are now documented rather than left to be discovered: `rebond` takes from the most recently unbonded POLYX first, so a partial rebond leaves the lots closest to maturing where they are; and `unbond` chills a stash that unbonds its whole ledger, so unbonding the entire active bond with nothing already unlocking stops it nominating or validating too.
+
 ### Report the actual reason an on-chain transaction failed
 
 A failed transaction whose dispatch error was not a module error was reported as `Unknown error`, discarding the reason: `SpRuntimeDispatchError` has fifteen variants and only three were handled.

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, reading what an Identity holds now with the amount, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission and total issuance. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, the units of the total staked amount, and a false "not included" rejection when claiming dividends.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, reading what an Identity holds now with the amount, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission, total issuance, the election schedule and the nomination quota. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, the units of the total staked amount, era progress on a chain that has skipped epochs, bond and rebond calls the chain would refuse, and a false "not included" rejection when claiming dividends.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -169,6 +169,24 @@ const unsub = await sdk.staking.getEraRewardPoints(({ total, individual }) => { 
 Only the active era changes; subscribing to a past era calls back once and stops.
 
 `staking.getElectionPhase()` returns the election's phase as an `ElectionPhase` enum, and is subscribable too. Staking transactions behave differently while an election is open, so a UI should say when this is anything other than `Off` — and a warning that waits for the next poll arrives after the user has acted.
+
+### Know when the next validator election opens
+
+`staking.getElectionSchedule()` answers whether a nomination made now takes effect this era or the next — the one figure a nominator acts on, and one nothing in the SDK could answer.
+
+```typescript
+const { opensAt, closesAt, opensIn, closesIn } = await sdk.staking.getElectionSchedule();
+
+const unsub = await sdk.staking.getElectionSchedule(({ opensIn }) => {
+  setCountdown(opensIn.toNumber());
+});
+```
+
+It is **not** the era's countdown. The election closes at the session rotation one session before the era ends, so it can be minutes away while the era still has hours left — measured on mainnet at 9.6 minutes against 5h 13m.
+
+`opensAt` and `closesAt` are block numbers, and they are projections: the chain schedules the election in slots, and a slot that produces no block moves the block it lands on. `opensIn` and `closesIn` are milliseconds, from the exact slot arithmetic.
+
+The chain does not publish the length of the election window — `UnsignedPhase` is not a `#[pallet::constant]`, so it never reaches metadata — and the SDK carries the runtimes' `EPOCH_DURATION_IN_BLOCKS / 4` instead. Verified against a completed election on testnet: it opened exactly 150 slots before it closed, on a 600 slot epoch.
 
 ### Read the validator set, historical commission and total issuance
 

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -454,6 +454,10 @@ Sort direction is unchanged everywhere one was already defined, so only the rela
 
 `polyxTransactionsQuery` never selected `totalCount`, so the `count` on every `getPolyxTransactions` result was `NaN`. `next` is derived from it by `totalCount.gt(next) ? next : null`, and a `NaN` comparison is always false — so `next` was always `null` and a caller paging through history stopped after the first page, with no error to say why.
 
+### Bonding an account that is already staking
+
+`staking.bond()` checked only the free balance. The chain also refuses a stash that is already bonded, and an Account that is a controller for some other stash, since one Account cannot be both. Both are now caught before signing, and the already-bonded message points at `bondExtra`.
+
 ### Rebonding with nothing unbonding
 
 `staking.rebond()` compared the amount against the total across the unlocking chunks, which nothing is not less than — so a rebond with nothing unbonding passed the check and was refused by the chain as `NoUnlockChunk`. That case is now its own error.

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -120,7 +120,7 @@ await collection.issue({
 
 `staking.eraProgress()` reports which era and session are in force and how far through each the chain has got — previously derivable only from BABE slots and session indices via `_polkadotApi`.
 
-Progress is counted in **slots**, so it advances every block and `progress` is exact. `remaining` and `end` are projections from `expectedBlockTime` and drift with block production.
+Progress is counted in **slots**, so it advances every block and `progress` is exact. It is measured from the slot the current epoch began in, so a chain that has skipped epochs — a paused and restarted dev chain, for instance — reports the same as one that has not. `remaining` and `end` are projections from `expectedBlockTime` and drift with block production.
 
 ```typescript
 const { era, session } = await sdk.staking.eraProgress();

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -214,6 +214,40 @@ await sdk.staking.chill();
 await sdk.staking.rebond({ amount: new BigNumber(100) });
 ```
 
+### Read how many validators an Account may nominate
+
+`account.staking.getNominationQuota()` returns the cap the chain will hold `nominate` to.
+
+```typescript
+const quota = await account.staking.getNominationQuota();
+
+// or for a bond being planned, rather than the one in place
+const quota = await account.staking.getNominationQuota({ bonded: new BigNumber(500) });
+```
+
+The cap is not a chain constant and cannot be read as one — it comes from the runtime API `StakingApi_nominations_quota`, whose argument is a **balance**, because the chain derives the cap from the amount bonded. On Polymesh v8 it is a flat 16 whatever the bond, but that is a runtime setting and can change, which is why it is read rather than assumed.
+
+Where the Account has bonded nothing and no `bonded` amount is given, the answer is for the smallest bond the chain accepts from a nominator, since anything less cannot nominate at all.
+
+`staking.nominate()` now checks the list against the cap, and the bond against `minNominatorBond`, before building the transaction — so both are refused before the caller signs rather than by the chain afterwards.
+
+### Bond and nominate in one batch
+
+`staking.nominate()` accepts `bonded`, the total POLYX that will be bonded by the time it executes. A batch is prepared before any of it has run, so the acting Account is not a controller yet and there is no ledger to check the nomination against:
+
+```typescript
+const bonded = new BigNumber(500);
+
+await sdk.createTransactionBatch({
+  transactions: [
+    await sdk.staking.bond({ amount: bonded, payee: account, autoStake: false }),
+    await sdk.staking.nominate({ validators, bonded }),
+  ] as const,
+});
+```
+
+Without it, `nominate()` still requires the acting Account to be a controller already.
+
 ### Order POLYX transaction history
 
 `Account.getPolyxTransactions` accepts `orderBy`, threaded through to the indexer.

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -221,7 +221,9 @@ export class Staking {
   /**
    * Bond POLYX for staking
    *
-   * @note the signing account cannot be a stash
+   * @note the signing Account cannot already be a stash — use
+   *   {@link api/client/Staking!Staking.bondExtra | bondExtra} to add to a bond it already has —
+   *   nor a controller for another stash, since one Account cannot be both
    */
   public bond: ProcedureMethod<BondPolyxParams, void>;
 

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -1,5 +1,6 @@
 import { Option, u32, u64, u128 } from '@polkadot/types';
 import { PalletStakingActiveEraInfo, PalletStakingEraRewardPoints } from '@polkadot/types/lookup';
+import { ITuple } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
 import {
@@ -51,6 +52,7 @@ import {
 import {
   asAccount,
   createProcedureMethod,
+  getSlotAtBlock,
   QueryMultiParam,
   requestMulti,
   requestPaginated,
@@ -77,6 +79,63 @@ function toPeriodProgress(
     progress: capped.dividedBy(total),
     remaining,
     end: new Date(new BigNumber(Date.now()).plus(remaining).toNumber()),
+  };
+}
+
+/**
+ * @hidden
+ *
+ * What one round of `eraProgress`'s multi query comes back with
+ */
+type EraProgressReads = [
+  Option<PalletStakingActiveEraInfo>,
+  Option<u32>,
+  u32,
+  u64,
+  ITuple<[u32, u32]>
+];
+
+/**
+ * @hidden
+ *
+ * Assemble the era and session progress from one round of chain reads, the session the era began
+ *   in, and the slot the current epoch began in
+ */
+function assembleEraProgress(
+  [rawActiveEra, rawCurrentEra, rawSession, rawSlot]: EraProgressReads,
+  eraStartSession: BigNumber,
+  epochStartSlot: BigNumber,
+  { slotsPerSession, sessionsPerEra, expectedBlockTime }: StakingConstants
+): EraProgress {
+  const { index: rawEraIndex, start: rawStart } = rawActiveEra.unwrap();
+
+  const era = u32ToBigNumber(rawEraIndex);
+  const session = u32ToBigNumber(rawSession);
+
+  const sessionElapsed = BigNumber.max(u64ToBigNumber(rawSlot).minus(epochStartSlot), 0);
+
+  /* sessions of this era that are already behind the chain */
+  const sessionsDone = BigNumber.max(session.minus(eraStartSession), 0);
+
+  const eraElapsed = sessionsDone.multipliedBy(slotsPerSession).plus(sessionElapsed);
+
+  return {
+    era: {
+      index: era,
+      planned: rawCurrentEra.isSome ? u32ToBigNumber(rawCurrentEra.unwrap()) : era,
+      start: rawStart.isSome ? new Date(u64ToBigNumber(rawStart.unwrap()).toNumber()) : null,
+      progress: toPeriodProgress(
+        eraElapsed,
+        slotsPerSession.multipliedBy(sessionsPerEra),
+        expectedBlockTime
+      ),
+    },
+    session: {
+      index: session,
+      inEra: BigNumber.min(sessionsDone.plus(1), sessionsPerEra),
+      perEra: sessionsPerEra,
+      progress: toPeriodProgress(sessionElapsed, slotsPerSession, expectedBlockTime),
+    },
   };
 }
 
@@ -522,15 +581,12 @@ export class Staking {
       },
     } = this;
 
-    const { slotsPerSession, sessionsPerEra, expectedBlockTime } = this.getConstants();
-
     type ProgressQueries = [
       typeof query.staking.activeEra,
       typeof query.staking.currentEra,
       typeof query.session.currentIndex,
-      typeof query.babe.epochIndex,
       typeof query.babe.currentSlot,
-      typeof query.babe.genesisSlot
+      typeof query.babe.epochStart
     ];
 
     /* `babe.currentSlot` alone changes every block; the rest ride along on the same notification */
@@ -538,12 +594,9 @@ export class Staking {
       [query.staking.activeEra, undefined],
       [query.staking.currentEra, undefined],
       [query.session.currentIndex, undefined],
-      [query.babe.epochIndex, undefined],
       [query.babe.currentSlot, undefined],
-      [query.babe.genesisSlot, undefined],
+      [query.babe.epochStart, undefined],
     ];
-
-    type RawProgress = [Option<PalletStakingActiveEraInfo>, Option<u32>, u32, u64, u64, u64];
 
     /*
      * `erasStartSessionIndex` is keyed by the active era, so it cannot join the multi query that
@@ -569,51 +622,37 @@ export class Staking {
       return startSession;
     };
 
-    const assembleResult = (
-      [rawActiveEra, rawCurrentEra, rawSession, rawEpoch, rawSlot, rawGenesisSlot]: RawProgress,
-      eraStartSession: BigNumber
-    ): EraProgress => {
-      const { index: rawEraIndex, start: rawStart } = rawActiveEra.unwrap();
+    /*
+     * the slot an epoch began in is not stored anywhere — the runtime recomputes it from the
+     *   genesis slot and the epoch index whenever it needs it, an identity that a chain which has
+     *   skipped epochs no longer satisfies. What the chain does record is the *block* each epoch
+     *   began on, and that block's header carries the BABE pre-digest naming the slot it was
+     *   authored in. Reading it back gives an exact slot anchored inside the epoch itself.
+     *
+     * It costs two RPC round trips, paid once per rotation rather than once per block, and it
+     *   reads a header rather than state, so a pruning node answers it as readily as an archive.
+     *
+     * Where the opening slots of an epoch produced no block the anchor is the first slot that
+     *   did, so the count is short by however many were skipped at that boundary — a handful at
+     *   most, and it cannot accumulate, since the next rotation re-anchors
+     */
+    let cachedForBlock: string | null = null;
+    let epochStart = new BigNumber(0);
 
-      const era = u32ToBigNumber(rawEraIndex);
-      const session = u32ToBigNumber(rawSession);
+    const readEpochStartSlot = async (rawEpochStart: ITuple<[u32, u32]>): Promise<BigNumber> => {
+      /* the chain writes `epochStart` on rotation, and treats epoch 0 as opening at block 1 */
+      const startBlock = u32ToBigNumber(rawEpochStart[1]);
+      const anchorBlock = startBlock.isZero() ? new BigNumber(1) : startBlock;
 
-      /*
-       * the chain does not store where a session began, so it is derived the way the runtime lays
-       *   epochs out: the Nth epoch starts `N * slotsPerSession` slots after genesis
-       */
-      const sessionStartSlot = u64ToBigNumber(rawEpoch)
-        .multipliedBy(slotsPerSession)
-        .plus(u64ToBigNumber(rawGenesisSlot));
+      if (cachedForBlock !== anchorBlock.toString()) {
+        epochStart = await getSlotAtBlock(context, anchorBlock);
+        cachedForBlock = anchorBlock.toString();
+      }
 
-      const sessionElapsed = BigNumber.max(u64ToBigNumber(rawSlot).minus(sessionStartSlot), 0);
-
-      /* sessions of this era that are already behind the chain */
-      const sessionsDone = BigNumber.max(session.minus(eraStartSession), 0);
-
-      const eraElapsed = sessionsDone.multipliedBy(slotsPerSession).plus(sessionElapsed);
-
-      return {
-        era: {
-          index: era,
-          planned: rawCurrentEra.isSome ? u32ToBigNumber(rawCurrentEra.unwrap()) : era,
-          start: rawStart.isSome ? new Date(u64ToBigNumber(rawStart.unwrap()).toNumber()) : null,
-          progress: toPeriodProgress(
-            eraElapsed,
-            slotsPerSession.multipliedBy(sessionsPerEra),
-            expectedBlockTime
-          ),
-        },
-        session: {
-          index: session,
-          inEra: BigNumber.min(sessionsDone.plus(1), sessionsPerEra),
-          perEra: sessionsPerEra,
-          progress: toPeriodProgress(sessionElapsed, slotsPerSession, expectedBlockTime),
-        },
-      };
+      return epochStart;
     };
 
-    const assertActiveEra = (raw: RawProgress): void => {
+    const assertActiveEra = (raw: EraProgressReads): void => {
       if (raw[0].isNone) {
         throw new PolymeshError({
           code: ErrorCode.DataUnavailable,
@@ -628,9 +667,14 @@ export class Staking {
       return requestMulti<ProgressQueries>(context, queries, async raw => {
         assertActiveEra(raw);
 
-        const eraStartSession = await readStartSession(u32ToBigNumber(raw[0].unwrap().index));
+        const [eraStartSession, epochStartSlot] = await Promise.all([
+          readStartSession(u32ToBigNumber(raw[0].unwrap().index)),
+          readEpochStartSlot(raw[4]),
+        ]);
 
-        await callback(assembleResult(raw, eraStartSession));
+        await callback(
+          assembleEraProgress(raw, eraStartSession, epochStartSlot, this.getConstants())
+        );
       });
     }
 
@@ -638,7 +682,12 @@ export class Staking {
 
     assertActiveEra(raw);
 
-    return assembleResult(raw, await readStartSession(u32ToBigNumber(raw[0].unwrap().index)));
+    const [eraStartSession, epochStartSlot] = await Promise.all([
+      readStartSession(u32ToBigNumber(raw[0].unwrap().index)),
+      readEpochStartSlot(raw[4]),
+    ]);
+
+    return assembleEraProgress(raw, eraStartSession, epochStartSlot, this.getConstants());
   }
 
   /**

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -19,6 +19,7 @@ import {
   ActiveEraInfo,
   BondPolyxParams,
   ElectionPhase,
+  ElectionSchedule,
   EraExposure,
   EraNominators,
   EraProgress,
@@ -38,7 +39,10 @@ import {
   UnsubCallback,
   UpdatePolyxBondParams,
 } from '~/types';
-import { MILLISECONDS_PER_YEAR } from '~/utils/constants';
+import {
+  MILLISECONDS_PER_YEAR,
+  UNSIGNED_ELECTION_PHASE_EPOCH_FRACTION,
+} from '~/utils/constants';
 import {
   accountIdToString,
   activeEraStakingToActiveEraInfo,
@@ -80,6 +84,20 @@ function toPeriodProgress(
     remaining,
     end: new Date(new BigNumber(Date.now()).plus(remaining).toNumber()),
   };
+}
+
+/**
+ * @hidden
+ *
+ * The block the current epoch began on
+ *
+ * @note the chain writes `babe.epochStart` on rotation and treats epoch 0 as opening at block 1,
+ *   so `(0, 0)` means no rotation has happened yet
+ */
+function epochStartBlock(rawEpochStart: ITuple<[u32, u32]>): BigNumber {
+  const startBlock = u32ToBigNumber(rawEpochStart[1]);
+
+  return startBlock.isZero() ? new BigNumber(1) : startBlock;
 }
 
 /**
@@ -136,6 +154,56 @@ function assembleEraProgress(
       perEra: sessionsPerEra,
       progress: toPeriodProgress(sessionElapsed, slotsPerSession, expectedBlockTime),
     },
+  };
+}
+
+/**
+ * @hidden
+ *
+ * What one round of `getElectionSchedule`'s multi query comes back with
+ */
+type ElectionScheduleReads = [Option<PalletStakingActiveEraInfo>, u32, u64, u32, ITuple<[u32, u32]>];
+
+/**
+ * @hidden
+ *
+ * Work out when the next election opens and closes, from the session the era began in and the slot
+ *   the current epoch began in
+ */
+function assembleElectionSchedule(
+  [, rawSession, rawSlot, rawBlock]: ElectionScheduleReads,
+  eraStartSession: BigNumber,
+  epochStartSlot: BigNumber,
+  { slotsPerSession, sessionsPerEra, expectedBlockTime }: StakingConstants
+): ElectionSchedule {
+  const session = u32ToBigNumber(rawSession);
+  const currentSlot = u64ToBigNumber(rawSlot);
+  const currentBlock = u32ToBigNumber(rawBlock);
+
+  /*
+   * the election closes at the rotation into the era's last session, not at the era boundary —
+   *   measured on chain as exactly one epoch of slots before that session's start. Where that
+   *   rotation is already behind, the next election is the one an era later
+   */
+  const lastSession = eraStartSession.plus(sessionsPerEra).minus(1);
+  const sessionsAway = lastSession.minus(session);
+
+  /* `isPositive` is true of zero, and a zero here means the rotation is the one already behind */
+  const sessionsUntilClose = sessionsAway.isGreaterThan(0)
+    ? sessionsAway
+    : sessionsAway.plus(sessionsPerEra);
+
+  const closeSlot = epochStartSlot.plus(sessionsUntilClose.multipliedBy(slotsPerSession));
+  const openSlot = closeSlot.minus(slotsPerSession.dividedToIntegerBy(UNSIGNED_ELECTION_PHASE_EPOCH_FRACTION));
+
+  const toProjection = (slot: BigNumber): BigNumber =>
+    BigNumber.max(slot.minus(currentSlot), 0).multipliedBy(expectedBlockTime);
+
+  return {
+    opensAt: currentBlock.plus(openSlot.minus(currentSlot)),
+    closesAt: currentBlock.plus(closeSlot.minus(currentSlot)),
+    opensIn: toProjection(openSlot),
+    closesIn: toProjection(closeSlot),
   };
 }
 
@@ -649,9 +717,7 @@ export class Staking {
     let epochStart = new BigNumber(0);
 
     const readEpochStartSlot = async (rawEpochStart: ITuple<[u32, u32]>): Promise<BigNumber> => {
-      /* the chain writes `epochStart` on rotation, and treats epoch 0 as opening at block 1 */
-      const startBlock = u32ToBigNumber(rawEpochStart[1]);
-      const anchorBlock = startBlock.isZero() ? new BigNumber(1) : startBlock;
+      const anchorBlock = epochStartBlock(rawEpochStart);
 
       if (cachedForBlock !== anchorBlock.toString()) {
         epochStart = await getSlotAtBlock(context, anchorBlock);
@@ -905,6 +971,107 @@ export class Staking {
         value: balanceToBigNumber(value.unwrap()),
       })),
     };
+  }
+
+  /**
+   * Retrieve when the next validator election opens and closes
+   *
+   * @throws if there is no active era
+   *
+   * @note this is the figure that says whether a nomination made now takes effect this era or the
+   *   next. It is not the era's own countdown: the election closes a session before the era ends,
+   *   so it can be minutes away while the era still has hours left
+   */
+  public async getElectionSchedule(): Promise<ElectionSchedule>;
+
+  /**
+   * Retrieve when the next validator election opens and closes, and subscribe to it
+   *
+   * @param callback - called on every block, since the projections advance with each one
+   *
+   * @returns Promise that resolves to an unsubscribe function
+   *
+   * @note can be subscribed to, if connected to node using a web socket
+   */
+  public async getElectionSchedule(
+    callback: SubCallback<ElectionSchedule>
+  ): Promise<UnsubCallback>;
+
+  // eslint-disable-next-line require-jsdoc
+  public async getElectionSchedule(
+    callback?: SubCallback<ElectionSchedule>
+  ): Promise<ElectionSchedule | UnsubCallback> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+    } = this;
+
+    type ScheduleQueries = [
+      typeof query.staking.activeEra,
+      typeof query.session.currentIndex,
+      typeof query.babe.currentSlot,
+      typeof query.system.number,
+      typeof query.babe.epochStart
+    ];
+
+    const queries: QueryMultiParam<ScheduleQueries> = [
+      [query.staking.activeEra, undefined],
+      [query.session.currentIndex, undefined],
+      [query.babe.currentSlot, undefined],
+      [query.system.number, undefined],
+      [query.babe.epochStart, undefined],
+    ];
+
+    const readAnchors = async (
+      raw: ElectionScheduleReads
+    ): Promise<[BigNumber, BigNumber]> => {
+      const [rawActiveEra] = raw;
+
+      if (rawActiveEra.isNone) {
+        throw new PolymeshError({
+          code: ErrorCode.DataUnavailable,
+          message: 'There is no active staking era',
+        });
+      }
+
+      const rawStartSession = await query.staking.erasStartSessionIndex(rawActiveEra.unwrap().index);
+
+      /*
+       * which session the era ends on is what dates the election, so an era whose start the chain
+       *   has pruned cannot be answered for — where `eraProgress` treats a missing anchor as
+       *   session 0 and reads as overdue, a schedule built on that would name a block in the past
+       */
+      if (rawStartSession.isNone) {
+        throw new PolymeshError({
+          code: ErrorCode.DataUnavailable,
+          message: 'The chain has no start session recorded for the active era',
+        });
+      }
+
+      return [
+        u32ToBigNumber(rawStartSession.unwrap()),
+        await getSlotAtBlock(context, epochStartBlock(raw[4])),
+      ];
+    };
+
+    if (callback) {
+      context.assertSupportsSubscription();
+
+      return requestMulti<ScheduleQueries>(context, queries, async raw => {
+        const [eraStartSession, epochStartSlot] = await readAnchors(raw);
+
+        await callback(
+          assembleElectionSchedule(raw, eraStartSession, epochStartSlot, this.getConstants())
+        );
+      });
+    }
+
+    const raw = await requestMulti<ScheduleQueries>(context, queries);
+    const [eraStartSession, epochStartSlot] = await readAnchors(raw);
+
+    return assembleElectionSchedule(raw, eraStartSession, epochStartSlot, this.getConstants());
   }
 
   /**

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -234,6 +234,10 @@ export class Staking {
 
   /**
    * Unbond POLYX for staking. The unbonded amount can be withdrawn after the lockup period
+   *
+   * @note the chain chills a stash that unbonds its whole ledger. Since this refuses an amount
+   *   larger than the active bond, that is the case where nothing is already unlocking and the
+   *   whole of it is unbonded — the stash stops nominating or validating as well
    */
   public unbond: ProcedureMethod<UpdatePolyxBondParams, void>;
 
@@ -241,6 +245,9 @@ export class Staking {
    * Rebond POLYX that is currently unbonding, without waiting for the lockup period to elapse
    *
    * @note this transaction must be signed by a controller
+   *
+   * @note the chain takes the amount from the most recently unbonded POLYX first, so a partial
+   *   rebond leaves the lots closest to maturing where they are
    */
   public rebond: ProcedureMethod<UpdatePolyxBondParams, void>;
 

--- a/src/api/client/__tests__/Staking.ts
+++ b/src/api/client/__tests__/Staking.ts
@@ -184,14 +184,14 @@ describe('Staking Class', () => {
 
   describe('method: eraProgress', () => {
     /*
-     * 300 slots per session, 3 sessions per era, so 900 slots per era. Genesis at slot 1000, and
-     *   the active era anchored to session 30 — so the era opened at epoch 40, slot 13000
+     * 300 slots per session, 3 sessions per era, so 900 slots per era. The active era is anchored
+     *   to session 30; the chain recorded that session opening at block 13000, and the header of
+     *   that block names the slot it was authored in
      */
-    const genesisSlot = 1000;
     const slotsPerSession = 300;
     const eraStartSession = 30;
-    const eraStartEpoch = 40;
-    const eraStartSlot = genesisSlot + eraStartEpoch * slotsPerSession;
+    const eraStartBlock = 13000;
+    const eraStartSlot = 41_000;
     const eraStartedAt = 1_700_000_000_000;
 
     let queryMultiMock: jest.Mock;
@@ -229,9 +229,8 @@ describe('Staking Class', () => {
       dsMockUtils.createQueryMock('staking', 'activeEra');
       dsMockUtils.createQueryMock('staking', 'currentEra');
       dsMockUtils.createQueryMock('session', 'currentIndex');
-      dsMockUtils.createQueryMock('babe', 'epochIndex');
       dsMockUtils.createQueryMock('babe', 'currentSlot');
-      dsMockUtils.createQueryMock('babe', 'genesisSlot');
+      dsMockUtils.createQueryMock('babe', 'epochStart');
 
       queryMultiMock = dsMockUtils.getQueryMultiMock();
     });
@@ -241,15 +240,75 @@ describe('Staking Class', () => {
     });
 
     /**
+     * The epoch began on `epochStartBlock`, whose header names `epochStartSlot`. `getBlockHash` and
+     *   `getHeader` are what the SDK reads that header with, and `createType` decodes the
+     *   pre-runtime digest it finds there
+     */
+    const mockEpochStartBlock = (epochStartBlock: number, epochStartSlot: number): void => {
+      const blockHash = dsMockUtils.createMockHash(`0xblock${epochStartBlock}`);
+      const payload = dsMockUtils.createMockBytes(`0xdigest${epochStartSlot}`);
+
+      when(dsMockUtils.createRpcMock('chain', 'getBlockHash'))
+        .calledWith(expect.objectContaining({ toString: expect.anything() }))
+        .mockResolvedValue(blockHash);
+
+      dsMockUtils.createRpcMock('chain', 'getHeader', {
+        returnValue: dsMockUtils.createMockHeader({
+          parentHash: dsMockUtils.createMockHash(),
+          number: dsMockUtils.createMockCompact(
+            dsMockUtils.createMockU32(new BigNumber(epochStartBlock))
+          ),
+          stateRoot: dsMockUtils.createMockHash(),
+          extrinsicsRoot: dsMockUtils.createMockHash(),
+          digest: {
+            logs: [
+              dsMockUtils.createMockDigestItem({
+                PreRuntime: dsMockUtils.createMockTupleCodec([
+                  dsMockUtils.createMockU8aFixed('BABE'),
+                  payload,
+                ]),
+              }),
+            ],
+          },
+        }),
+      });
+
+      when(mockContext.createType)
+        .calledWith('SpConsensusBabeDigestsPreDigest', payload)
+        .mockReturnValue(
+          dsMockUtils.createMockBabePreDigest({
+            SecondaryPlain: {
+              authorityIndex: dsMockUtils.createMockU32(new BigNumber(0)),
+              slot: dsMockUtils.createMockU64(new BigNumber(epochStartSlot)),
+            },
+          })
+        );
+    };
+
+    /**
      * @param sessionsIn - how many sessions of the era are already behind the chain
      * @param slotsIntoSession - how far into the current session the chain is
      */
     const mockProgress = (
       sessionsIn: number,
       slotsIntoSession: number,
-      opts: { start?: number | null; activeEra?: number; plannedEra?: number | null } = {}
+      opts: {
+        start?: number | null;
+        activeEra?: number;
+        plannedEra?: number | null;
+        epochStartBlock?: number;
+        epochStartSlot?: number;
+      } = {}
     ): void => {
-      const { start = eraStartedAt, activeEra = 7131, plannedEra = activeEra } = opts;
+      const {
+        start = eraStartedAt,
+        activeEra = 7131,
+        plannedEra = activeEra,
+        epochStartBlock = eraStartBlock + sessionsIn * slotsPerSession,
+        epochStartSlot = eraStartSlot + sessionsIn * slotsPerSession,
+      } = opts;
+
+      mockEpochStartBlock(epochStartBlock, epochStartSlot);
 
       queryMultiMock.mockResolvedValue([
         dsMockUtils.createMockOption(
@@ -265,11 +324,11 @@ describe('Staking Class', () => {
           ? dsMockUtils.createMockOption()
           : dsMockUtils.createMockOption(dsMockUtils.createMockU32(new BigNumber(plannedEra))),
         dsMockUtils.createMockU32(new BigNumber(eraStartSession + sessionsIn)),
-        dsMockUtils.createMockU64(new BigNumber(eraStartEpoch + sessionsIn)),
-        dsMockUtils.createMockU64(
-          new BigNumber(eraStartSlot + sessionsIn * slotsPerSession + slotsIntoSession)
-        ),
-        dsMockUtils.createMockU64(new BigNumber(genesisSlot)),
+        dsMockUtils.createMockU64(new BigNumber(epochStartSlot + slotsIntoSession)),
+        dsMockUtils.createMockTupleCodec([
+          dsMockUtils.createMockU32(new BigNumber(Math.max(epochStartBlock - slotsPerSession, 0))),
+          dsMockUtils.createMockU32(new BigNumber(epochStartBlock)),
+        ]),
       ]);
     };
 
@@ -293,6 +352,34 @@ describe('Staking Class', () => {
       expect(result.session.progress.total).toEqual(new BigNumber(300));
       expect(result.session.progress.progress).toEqual(new BigNumber(0.5));
       expect(result.session.progress.remaining).toEqual(new BigNumber(150 * 6000));
+    });
+
+    it('should read block 1 where no rotation has been recorded yet', async () => {
+      /* `babe.epochStart` is `(0, 0)` until the first rotation, and the chain opens epoch 0 at
+       * block 1 — so that is the header the slot has to come from */
+      const bigNumberToU32Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU32');
+
+      mockProgress(0, 150, { epochStartBlock: 0 });
+
+      const result = await staking.eraProgress();
+
+      expect(bigNumberToU32Spy).toHaveBeenCalledWith(new BigNumber(1), mockContext);
+      expect(result.session.progress.elapsed).toEqual(new BigNumber(150));
+    });
+
+    it('should stay local to the epoch on a chain that skipped epochs', async () => {
+      /*
+       * a chain paused mid-era and restarted rotates the epoch on its next block, and the slot it
+       *   resumes in bears no relation to `genesisSlot + epochIndex * slotsPerSession`. Progress
+       *   counts forward from the slot that block was authored in, so the gap cannot reach it
+       */
+      mockProgress(2, 12, { epochStartBlock: 90_000, epochStartSlot: 8_000_000 });
+
+      const result = await staking.eraProgress();
+
+      expect(result.session.progress.elapsed).toEqual(new BigNumber(12));
+      expect(result.session.inEra).toEqual(new BigNumber(3));
+      expect(result.era.progress.elapsed).toEqual(new BigNumber(2 * slotsPerSession + 12));
     });
 
     it('should report zero progress at the very start of an era', async () => {
@@ -361,9 +448,11 @@ describe('Staking Class', () => {
         dsMockUtils.createMockOption(),
         dsMockUtils.createMockOption(),
         dsMockUtils.createMockU32(new BigNumber(0)),
-        dsMockUtils.createMockU64(new BigNumber(0)),
-        dsMockUtils.createMockU64(new BigNumber(0)),
-        dsMockUtils.createMockU64(new BigNumber(0)),
+        dsMockUtils.createMockU32(new BigNumber(0)),
+        dsMockUtils.createMockTupleCodec([
+          dsMockUtils.createMockU32(new BigNumber(0)),
+          dsMockUtils.createMockU32(new BigNumber(0)),
+        ]),
       ]);
 
       return expect(staking.eraProgress()).rejects.toThrow('There is no active staking era');
@@ -372,6 +461,8 @@ describe('Staking Class', () => {
     it('should allow subscription', async () => {
       const unsubCallback = 'unsubCallback';
       const callback = jest.fn();
+
+      mockEpochStartBlock(eraStartBlock + slotsPerSession, eraStartSlot + slotsPerSession);
 
       queryMultiMock.mockImplementation(async (_, cb) => {
         await cb([
@@ -385,9 +476,11 @@ describe('Staking Class', () => {
           ),
           dsMockUtils.createMockOption(dsMockUtils.createMockU32(new BigNumber(7131))),
           dsMockUtils.createMockU32(new BigNumber(eraStartSession + 1)),
-          dsMockUtils.createMockU64(new BigNumber(eraStartEpoch + 1)),
           dsMockUtils.createMockU64(new BigNumber(eraStartSlot + slotsPerSession + 150)),
-          dsMockUtils.createMockU64(new BigNumber(genesisSlot)),
+          dsMockUtils.createMockTupleCodec([
+            dsMockUtils.createMockU32(new BigNumber(eraStartBlock)),
+            dsMockUtils.createMockU32(new BigNumber(eraStartBlock + slotsPerSession)),
+          ]),
         ]);
 
         return unsubCallback;

--- a/src/api/client/__tests__/Staking.ts
+++ b/src/api/client/__tests__/Staking.ts
@@ -498,6 +498,196 @@ describe('Staking Class', () => {
     });
   });
 
+  describe('method: getElectionSchedule', () => {
+    /* 300 slots per session, 3 sessions per era, so the election window is 300 / 4 = 75 slots */
+    const slotsPerSession = 300;
+    const eraStartSession = 30;
+    const epochStartBlock = 13000;
+    const epochStartSlot = 41000;
+
+    beforeEach(() => {
+      dsMockUtils.setConstMock('staking', 'sessionsPerEra', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(3)),
+      });
+      dsMockUtils.setConstMock('staking', 'bondingDuration', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(7)),
+      });
+      dsMockUtils.setConstMock('staking', 'historyDepth', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(84)),
+      });
+      dsMockUtils.setConstMock('babe', 'epochDuration', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(slotsPerSession)),
+      });
+      dsMockUtils.setConstMock('babe', 'expectedBlockTime', {
+        returnValue: dsMockUtils.createMockU64(new BigNumber(6000)),
+      });
+      dsMockUtils.setConstMock('validators', 'fixedYearlyReward', {
+        returnValue: dsMockUtils.createMockBalance(new BigNumber(140000000000000)),
+      });
+      dsMockUtils.setConstMock('validators', 'maxVariableInflationTotalIssuance', {
+        returnValue: dsMockUtils.createMockBalance(new BigNumber(1000000000000000)),
+      });
+
+      dsMockUtils.createQueryMock('staking', 'erasStartSessionIndex', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockU32(new BigNumber(eraStartSession))
+        ),
+      });
+
+      dsMockUtils.createQueryMock('staking', 'activeEra');
+      dsMockUtils.createQueryMock('session', 'currentIndex');
+      dsMockUtils.createQueryMock('babe', 'currentSlot');
+      dsMockUtils.createQueryMock('system', 'number');
+      dsMockUtils.createQueryMock('babe', 'epochStart');
+
+      const blockHash = dsMockUtils.createMockHash('0xepoch');
+      const payload = dsMockUtils.createMockBytes('0xdigest');
+
+      dsMockUtils.createRpcMock('chain', 'getBlockHash', { returnValue: blockHash });
+      dsMockUtils.createRpcMock('chain', 'getHeader', {
+        returnValue: dsMockUtils.createMockHeader({
+          parentHash: dsMockUtils.createMockHash(),
+          number: dsMockUtils.createMockCompact(
+            dsMockUtils.createMockU32(new BigNumber(epochStartBlock))
+          ),
+          stateRoot: dsMockUtils.createMockHash(),
+          extrinsicsRoot: dsMockUtils.createMockHash(),
+          digest: {
+            logs: [
+              dsMockUtils.createMockDigestItem({
+                PreRuntime: dsMockUtils.createMockTupleCodec([
+                  dsMockUtils.createMockU8aFixed('BABE'),
+                  payload,
+                ]),
+              }),
+            ],
+          },
+        }),
+      });
+
+      when(mockContext.createType)
+        .calledWith('SpConsensusBabeDigestsPreDigest', payload)
+        .mockReturnValue(
+          dsMockUtils.createMockBabePreDigest({
+            SecondaryPlain: {
+              authorityIndex: dsMockUtils.createMockU32(new BigNumber(0)),
+              slot: dsMockUtils.createMockU64(new BigNumber(epochStartSlot)),
+            },
+          })
+        );
+    });
+
+    /**
+     * @param sessionsIn - how many sessions of the era are behind the chain
+     * @param slotsIntoSession - how far into the current session the chain is
+     */
+    const mockSchedule = (sessionsIn: number, slotsIntoSession: number, hasEra = true): void => {
+      dsMockUtils.getQueryMultiMock().mockResolvedValue([
+        hasEra
+          ? dsMockUtils.createMockOption(
+              dsMockUtils.createMockActiveEraInfo({
+                index: dsMockUtils.createMockU32(new BigNumber(7131)),
+                start: dsMockUtils.createMockOption(),
+              })
+            )
+          : dsMockUtils.createMockOption(),
+        dsMockUtils.createMockU32(new BigNumber(eraStartSession + sessionsIn)),
+        dsMockUtils.createMockU64(new BigNumber(epochStartSlot + slotsIntoSession)),
+        dsMockUtils.createMockU32(new BigNumber(epochStartBlock + slotsIntoSession)),
+        dsMockUtils.createMockTupleCodec([
+          dsMockUtils.createMockU32(new BigNumber(epochStartBlock - slotsPerSession)),
+          dsMockUtils.createMockU32(new BigNumber(epochStartBlock)),
+        ]),
+      ]);
+    };
+
+    it('should report when the election opens and closes', async () => {
+      /* first session of a three session era, 100 slots in: the close is two rotations away */
+      mockSchedule(0, 100);
+
+      const result = await staking.getElectionSchedule();
+
+      /* closes 600 slots out, opens 75 before that */
+      expect(result.closesAt).toEqual(new BigNumber(epochStartBlock + 600));
+      expect(result.opensAt).toEqual(new BigNumber(epochStartBlock + 525));
+      expect(result.closesIn).toEqual(new BigNumber(500 * 6000));
+      expect(result.opensIn).toEqual(new BigNumber(425 * 6000));
+    });
+
+    it('should report the next era where this era has already elected', async () => {
+      /* the last session of the era is running, so its election is behind the chain */
+      mockSchedule(2, 100);
+
+      const result = await staking.getElectionSchedule();
+
+      /* three more rotations: the last session of the era after this one */
+      expect(result.closesAt).toEqual(new BigNumber(epochStartBlock + 900));
+      expect(result.closesIn).toEqual(new BigNumber(800 * 6000));
+    });
+
+    it('should report nothing left until an election that is already open', async () => {
+      /* one rotation from the close, and past the 75 slot window in which it opens */
+      mockSchedule(1, 250);
+
+      const result = await staking.getElectionSchedule();
+
+      expect(result.opensIn).toEqual(new BigNumber(0));
+      expect(result.opensAt).toEqual(new BigNumber(epochStartBlock + 225));
+      expect(result.closesIn).toEqual(new BigNumber(50 * 6000));
+    });
+
+    it('should throw if there is no active era', () => {
+      mockSchedule(0, 100, false);
+
+      return expect(staking.getElectionSchedule()).rejects.toThrow(
+        'There is no active staking era'
+      );
+    });
+
+    it('should throw where the chain has pruned the era start', () => {
+      dsMockUtils.createQueryMock('staking', 'erasStartSessionIndex', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+      mockSchedule(0, 100);
+
+      return expect(staking.getElectionSchedule()).rejects.toThrow(
+        'The chain has no start session recorded for the active era'
+      );
+    });
+
+    it('should allow subscription', async () => {
+      const unsubCallback = 'unsubCallback';
+      const callback = jest.fn();
+
+      dsMockUtils.getQueryMultiMock().mockImplementation(async (_, cb) => {
+        await cb([
+          dsMockUtils.createMockOption(
+            dsMockUtils.createMockActiveEraInfo({
+              index: dsMockUtils.createMockU32(new BigNumber(7131)),
+              start: dsMockUtils.createMockOption(),
+            })
+          ),
+          dsMockUtils.createMockU32(new BigNumber(eraStartSession)),
+          dsMockUtils.createMockU64(new BigNumber(epochStartSlot + 100)),
+          dsMockUtils.createMockU32(new BigNumber(epochStartBlock + 100)),
+          dsMockUtils.createMockTupleCodec([
+            dsMockUtils.createMockU32(new BigNumber(epochStartBlock - slotsPerSession)),
+            dsMockUtils.createMockU32(new BigNumber(epochStartBlock)),
+          ]),
+        ]);
+
+        return unsubCallback;
+      });
+
+      const result = await staking.getElectionSchedule(callback);
+
+      expect(result).toEqual(unsubCallback);
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ closesAt: new BigNumber(epochStartBlock + 600) })
+      );
+    });
+  });
+
   describe('per-era reads', () => {
     const era = new BigNumber(7131);
 

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -407,6 +407,41 @@ export enum ElectionPhase {
   Emergency = 'Emergency',
 }
 
+/**
+ * When the next validator election opens and closes
+ *
+ * @note the election closes at the session rotation one session before the era ends, not at the
+ *   era boundary, so it can be far closer than the era's own countdown suggests. The blocks are
+ *   **projections** — the chain schedules the election in slots, and a slot that produces no block
+ *   moves the block it lands on
+ */
+export interface ElectionSchedule {
+  /**
+   * The block the election is expected to open on
+   *
+   * @note in the past once the election is open
+   */
+  opensAt: BigNumber;
+
+  /**
+   * The block the election is expected to close on, which is when the next era's validator set is
+   *   decided
+   */
+  closesAt: BigNumber;
+
+  /**
+   * Projected milliseconds until the election opens
+   *
+   * @note `0` once it has opened
+   */
+  opensIn: BigNumber;
+
+  /**
+   * Projected milliseconds until the election closes
+   */
+  closesIn: BigNumber;
+}
+
 export interface EraRewardPoints {
   /**
    * The total points awarded across all validators in the era

--- a/src/api/entities/Account/Staking/index.ts
+++ b/src/api/entities/Account/Staking/index.ts
@@ -14,12 +14,15 @@ import {
 } from '~/types';
 import {
   accountIdToString,
+  balanceToBigNumber,
+  bigNumberToBalance,
   bigNumberToU32,
   rawNominationToStakingNomination,
   rawStakingLedgerToStakingLedgerEntry,
   rawValidatorPrefToCommission,
   rewardDestinationToPayee,
   stringToAccountId,
+  u32ToBigNumber,
 } from '~/utils/conversion';
 
 /**
@@ -278,5 +281,36 @@ export class Staking extends Namespace<Account> {
       account: this.parent,
       ...commission,
     };
+  }
+
+  /**
+   * Fetch how many validators this Account may nominate
+   *
+   * @param args.bonded - the total POLYX that will be bonded, for bonding and nominating in one
+   *   batch. Defaults to what the Account has bonded now, or to the chain's minimum nominator bond
+   *   where it has none
+   *
+   * @note the chain derives the cap from the amount bonded, so it is read rather than assumed. On
+   *   Polymesh v8 it is always 16 whatever the bond, but that is a runtime setting and can change
+   */
+  public async getNominationQuota(args?: { bonded?: BigNumber }): Promise<BigNumber> {
+    const {
+      context,
+      context: {
+        polymeshApi: { call, query },
+      },
+    } = this;
+
+    let bonded = args?.bonded;
+
+    if (!bonded) {
+      const ledger = await this.getLedger();
+
+      bonded = ledger ? ledger.active : balanceToBigNumber(await query.staking.minNominatorBond());
+    }
+
+    const rawQuota = await call.stakingApi.nominationsQuota(bigNumberToBalance(bonded, context));
+
+    return u32ToBigNumber(rawQuota);
   }
 }

--- a/src/api/entities/Account/__tests__/Staking.ts
+++ b/src/api/entities/Account/__tests__/Staking.ts
@@ -101,6 +101,77 @@ describe('Staking namespace', () => {
     });
   });
 
+  describe('method: getNominationQuota', () => {
+    const mockLedger = (active: BigNumber): void => {
+      dsMockUtils.createQueryMock('staking', 'ledger', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockStakingLedger({
+            stash: dsMockUtils.createMockAccountId('someId'),
+            total: dsMockUtils.createMockCompact(
+              dsMockUtils.createMockU128(active.times(10 ** 6))
+            ),
+            active: dsMockUtils.createMockCompact(
+              dsMockUtils.createMockU128(active.times(10 ** 6))
+            ),
+            unlocking: dsMockUtils.createMockVec(),
+            legacyClaimedRewards: dsMockUtils.createMockVec(),
+          })
+        ),
+      });
+    };
+
+    it('should return how many validators the account may nominate', async () => {
+      mockLedger(new BigNumber(5));
+
+      dsMockUtils.createCallMock('stakingApi', 'nominationsQuota', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(16)),
+      });
+
+      const bigNumberToBalanceSpy = jest.spyOn(utilsConversionModule, 'bigNumberToBalance');
+
+      const result = await staking.getNominationQuota();
+
+      expect(result).toEqual(new BigNumber(16));
+      /* the runtime call takes raw units, not POLYX */
+      expect(bigNumberToBalanceSpy).toHaveBeenCalledWith(new BigNumber(5), mockContext);
+    });
+
+    it('should answer for the minimum bond where the account has bonded nothing', async () => {
+      dsMockUtils.createQueryMock('staking', 'ledger', {
+        returnValue: dsMockUtils.createMockOption(),
+      });
+      dsMockUtils.createQueryMock('staking', 'minNominatorBond', {
+        returnValue: dsMockUtils.createMockU128(new BigNumber(20).times(10 ** 6)),
+      });
+      dsMockUtils.createCallMock('stakingApi', 'nominationsQuota', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(16)),
+      });
+
+      const bigNumberToBalanceSpy = jest.spyOn(utilsConversionModule, 'bigNumberToBalance');
+
+      const result = await staking.getNominationQuota();
+
+      expect(result).toEqual(new BigNumber(16));
+      expect(bigNumberToBalanceSpy).toHaveBeenCalledWith(new BigNumber(20), mockContext);
+    });
+
+    it('should answer for a supplied amount rather than the bond in place', async () => {
+      const ledgerMock = dsMockUtils.createQueryMock('staking', 'ledger');
+      dsMockUtils.createCallMock('stakingApi', 'nominationsQuota', {
+        returnValue: dsMockUtils.createMockU32(new BigNumber(16)),
+      });
+
+      const bigNumberToBalanceSpy = jest.spyOn(utilsConversionModule, 'bigNumberToBalance');
+
+      const result = await staking.getNominationQuota({ bonded: new BigNumber(300) });
+
+      expect(result).toEqual(new BigNumber(16));
+      expect(bigNumberToBalanceSpy).toHaveBeenCalledWith(new BigNumber(300), mockContext);
+      /* the supplied amount stands in for the ledger, so it should not be read */
+      expect(ledgerMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe('method: getPayee', () => {
     it('should return payee info for Staked', async () => {
       dsMockUtils.createQueryMock('staking', 'payee', {

--- a/src/api/procedures/__tests__/bondPolyx.ts
+++ b/src/api/procedures/__tests__/bondPolyx.ts
@@ -74,6 +74,8 @@ describe('bondPolyx procedure', () => {
     storage = {
       actingBalance,
       actingAccount,
+      currentController: null,
+      controlledLedger: null,
     };
   });
 
@@ -86,6 +88,45 @@ describe('bondPolyx procedure', () => {
   afterAll(() => {
     procedureMockUtils.cleanup();
     dsMockUtils.cleanup();
+  });
+
+  it('should throw an error if the stash is already bonded', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      ...storage,
+      currentController: entityMockUtils.getAccountInstance(),
+    });
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The stash account is already bonded. Use bondExtra to add to the existing bond',
+    });
+
+    return expect(
+      prepareBondPolyx.call(proc, { payee: actingAccount, autoStake: false, amount })
+    ).rejects.toThrow(expectedError);
+  });
+
+  it('should throw an error if the account already controls another stash', () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      ...storage,
+      controlledLedger: {
+        stash: entityMockUtils.getAccountInstance(),
+        total: new BigNumber(10),
+        active: new BigNumber(10),
+        unlocking: [],
+        claimedRewards: [],
+      },
+    });
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message:
+        'The account is a controller for another stash, so it cannot become a stash itself',
+    });
+
+    return expect(
+      prepareBondPolyx.call(proc, { payee: actingAccount, autoStake: false, amount })
+    ).rejects.toThrow(expectedError);
   });
 
   it('should throw an error if there is insufficient free balance', async () => {
@@ -143,7 +184,7 @@ describe('bondPolyx procedure', () => {
 
   it('should return a bond transaction spec', async () => {
     const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
-      actingBalance,
+      ...storage,
       actingAccount,
     });
 
@@ -165,7 +206,7 @@ describe('bondPolyx procedure', () => {
 
   it('should handle auto stake', async () => {
     const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
-      actingBalance,
+      ...storage,
       actingAccount: entityMockUtils.getAccountInstance({
         isEqual: false,
         address: actingAccount.address,
@@ -186,7 +227,7 @@ describe('bondPolyx procedure', () => {
 
   it('should handle different an account destination', async () => {
     const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
-      actingBalance,
+      ...storage,
       actingAccount: entityMockUtils.getAccountInstance({
         isEqual: false,
         address: actingAccount.address,

--- a/src/api/procedures/__tests__/nominateValidators.ts
+++ b/src/api/procedures/__tests__/nominateValidators.ts
@@ -46,6 +46,13 @@ describe('nominateValidators procedure', () => {
     });
     rawAccountId = dsMockUtils.createMockAccountId(validator.address);
 
+    dsMockUtils.createCallMock('stakingApi', 'nominationsQuota', {
+      returnValue: dsMockUtils.createMockU32(new BigNumber(16)),
+    });
+    dsMockUtils.createQueryMock('staking', 'minNominatorBond', {
+      returnValue: dsMockUtils.createMockU128(new BigNumber(1).times(10 ** 6)),
+    });
+
     stringToAccountIdSpy = jest.spyOn(utilsConversionModule, 'stringToAccountId');
 
     when(stringToAccountIdSpy)
@@ -83,12 +90,51 @@ describe('nominateValidators procedure', () => {
 
     const expectedError = new PolymeshError({
       code: ErrorCode.ValidationError,
-      message: 'The acting account must be a controller',
+      message:
+        'The acting account must be a controller. Pass `bonded` to nominate against a bond that is being made in the same batch',
     });
 
     await expect(
       prepareNominateValidators.call(proc, {
         validators: [validator],
+      })
+    ).rejects.toThrow(expectedError);
+  });
+
+  it('should nominate against a bond made in the same batch', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      ...storage,
+      ledger: null,
+    });
+
+    const result = await prepareNominateValidators.call(proc, {
+      validators: [validator],
+      bonded: new BigNumber(500),
+    });
+
+    /* not a controller yet — the bond that makes it one is in the same batch */
+    expect(result).toEqual({
+      transaction: nominateTx,
+      args: [[rawAccountId]],
+      resolver: undefined,
+    });
+  });
+
+  it('should throw an error if the bond is below the minimum a nominator may hold', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
+      ...storage,
+      ledger: null,
+    });
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.InsufficientBalance,
+      message: 'The bonded amount is below the minimum the chain accepts from a nominator',
+    });
+
+    await expect(
+      prepareNominateValidators.call(proc, {
+        validators: [validator],
+        bonded: new BigNumber(0.5),
       })
     ).rejects.toThrow(expectedError);
   });
@@ -107,6 +153,30 @@ describe('nominateValidators procedure', () => {
     await expect(
       prepareNominateValidators.call(proc, {
         validators: [validator, validator],
+      })
+    ).rejects.toThrow(expectedError);
+  });
+
+  it('should throw an error if more validators are nominated than the quota allows', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
+
+    dsMockUtils.createCallMock('stakingApi', 'nominationsQuota', {
+      returnValue: dsMockUtils.createMockU32(new BigNumber(1)),
+    });
+
+    const otherValidator = entityMockUtils.getAccountInstance({
+      address: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
+      stakingGetCommission: { commission: new BigNumber(7), blocked: false },
+    });
+
+    const expectedError = new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'More validators nominated than the acting account may nominate',
+    });
+
+    await expect(
+      prepareNominateValidators.call(proc, {
+        validators: [validator, otherValidator],
       })
     ).rejects.toThrow(expectedError);
   });

--- a/src/api/procedures/__tests__/updateBondedPolyx.ts
+++ b/src/api/procedures/__tests__/updateBondedPolyx.ts
@@ -31,6 +31,7 @@ describe('updateBondedPolyx procedure', () => {
   let bondExtraTx: PolymeshTx<[Balance]>;
   let rebondTx: PolymeshTx<[Balance]>;
   let actingAccount: Account;
+  let stash: Account;
   let rawAmount: Balance;
 
   let bigNumberToBalanceSpy: jest.SpyInstance;
@@ -49,6 +50,8 @@ describe('updateBondedPolyx procedure', () => {
 
     when(bigNumberToBalanceSpy).calledWith(amount, mockContext).mockReturnValue(rawAmount);
 
+    stash = entityMockUtils.getAccountInstance();
+
     storage = {
       isStash: false,
       actingAccount,
@@ -58,7 +61,7 @@ describe('updateBondedPolyx procedure', () => {
         locked: new BigNumber(0),
       },
       controllerEntry: {
-        stash: entityMockUtils.getAccountInstance(),
+        stash,
         total: new BigNumber(100),
         active: new BigNumber(100),
         unlocking: [],
@@ -223,6 +226,20 @@ describe('updateBondedPolyx procedure', () => {
       expect(() => prepareUnbondPolyx.call(proc, { type: 'rebond', amount })).toThrow(
         expectedError
       );
+    });
+
+    it('should throw an error if there is nothing unbonding at all', () => {
+      const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, storage);
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'There is no unbonding POLYX to rebond',
+      });
+
+      /* zero passes the amount check, since nothing is not less than nothing */
+      expect(() =>
+        prepareUnbondPolyx.call(proc, { type: 'rebond', amount: new BigNumber(0) })
+      ).toThrow(expectedError);
     });
 
     it('should throw an error if there is insufficient unbonding POLYX', () => {

--- a/src/api/procedures/bondPolyx.ts
+++ b/src/api/procedures/bondPolyx.ts
@@ -1,5 +1,5 @@
 import { PolymeshError, Procedure } from '~/internal';
-import { Account, Balance, BondPolyxParams, ErrorCode } from '~/types';
+import { Account, Balance, BondPolyxParams, ErrorCode, StakingLedger } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
 import { bigNumberToBalance } from '~/utils/conversion';
 import { asAccount, calculateRawStakingPayee } from '~/utils/internal';
@@ -7,6 +7,10 @@ import { asAccount, calculateRawStakingPayee } from '~/utils/internal';
 export interface Storage {
   actingBalance: Balance;
   actingAccount: Account;
+  /** the controller the acting Account has bonded to, where it is a stash already */
+  currentController: Account | null;
+  /** the ledger the acting Account controls, where it is some other stash's controller */
+  controlledLedger: StakingLedger | null;
 }
 
 /**
@@ -33,11 +37,36 @@ export async function prepareBondPolyx(
     storage: {
       actingAccount,
       actingBalance: { free, locked },
+      currentController,
+      controlledLedger,
     },
   } = this;
   const { autoStake, payee: payeeInput, amount } = args;
 
   const payee = asAccount(payeeInput, context);
+
+  if (currentController) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The stash account is already bonded. Use bondExtra to add to the existing bond',
+      data: {
+        actingAccount: actingAccount.address,
+        currentController: currentController.address,
+      },
+    });
+  }
+
+  /* the chain will not let one Account be a controller and a stash at the same time */
+  if (controlledLedger) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The account is a controller for another stash, so it cannot become a stash itself',
+      data: {
+        actingAccount: actingAccount.address,
+        stash: controlledLedger.stash.address,
+      },
+    });
+  }
 
   if (free.lt(amount)) {
     throw new PolymeshError({
@@ -88,11 +117,17 @@ export async function prepareStorage(this: Procedure<Params, void, Storage>): Pr
 
   const actingAccount = await context.getActingAccount();
 
-  const actingBalance = await actingAccount.getBalance();
+  const [actingBalance, currentController, controlledLedger] = await Promise.all([
+    actingAccount.getBalance(),
+    actingAccount.staking.getController(),
+    actingAccount.staking.getLedger(),
+  ]);
 
   return {
     actingAccount,
     actingBalance,
+    currentController,
+    controlledLedger,
   };
 }
 

--- a/src/api/procedures/nominateValidators.ts
+++ b/src/api/procedures/nominateValidators.ts
@@ -1,9 +1,15 @@
+import BigNumber from 'bignumber.js';
 import { uniqBy } from 'lodash';
 
 import { PolymeshError, Procedure } from '~/internal';
 import { Account, ErrorCode, NominateValidatorsParams, StakingLedger } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
-import { stringToAccountId } from '~/utils/conversion';
+import {
+  balanceToBigNumber,
+  bigNumberToBalance,
+  stringToAccountId,
+  u32ToBigNumber,
+} from '~/utils/conversion';
 import { asAccount } from '~/utils/internal';
 
 export interface Storage {
@@ -29,12 +35,18 @@ export async function prepareNominateValidators(
         tx: {
           staking: { nominate },
         },
+        call: {
+          stakingApi: { nominationsQuota },
+        },
+        query: {
+          staking: { minNominatorBond },
+        },
       },
     },
     context,
     storage: { actingAccount, ledger },
   } = this;
-  const { validators: validatorsInput } = args;
+  const { validators: validatorsInput, bonded } = args;
 
   const validators = validatorsInput.map(validator => asAccount(validator, context));
 
@@ -97,11 +109,49 @@ export async function prepareNominateValidators(
     });
   }
 
-  if (!ledger) {
+  /* `bonded` stands in for the ledger where the bond is being made in the same batch */
+  let activeBond: BigNumber;
+
+  if (bonded) {
+    activeBond = bonded;
+  } else if (ledger) {
+    activeBond = ledger.active;
+  } else {
     throw new PolymeshError({
       code: ErrorCode.ValidationError,
-      message: 'The acting account must be a controller',
+      message:
+        'The acting account must be a controller. Pass `bonded` to nominate against a bond that is being made in the same batch',
       data: { actingAccount: actingAccount.address },
+    });
+  }
+
+  const minBond = balanceToBigNumber(await minNominatorBond());
+
+  if (activeBond.lt(minBond)) {
+    throw new PolymeshError({
+      code: ErrorCode.InsufficientBalance,
+      message: 'The bonded amount is below the minimum the chain accepts from a nominator',
+      data: {
+        actingAccount: actingAccount.address,
+        bonded: activeBond.toString(),
+        minBond: minBond.toString(),
+      },
+    });
+  }
+
+  /* the chain refuses a list longer than the cap, so check it before the caller signs */
+  const rawQuota = await nominationsQuota(bigNumberToBalance(activeBond, context));
+  const quota = u32ToBigNumber(rawQuota);
+
+  if (quota.lt(validators.length)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'More validators nominated than the acting account may nominate',
+      data: {
+        actingAccount: actingAccount.address,
+        nominated: validators.length,
+        quota: quota.toString(),
+      },
     });
   }
 

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1967,6 +1967,14 @@ export interface UpdatePolyxBondParams {
 
 export interface NominateValidatorsParams {
   validators: (Account | string)[];
+
+  /**
+   * (optional) The **total** POLYX that will be bonded when this executes, not an amount to add to
+   *   the current bond. Pass it when bonding and nominating in one batch: the batch is prepared
+   *   before the bond exists, so there is no ledger yet to check the nomination against, and the
+   *   acting Account is not required to be a controller already
+   */
+  bonded?: BigNumber;
 }
 
 export interface CreateBallotParams {

--- a/src/api/procedures/updateBondedPolyx.ts
+++ b/src/api/procedures/updateBondedPolyx.ts
@@ -23,6 +23,121 @@ export type Params = UpdatePolyxBondParams &
 
 /**
  * @hidden
+ *
+ * @throws if the acting account controls no bond
+ */
+function assertControllerEntry(
+  controllerEntry: StakingLedger | null,
+  actingAccount: Account
+): StakingLedger {
+  if (!controllerEntry) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The caller must be a controller account',
+      data: { actingAccount: actingAccount.address },
+    });
+  }
+
+  return controllerEntry;
+}
+
+/**
+ * @hidden
+ *
+ * @throws if `amount` cannot be rebonded
+ */
+function assertRebondable(
+  amount: BigNumber,
+  controllerEntry: StakingLedger | null,
+  actingAccount: Account
+): void {
+  const { unlocking } = assertControllerEntry(controllerEntry, actingAccount);
+
+  /* the chain refuses a rebond with nothing unbonding, whatever the amount */
+  if (!unlocking.length) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'There is no unbonding POLYX to rebond',
+      data: { actingAccount: actingAccount.address },
+    });
+  }
+
+  const unlockingTotal = unlocking.reduce(
+    (total, { value }) => total.plus(value),
+    new BigNumber(0)
+  );
+
+  if (unlockingTotal.lt(amount)) {
+    throw new PolymeshError({
+      code: ErrorCode.InsufficientBalance,
+      message: 'Insufficient unbonding POLYX',
+      data: {
+        amount: amount.toString(),
+        unlocking: unlockingTotal.toString(),
+        actingAccount: actingAccount.address,
+      },
+    });
+  }
+}
+
+/**
+ * @hidden
+ *
+ * @throws if `amount` cannot be unbonded
+ */
+function assertUnbondable(
+  amount: BigNumber,
+  controllerEntry: StakingLedger | null,
+  actingAccount: Account
+): void {
+  const { active } = assertControllerEntry(controllerEntry, actingAccount);
+
+  if (active.lt(amount)) {
+    throw new PolymeshError({
+      code: ErrorCode.InsufficientBalance,
+      message: 'Insufficient bonded POLYX',
+      data: {
+        amount: amount.toString(),
+        active: active.toString(),
+        actingAccount: actingAccount.address,
+      },
+    });
+  }
+}
+
+/**
+ * @hidden
+ *
+ * @throws if `amount` cannot be added to an existing bond
+ */
+function assertBondExtraPossible(
+  amount: BigNumber,
+  actingBalance: Balance,
+  isStash: boolean,
+  actingAccount: Account
+): void {
+  if (!isStash) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'The caller must be a stash account',
+      data: { actingAccount: actingAccount.address },
+    });
+  }
+
+  if (actingBalance.free.lt(amount)) {
+    throw new PolymeshError({
+      code: ErrorCode.InsufficientBalance,
+      message: 'The stash account has insufficient free balance',
+      data: {
+        actingAccount: actingAccount.address,
+        free: actingBalance.free.toString(),
+      },
+    });
+  }
+}
+
+/**
+ * @hidden
  */
 export function prepareUnbondPolyx(
   this: Procedure<Params, void, Storage>,
@@ -50,85 +165,13 @@ export function prepareUnbondPolyx(
 
   if (type === 'rebond') {
     transaction = rebond;
-
-    if (!controllerEntry) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: 'The caller must be a controller account',
-        data: { actingAccount: actingAccount.address },
-      });
-    }
-
-    /* the chain refuses a rebond with nothing unbonding, whatever the amount */
-    if (!controllerEntry.unlocking.length) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: 'There is no unbonding POLYX to rebond',
-        data: { actingAccount: actingAccount.address },
-      });
-    }
-
-    const unlockingTotal = controllerEntry.unlocking.reduce(
-      (total, { value }) => total.plus(value),
-      new BigNumber(0)
-    );
-
-    if (unlockingTotal.lt(amount)) {
-      throw new PolymeshError({
-        code: ErrorCode.InsufficientBalance,
-        message: 'Insufficient unbonding POLYX',
-        data: {
-          amount: amount.toString(),
-          unlocking: unlockingTotal.toString(),
-          actingAccount: actingAccount.address,
-        },
-      });
-    }
+    assertRebondable(amount, controllerEntry, actingAccount);
   } else if (type === 'unbond') {
     transaction = unbond;
-
-    if (!controllerEntry) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: 'The caller must be a controller account',
-        data: { actingAccount: actingAccount.address },
-      });
-    }
-
-    const { active } = controllerEntry;
-
-    if (active.lt(amount)) {
-      throw new PolymeshError({
-        code: ErrorCode.InsufficientBalance,
-        message: 'Insufficient bonded POLYX',
-        data: {
-          amount: amount.toString(),
-          active: active.toString(),
-          actingAccount: actingAccount.address,
-        },
-      });
-    }
+    assertUnbondable(amount, controllerEntry, actingAccount);
   } else {
     transaction = bondExtra;
-
-    if (!isStash) {
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: 'The caller must be a stash account',
-        data: { actingAccount: actingAccount.address },
-      });
-    }
-
-    if (actingBalance.free.lt(amount)) {
-      throw new PolymeshError({
-        code: ErrorCode.InsufficientBalance,
-        message: 'The stash account has insufficient free balance',
-        data: {
-          actingAccount: actingAccount.address,
-          free: actingBalance.free.toString(),
-        },
-      });
-    }
+    assertBondExtraPossible(amount, actingBalance, isStash, actingAccount);
   }
 
   const rawAmount = bigNumberToBalance(amount, context);

--- a/src/api/procedures/updateBondedPolyx.ts
+++ b/src/api/procedures/updateBondedPolyx.ts
@@ -59,6 +59,15 @@ export function prepareUnbondPolyx(
       });
     }
 
+    /* the chain refuses a rebond with nothing unbonding, whatever the amount */
+    if (!controllerEntry.unlocking.length) {
+      throw new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'There is no unbonding POLYX to rebond',
+        data: { actingAccount: actingAccount.address },
+      });
+    }
+
     const unlockingTotal = controllerEntry.unlocking.reduce(
       (total, { value }) => total.plus(value),
       new BigNumber(0)

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -34,6 +34,8 @@ import {
   Block,
   BlockHash,
   Call,
+  Digest,
+  DigestItem,
   DispatchError,
   DispatchErrorModule,
   DispatchErrorModuleU8,
@@ -156,6 +158,7 @@ import {
   PolymeshPrimitivesTransferComplianceAssetTransferCompliance,
   PolymeshPrimitivesTransferComplianceTransferCondition,
   PolymeshPrimitivesTransferComplianceTransferConditionExemptKey,
+  SpConsensusBabeDigestsPreDigest,
   SpStakingExposurePage,
   SpStakingIndividualExposure,
   SpStakingPagedExposureMetadata,
@@ -2557,6 +2560,38 @@ export const createMockAssetType = (
  * @hidden
  * NOTE: `isEmpty` will be set to true if no value is passed
  */
+export const createMockDigestItem = (
+  digestItem?:
+    | 'RuntimeEnvironmentUpdated'
+    | { Other: Bytes }
+    | { Consensus: ITuple<[U8aFixed, Bytes]> }
+    | { Seal: ITuple<[U8aFixed, Bytes]> }
+    | { PreRuntime: ITuple<[U8aFixed, Bytes]> }
+    | DigestItem
+): MockCodec<DigestItem> => {
+  return createMockEnum<DigestItem>(digestItem);
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
+export const createMockBabePreDigest = (
+  preDigest?:
+    | { Primary: Record<string, unknown> }
+    | { SecondaryPlain: Record<string, unknown> }
+    /* the chain spells this variant `SecondaryVRF`, which is not strict PascalCase */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    | { SecondaryVRF: Record<string, unknown> }
+    | SpConsensusBabeDigestsPreDigest
+): MockCodec<SpConsensusBabeDigestsPreDigest> => {
+  return createMockEnum<SpConsensusBabeDigestsPreDigest>(preDigest);
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
 export const createMockNftType = (
   assetType?:
     | 'Derivative'
@@ -4015,13 +4050,16 @@ export const createMockHeader = (
         number: Compact<u32>;
         stateRoot: Hash | Parameters<typeof createMockHash>[0];
         extrinsicsRoot: Hash | Parameters<typeof createMockHash>[0];
+        /* the consensus digest a real header carries; empty unless a test needs to read it */
+        digest?: Digest | { logs: DigestItem[] };
       }
 ): MockCodec<Header> => {
-  const { parentHash, number, stateRoot, extrinsicsRoot } = header ?? {
+  const { parentHash, number, stateRoot, extrinsicsRoot, digest } = header ?? {
     parentHash: createMockHash(),
     number: createMockCompact(),
     stateRoot: createMockHash(),
     extrinsicsRoot: createMockHash(),
+    digest: undefined,
   };
 
   return createMockCodec(
@@ -4030,6 +4068,7 @@ export const createMockHeader = (
       number: createMockCompact(number.unwrap()),
       stateRoot: createMockHash(stateRoot),
       extrinsicsRoot: createMockHash(extrinsicsRoot),
+      digest: digest ?? { logs: [] },
     },
     !header
   );

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -1,5 +1,5 @@
 import { Bytes, u32 } from '@polkadot/types';
-import { AccountId, EventRecord, Moment } from '@polkadot/types/interfaces';
+import { AccountId, DigestItem, EventRecord, Moment } from '@polkadot/types/interfaces';
 import {
   PolymeshPrimitivesIdentityClaimClaimType,
   PolymeshPrimitivesIdentityId,
@@ -127,6 +127,7 @@ import {
   getIdentityFromKeyRecord,
   getPortfolioIdsByName,
   getSecondaryAccountPermissions,
+  getSlotAtBlock,
   getTickerForAsset,
   hasSameElements,
   isAllowedCharacters,
@@ -4006,5 +4007,114 @@ describe('getCorporateBallotDetailsOrThrow success', () => {
 
     expect(result.meta).toEqual({ title: 't', motions: [] });
     expect(result.rcv).toBe(false);
+  });
+});
+
+describe('getSlotAtBlock', () => {
+  let mockContext: Context;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  beforeEach(() => {
+    mockContext = dsMockUtils.getContextInstance();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  /**
+   * A header carrying one pre-runtime digest, stamped with `engineId` and holding `payload`
+   */
+  const mockHeaderWith = (logs: DigestItem[]): void => {
+    dsMockUtils.createRpcMock('chain', 'getBlockHash', {
+      returnValue: dsMockUtils.createMockHash('0xabc'),
+    });
+    dsMockUtils.createRpcMock('chain', 'getHeader', {
+      returnValue: dsMockUtils.createMockHeader({
+        parentHash: dsMockUtils.createMockHash(),
+        number: dsMockUtils.createMockCompact(dsMockUtils.createMockU32(new BigNumber(13000))),
+        stateRoot: dsMockUtils.createMockHash(),
+        extrinsicsRoot: dsMockUtils.createMockHash(),
+        digest: { logs },
+      }),
+    });
+  };
+
+  const babeLog = (payload: Bytes): DigestItem =>
+    dsMockUtils.createMockDigestItem({
+      PreRuntime: dsMockUtils.createMockTupleCodec([
+        dsMockUtils.createMockU8aFixed('BABE'),
+        payload,
+      ]),
+    });
+
+  it('should return the slot named by the BABE pre-runtime digest', async () => {
+    const payload = dsMockUtils.createMockBytes('0x01');
+    mockHeaderWith([babeLog(payload)]);
+
+    when(mockContext.createType)
+      .calledWith('SpConsensusBabeDigestsPreDigest', payload)
+      .mockReturnValue(
+        dsMockUtils.createMockBabePreDigest({
+          Primary: {
+            authorityIndex: dsMockUtils.createMockU32(new BigNumber(3)),
+            slot: dsMockUtils.createMockU64(new BigNumber(41_000)),
+          },
+        })
+      );
+
+    const result = await getSlotAtBlock(mockContext, new BigNumber(13000));
+
+    expect(result).toEqual(new BigNumber(41_000));
+  });
+
+  it('should read the slot from a secondary VRF claim as readily as a primary one', async () => {
+    const payload = dsMockUtils.createMockBytes('0x02');
+    mockHeaderWith([babeLog(payload)]);
+
+    when(mockContext.createType)
+      .calledWith('SpConsensusBabeDigestsPreDigest', payload)
+      .mockReturnValue(
+        dsMockUtils.createMockBabePreDigest({
+          SecondaryVRF: {
+            authorityIndex: dsMockUtils.createMockU32(new BigNumber(1)),
+            slot: dsMockUtils.createMockU64(new BigNumber(41_001)),
+          },
+        })
+      );
+
+    const result = await getSlotAtBlock(mockContext, new BigNumber(13000));
+
+    expect(result).toEqual(new BigNumber(41_001));
+  });
+
+  it('should throw where the header carries no pre-runtime digest', () => {
+    mockHeaderWith([dsMockUtils.createMockDigestItem('RuntimeEnvironmentUpdated')]);
+
+    return expect(getSlotAtBlock(mockContext, new BigNumber(13000))).rejects.toThrow(
+      'The block header carries no consensus pre-runtime digest'
+    );
+  });
+
+  it('should throw where the block was authored by another consensus engine', () => {
+    mockHeaderWith([
+      dsMockUtils.createMockDigestItem({
+        PreRuntime: dsMockUtils.createMockTupleCodec([
+          dsMockUtils.createMockU8aFixed('aura'),
+          dsMockUtils.createMockBytes('0x03'),
+        ]),
+      }),
+    ]);
+
+    return expect(getSlotAtBlock(mockContext, new BigNumber(13000))).rejects.toThrow(
+      'The block was not authored by BABE, so it names no slot'
+    );
   });
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -194,3 +194,13 @@ export const MILLISECONDS_PER_YEAR = new BigNumber(1000 * 3600 * 24 * 36525).div
  * @note the slot a block was produced in is only recorded there — it is not in state
  */
 export const BABE_ENGINE_ID = 'BABE';
+
+/**
+ * How much of an epoch the chain's unsigned election phase runs for
+ *
+ * @note the runtimes set `UnsignedPhase = EPOCH_DURATION_IN_BLOCKS / 4` and it is not a
+ *   `#[pallet::constant]`, so it never reaches metadata and has to be carried here. The mainnet,
+ *   testnet and develop runtimes all agree on it, and `SignedPhase` is `0`, so the unsigned phase
+ *   is the whole election window
+ */
+export const UNSIGNED_ELECTION_PHASE_EPOCH_FRACTION = new BigNumber(4);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -187,3 +187,10 @@ export const MODULE_NAMES: string[] = Object.values(ModuleName);
  *   result by 0.0685%
  */
 export const MILLISECONDS_PER_YEAR = new BigNumber(1000 * 3600 * 24 * 36525).dividedBy(100);
+
+/**
+ * The consensus engine id BABE stamps on the pre-runtime digest of every block it authors
+ *
+ * @note the slot a block was produced in is only recorded there — it is not in state
+ */
+export const BABE_ENGINE_ID = 'BABE';

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -7,7 +7,7 @@ import {
   DropLast,
   ObsInnerType,
 } from '@polkadot/api/types';
-import { Bytes, Option, StorageKey, u32 } from '@polkadot/types';
+import { Bytes, Option, StorageKey, u32, u64 } from '@polkadot/types';
 import { EventRecord, RewardDestination } from '@polkadot/types/interfaces';
 import { BlockHash } from '@polkadot/types/interfaces/chain';
 import {
@@ -2541,11 +2541,15 @@ export async function getSlotAtBlock(context: Context, blockNumber: BigNumber): 
   );
 
   /* every variant carries the slot; which one it is depends only on how the slot was claimed */
-  const { slot } = preDigest.isPrimary
-    ? preDigest.asPrimary
-    : preDigest.isSecondaryPlain
-    ? preDigest.asSecondaryPlain
-    : preDigest.asSecondaryVRF;
+  let slot: u64;
+
+  if (preDigest.isPrimary) {
+    slot = preDigest.asPrimary.slot;
+  } else if (preDigest.isSecondaryPlain) {
+    slot = preDigest.asSecondaryPlain.slot;
+  } else {
+    slot = preDigest.asSecondaryVRF.slot;
+  }
 
   return u64ToBigNumber(slot);
 }

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -17,10 +17,11 @@ import {
   PolymeshPrimitivesSecondaryKeyKeyRecord,
   PolymeshPrimitivesStatisticsStatType,
   PolymeshPrimitivesTransferComplianceTransferCondition,
+  SpConsensusBabeDigestsPreDigest,
 } from '@polkadot/types/lookup';
 import type { Callback, Codec, Observable } from '@polkadot/types/types';
 import { AnyFunction, AnyTuple, IEvent, ISubmittableResult } from '@polkadot/types/types';
-import { stringUpperFirst } from '@polkadot/util';
+import { stringUpperFirst, u8aToString } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import BigNumber from 'bignumber.js';
 import stringify from 'json-stable-stringify';
@@ -100,6 +101,7 @@ import {
   UnionOfProcedureFuncs,
 } from '~/types/utils';
 import {
+  BABE_ENGINE_ID,
   CONFIDENTIAL_ASSETS_SUPPORTED_CALL,
   MAX_META_LENGTH,
   MAX_TICKER_LENGTH,
@@ -2492,4 +2494,58 @@ export async function getCorporateActionWithDescription(
   }
 
   return { corporateAction: ca.unwrap(), description };
+}
+
+/**
+ * @hidden
+ *
+ * Read the BABE slot a block was authored in, from its header's pre-runtime digest
+ *
+ * @note the slot is not in state, so it cannot be read back with a storage query — but every
+ *   authored block names it in its header, and headers survive state pruning. That makes this the
+ *   only way to anchor a slot count inside a period rather than deriving it from the genesis slot
+ */
+export async function getSlotAtBlock(context: Context, blockNumber: BigNumber): Promise<BigNumber> {
+  const {
+    polymeshApi: {
+      rpc: { chain },
+    },
+  } = context;
+
+  const blockHash = await chain.getBlockHash(bigNumberToU32(blockNumber, context));
+  const { digest } = await chain.getHeader(blockHash);
+
+  const preRuntime = digest.logs.find(log => log.isPreRuntime)?.asPreRuntime;
+
+  if (!preRuntime) {
+    throw new PolymeshError({
+      code: ErrorCode.DataUnavailable,
+      message: 'The block header carries no consensus pre-runtime digest',
+      data: { blockNumber: blockNumber.toString() },
+    });
+  }
+
+  const [engineId, payload] = preRuntime;
+
+  if (u8aToString(engineId) !== BABE_ENGINE_ID) {
+    throw new PolymeshError({
+      code: ErrorCode.DataUnavailable,
+      message: 'The block was not authored by BABE, so it names no slot',
+      data: { blockNumber: blockNumber.toString(), engineId: u8aToString(engineId) },
+    });
+  }
+
+  const preDigest = context.createType<SpConsensusBabeDigestsPreDigest>(
+    'SpConsensusBabeDigestsPreDigest',
+    payload
+  );
+
+  /* every variant carries the slot; which one it is depends only on how the slot was claimed */
+  const { slot } = preDigest.isPrimary
+    ? preDigest.asPrimary
+    : preDigest.isSecondaryPlain
+    ? preDigest.asSecondaryPlain
+    : preDigest.asSecondaryVRF;
+
+  return u64ToBigNumber(slot);
 }


### PR DESCRIPTION
### Description

Five staking changes, each checked against the runtime the chain is built from and, where the source was ambiguous, measured on testnet.

**New reads**

- `staking.getElectionSchedule()` — when the next validator election opens and closes, with a subscription overload. This is the figure that says whether a nomination made now lands this era or the next, and it is not the era's countdown: the election closes a session before the era ends, so it can be minutes away while the era has hours left. `UnsignedPhase` is not a `#[pallet::constant]`, so the window is derived from `babe.epochDuration / 4` and documented as carried rather than read.
- `account.staking.getNominationQuota()` — the cap the chain holds `nominate` to. Not a constant: it comes from `StakingApi_nominations_quota`, whose argument is a balance. Polymesh v8 returns a flat 16, so reading it keeps that a fact about the runtime rather than an assumption in the SDK.

**Fixes**

- `eraProgress()` derived the current epoch's start as `genesisSlot + epochIndex * slotsPerSession`, an identity a chain that has skipped epochs no longer satisfies — a paused and restarted dev chain reported the wrong position silently. It now reads the slot from the header of the block the chain recorded the epoch beginning on. Header rather than state, so a pruning node answers it too.
- `nominate` checks the list against the cap and the bond against `minNominatorBond`. It also takes `bonded`, for bonding and nominating in one batch: the batch is prepared before the bond exists, so there is no ledger yet to check against.
- `bond` refuses a stash that is already bonded (pointing at `bondExtra`) and an Account that already controls another stash. `rebond` refuses a rebond with nothing unbonding, which previously passed and failed on chain as `NoUnlockChunk`.

Also documents two chain behaviours: `rebond` takes from the most recently unbonded POLYX first, and `unbond` chills a stash that unbonds its whole ledger.

### Breaking Changes

None.

### JIRA Link

<!-- Insert JIRA issue here -->

### Checklist

- [x] Updated the Readme.md (if required) ?
