### PR TITLE
refactor: 💡 name the pagination options an indexer-backed read takes

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -526,6 +526,22 @@ For a consumer that fetches entities off one shared, long-lived `Context` while 
 
 `Assets.get()` paged `asset.assetNames` and then issued a second `.multi()` against `asset.assets` for the details. `asset.assets` is keyed by asset id alone, so paging it directly returns the details in the same response and halves the round trips. The Assets returned, and their order, are unchanged — both maps are keyed by the same asset id, so they iterate in the same order.
 
+### Indexer-backed reads name their pagination options
+
+The SDK pages two different things in two different ways, and until now the signatures did not say which was which. A read that pages the chain takes `PaginationOptions`, whose `start` is a storage key — it can only ever be a `next` returned by a previous call. A read that pages the indexer takes an offset, so any page can be requested directly.
+
+Every indexer-backed read now declares `MiddlewarePaginationOptions` — the type already existed, and `Instruction` already used it — instead of an inline `{ size?: BigNumber; start?: BigNumber }`:
+
+```typescript
+public async getInvestments(
+  opts: MiddlewarePaginationOptions & { orderBy?: InvestmentsOrderBy } = {}
+): Promise<ResultSet<Investment>>;
+```
+
+The shape is unchanged, so no call needs to change; `size` and `start` mean what they always did, and `size` still defaults to 25. What changes is that the distinction is now visible in the signature and documented in one place rather than repeated across twenty methods.
+
+`MiddlewarePaginationOptions.size` is optional, matching every read that uses it. It was previously declared required, which the three `Instruction` methods accepting either kind of options did not enforce.
+
 ---
 
 ## Behaviour changes

--- a/src/api/client/Claims.ts
+++ b/src/api/client/Claims.ts
@@ -25,6 +25,7 @@ import {
   CustomClaimWithoutScope,
   ErrorCode,
   IdentityWithClaims,
+  MiddlewarePaginationOptions,
   ModifyClaimsParams,
   NextKey,
   ProcedureMethod,
@@ -150,11 +151,9 @@ export class Claims {
    * @note uses the middlewareV2
    */
   public async getIssuedClaims(
-    opts: {
+    opts: MiddlewarePaginationOptions & {
       target?: string | Identity;
       includeExpired?: boolean;
-      size?: BigNumber;
-      start?: BigNumber;
     } = {}
   ): Promise<ResultSet<ClaimData>> {
     const { context } = this;
@@ -185,14 +184,12 @@ export class Claims {
    * @note uses the middleware V2
    */
   public async getIdentitiesWithClaims(
-    opts: {
+    opts: MiddlewarePaginationOptions & {
       targets?: (string | Identity)[];
       trustedClaimIssuers?: (string | Identity)[];
       scope?: Scope;
       claimTypes?: ClaimTypeInput[];
       includeExpired?: boolean;
-      size?: BigNumber;
-      start?: BigNumber;
     } = {}
   ): Promise<ResultSet<IdentityWithClaims>> {
     const { context } = this;
@@ -422,13 +419,11 @@ export class Claims {
    * @note uses the middlewareV2 (optional)
    */
   public async getTargetingClaims(
-    opts: {
+    opts: MiddlewarePaginationOptions & {
       target?: string | Identity;
       scope?: Scope;
       trustedClaimIssuers?: (string | Identity)[];
       includeExpired?: boolean;
-      size?: BigNumber;
-      start?: BigNumber;
     } = {}
   ): Promise<ResultSet<IdentityWithClaims>> {
     const { context } = this;
@@ -565,9 +560,7 @@ export class Claims {
    * @note uses the middlewareV2 (Required)
    */
   public async getAllCustomClaimTypes(
-    opts: {
-      size?: BigNumber;
-      start?: BigNumber;
+    opts: MiddlewarePaginationOptions & {
       dids?: string[];
       orderBy?: CustomClaimTypesOrderBy | CustomClaimTypesOrderBy[];
     } = {}

--- a/src/api/client/Network.ts
+++ b/src/api/client/Network.ts
@@ -21,6 +21,7 @@ import {
   EventIdentifier,
   ExtrinsicDataWithFees,
   MiddlewareMetadata,
+  MiddlewarePaginationOptions,
   NetworkProperties,
   ProcedureMethod,
   ProtocolFees,
@@ -594,16 +595,16 @@ export class Network {
    *
    * @note uses the middlewareV2
    */
-  public async getEventsByIndexedArgs(opts: {
-    moduleId: ModuleIdEnum;
-    eventId: EventIdEnum;
-    eventArg0?: string;
-    eventArg1?: string;
-    eventArg2?: string;
-    size?: BigNumber;
-    start?: BigNumber;
-    orderBy?: EventsOrderBy | EventsOrderBy[];
-  }): Promise<EventIdentifier[] | null> {
+  public async getEventsByIndexedArgs(
+    opts: MiddlewarePaginationOptions & {
+      moduleId: ModuleIdEnum;
+      eventId: EventIdEnum;
+      eventArg0?: string;
+      eventArg1?: string;
+      eventArg2?: string;
+      orderBy?: EventsOrderBy | EventsOrderBy[];
+    }
+  ): Promise<EventIdentifier[] | null> {
     const { context } = this;
 
     const { moduleId, eventId, eventArg0, eventArg1, eventArg2, size, start, orderBy } = opts;

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -3,7 +3,14 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
 import { InstructionsOrderBy } from '~/middleware/types';
-import { Account, Asset, Identity, InstructionStatusEnum, TxTag } from '~/types';
+import {
+  Account,
+  Asset,
+  Identity,
+  InstructionStatusEnum,
+  MiddlewarePaginationOptions,
+  TxTag,
+} from '~/types';
 
 export { InstructionStatusEnum };
 
@@ -244,7 +251,7 @@ export type CustomClaimTypeWithDid = CustomClaimType & { did?: string | undefine
  * Filters for instructions
  *
  */
-export interface HistoricalInstructionFilters {
+export interface HistoricalInstructionFilters extends MiddlewarePaginationOptions {
   /**
    * The DID of the identity to filter by
    */
@@ -273,14 +280,6 @@ export interface HistoricalInstructionFilters {
    * The party did to filter by
    */
   party?: string | Identity;
-  /**
-   * The number of results to return
-   */
-  size?: BigNumber;
-  /**
-   * The number of results to skip
-   */
-  start?: BigNumber;
   /**
    * The ordering of the results. Defaults to oldest first
    */

--- a/src/api/entities/Account/MultiSig/index.ts
+++ b/src/api/entities/Account/MultiSig/index.ts
@@ -26,6 +26,7 @@ import {
   AnyJson,
   ErrorCode,
   HistoricalMultiSigProposal,
+  MiddlewarePaginationOptions,
   ModifyMultiSigParams,
   MultiSigDetails,
   NoArgsProcedureMethod,
@@ -205,11 +206,11 @@ export class MultiSig extends Account {
    *
    * @note uses the middlewareV2
    */
-  public async getHistoricalProposals(opts?: {
-    size?: BigNumber;
-    start?: BigNumber;
-    orderBy?: MultiSigProposalsOrderBy | MultiSigProposalsOrderBy[];
-  }): Promise<ResultSet<HistoricalMultiSigProposal>> {
+  public async getHistoricalProposals(
+    opts?: MiddlewarePaginationOptions & {
+      orderBy?: MultiSigProposalsOrderBy | MultiSigProposalsOrderBy[];
+    }
+  ): Promise<ResultSet<HistoricalMultiSigProposal>> {
     const { context, address } = this;
     const { size, start, orderBy } = opts ?? {};
 

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -45,6 +45,7 @@ import {
   CheckPermissionsResult,
   ErrorCode,
   ExtrinsicData,
+  MiddlewarePaginationOptions,
   MultiSigTx,
   NftOwnerStatus,
   Permissions,
@@ -308,13 +309,11 @@ export class Account extends Entity<UniqueIdentifiers, string> {
    *   "no history" and read as a bug in the caller's code
    */
   public async getTransactionHistory(
-    filters: {
+    filters: MiddlewarePaginationOptions & {
       blockNumber?: BigNumber;
       blockHash?: string;
       tag?: TxTag;
       success?: boolean;
-      size?: BigNumber;
-      start?: BigNumber;
       orderBy?: ExtrinsicsOrderBy | ExtrinsicsOrderBy[];
     } = {}
   ): Promise<ResultSet<ExtrinsicData>> {
@@ -678,11 +677,11 @@ export class Account extends Entity<UniqueIdentifiers, string> {
    *
    * @note uses the middleware
    */
-  public getPolyxTransactions(filters: {
-    size?: BigNumber;
-    start?: BigNumber;
-    orderBy?: PolyxTransactionsOrderBy | PolyxTransactionsOrderBy[];
-  }): Promise<ResultSet<HistoricPolyxTransaction>> {
+  public getPolyxTransactions(
+    filters: MiddlewarePaginationOptions & {
+      orderBy?: PolyxTransactionsOrderBy | PolyxTransactionsOrderBy[];
+    }
+  ): Promise<ResultSet<HistoricPolyxTransaction>> {
     const { context } = this;
 
     return context.getPolyxTransactions({

--- a/src/api/entities/Asset/Fungible/index.ts
+++ b/src/api/entities/Asset/Fungible/index.ts
@@ -27,6 +27,7 @@ import {
   EventIdentifier,
   HistoricAgentOperation,
   HistoricAssetTransaction,
+  MiddlewarePaginationOptions,
   ProcedureMethod,
   RedeemTokensParams,
   ResultSet,
@@ -194,11 +195,11 @@ export class FungibleAsset extends BaseAsset {
    *
    * @note uses the middlewareV2
    */
-  public async getTransactionHistory(opts: {
-    size?: BigNumber;
-    start?: BigNumber;
-    orderBy?: AssetTransactionsOrderBy | AssetTransactionsOrderBy[];
-  }): Promise<ResultSet<HistoricAssetTransaction>> {
+  public async getTransactionHistory(
+    opts: MiddlewarePaginationOptions & {
+      orderBy?: AssetTransactionsOrderBy | AssetTransactionsOrderBy[];
+    }
+  ): Promise<ResultSet<HistoricAssetTransaction>> {
     const { context, id } = this;
     const { size, start, orderBy } = opts;
 

--- a/src/api/entities/Asset/NonFungible/AssetHolders/index.ts
+++ b/src/api/entities/Asset/NonFungible/AssetHolders/index.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import { Identity, Namespace, Nft } from '~/internal';
 import { nftCollectionHolders } from '~/middleware/queries/assets';
 import { Query } from '~/middleware/types';
-import { IdentityHeldNfts, NftCollection, ResultSet } from '~/types';
+import { IdentityHeldNfts, MiddlewarePaginationOptions, NftCollection, ResultSet } from '~/types';
 import { Ensured } from '~/types/utils';
 import { calculateNextKey, getAssetIdForMiddleware } from '~/utils/internal';
 
@@ -16,10 +16,7 @@ export class AssetHolders extends Namespace<NftCollection> {
    *
    * @note uses the middlewareV2
    */
-  public async get(opts: {
-    size?: BigNumber;
-    start?: BigNumber;
-  }): Promise<ResultSet<IdentityHeldNfts>> {
+  public async get(opts: MiddlewarePaginationOptions): Promise<ResultSet<IdentityHeldNfts>> {
     const {
       context,
       parent: { id: assetId },

--- a/src/api/entities/Asset/NonFungible/NftCollection.ts
+++ b/src/api/entities/Asset/NonFungible/NftCollection.ts
@@ -17,6 +17,7 @@ import {
   HistoricNftTransaction,
   IssueNftParams,
   MetadataType,
+  MiddlewarePaginationOptions,
   NftControllerTransferParams,
   ProcedureMethod,
   ResultSet,
@@ -361,11 +362,11 @@ export class NftCollection extends BaseAsset {
    *
    * @note uses the middlewareV2
    */
-  public async getTransactionHistory(opts: {
-    size?: BigNumber;
-    start?: BigNumber;
-    orderBy?: AssetTransactionsOrderBy | AssetTransactionsOrderBy[];
-  }): Promise<ResultSet<HistoricNftTransaction>> {
+  public async getTransactionHistory(
+    opts: MiddlewarePaginationOptions & {
+      orderBy?: AssetTransactionsOrderBy | AssetTransactionsOrderBy[];
+    }
+  ): Promise<ResultSet<HistoricNftTransaction>> {
     const { context, id } = this;
     const { size, start, orderBy } = opts;
 

--- a/src/api/entities/DividendDistribution/index.ts
+++ b/src/api/entities/DividendDistribution/index.ts
@@ -32,6 +32,7 @@ import {
   ErrorCode,
   IdentityBalance,
   InputCaCheckpoint,
+  MiddlewarePaginationOptions,
   ModifyCaCheckpointParams,
   NoArgsProcedureMethod,
   PayDividendsParams,
@@ -495,9 +496,7 @@ export class DividendDistribution extends CorporateActionBase {
    * @note supports pagination
    */
   public async getPaymentHistory(
-    opts: {
-      size?: BigNumber;
-      start?: BigNumber;
+    opts: MiddlewarePaginationOptions & {
       orderBy?: DistributionPaymentsOrderBy | DistributionPaymentsOrderBy[];
     } = {}
   ): Promise<ResultSet<DistributionPayment>> {

--- a/src/api/entities/Identity/AssetPermissions.ts
+++ b/src/api/entities/Identity/AssetPermissions.ts
@@ -28,6 +28,7 @@ import {
   CheckPermissionsResult,
   ErrorCode,
   EventIdentifier,
+  MiddlewarePaginationOptions,
   ModuleName,
   PermissionType,
   ProcedureMethod,
@@ -375,14 +376,14 @@ export class AssetPermissions extends Namespace<Identity> {
    * @note uses the middlewareV2
    * @note supports pagination
    */
-  public async getOperationHistory(opts: {
-    asset: string | FungibleAsset;
-    moduleId?: ModuleIdEnum;
-    eventId?: EventIdEnum;
-    size?: BigNumber;
-    start?: BigNumber;
-    orderBy?: TickerExternalAgentActionsOrderBy | TickerExternalAgentActionsOrderBy[];
-  }): Promise<ResultSet<EventIdentifier>> {
+  public async getOperationHistory(
+    opts: MiddlewarePaginationOptions & {
+      asset: string | FungibleAsset;
+      moduleId?: ModuleIdEnum;
+      eventId?: EventIdEnum;
+      orderBy?: TickerExternalAgentActionsOrderBy | TickerExternalAgentActionsOrderBy[];
+    }
+  ): Promise<ResultSet<EventIdentifier>> {
     const {
       context,
       parent: { did },

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -43,6 +43,7 @@ import {
   HistoricalInstructionFilters,
   HistoricInstruction,
   InstructionsByStatus,
+  MiddlewarePaginationOptions,
   MultiSigSigners,
   NumberedPortfolio,
   PaginationOptions,
@@ -423,15 +424,13 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    * @note supports pagination
    */
   public async getHeldAssets(
-    opts: {
+    opts: MiddlewarePaginationOptions & {
       /**
        * @deprecated in favour of `orderBy`, which every other read is ordered by. Passing both
        *   throws
        */
       order?: AssetHoldersOrderBy;
       orderBy?: AssetHoldersOrderBy | AssetHoldersOrderBy[];
-      size?: BigNumber;
-      start?: BigNumber | undefined;
     } = {}
   ): Promise<ResultSet<FungibleAsset>> {
     const { context, did } = this;
@@ -482,11 +481,9 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    * @note supports pagination
    */
   public async getAssetHoldings(
-    opts: {
+    opts: MiddlewarePaginationOptions & {
       heldNow?: boolean;
       orderBy?: AssetHoldersOrderBy | AssetHoldersOrderBy[];
-      size?: BigNumber;
-      start?: BigNumber | undefined;
     } = {}
   ): Promise<ResultSet<FungibleAssetHolding>> {
     const { context, did } = this;
@@ -541,7 +538,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    * @note supports pagination
    */
   public async getHeldNfts(
-    opts: {
+    opts: MiddlewarePaginationOptions & {
       heldNow?: boolean;
       /**
        * @deprecated in favour of `orderBy`, which every other read is ordered by. Passing both
@@ -549,8 +546,6 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
        */
       order?: NftHoldersOrderBy;
       orderBy?: NftHoldersOrderBy | NftHoldersOrderBy[];
-      size?: BigNumber;
-      start?: BigNumber;
     } = {}
   ): Promise<ResultSet<HeldNfts>> {
     const { context, did } = this;

--- a/src/api/entities/Offering/index.ts
+++ b/src/api/entities/Offering/index.ts
@@ -21,6 +21,7 @@ import {
   Account,
   EnableOffChainFundingParams,
   InvestInOfferingParams,
+  MiddlewarePaginationOptions,
   ModifyOfferingTimesParams,
   NoArgsProcedureMethod,
   OffChainFundingDetails,
@@ -253,11 +254,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
    * @note uses the middleware V2
    */
   public async getInvestments(
-    opts: {
-      size?: BigNumber;
-      start?: BigNumber;
-      orderBy?: InvestmentsOrderBy | InvestmentsOrderBy[];
-    } = {}
+    opts: MiddlewarePaginationOptions & { orderBy?: InvestmentsOrderBy | InvestmentsOrderBy[] } = {}
   ): Promise<ResultSet<Investment>> {
     const {
       context,

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -20,6 +20,7 @@ import {
   ErrorCode,
   GroupedInstructions,
   InstructionStatus,
+  MiddlewarePaginationOptions,
   ModifyVenueParams,
   NumberedPortfolio,
   ProcedureMethod,
@@ -256,10 +257,7 @@ export class Venue extends Entity<UniqueIdentifiers, string> {
    * @note supports pagination
    */
   public async getHistoricalInstructions(
-    opts: {
-      size?: BigNumber;
-      start?: BigNumber;
-    } = {}
+    opts: MiddlewarePaginationOptions = {}
   ): Promise<ResultSet<HistoricInstruction>> {
     const { context, id } = this;
 

--- a/src/api/entities/common/namespaces/Authorizations.ts
+++ b/src/api/entities/common/namespaces/Authorizations.ts
@@ -11,7 +11,15 @@ import {
   AuthTypeEnum,
   Query,
 } from '~/middleware/types';
-import { AuthorizationType, ErrorCode, ResultSet, Signer, SignerType, SignerValue } from '~/types';
+import {
+  AuthorizationType,
+  ErrorCode,
+  MiddlewarePaginationOptions,
+  ResultSet,
+  Signer,
+  SignerType,
+  SignerValue,
+} from '~/types';
 import { Ensured, QueryArgs } from '~/types/utils';
 import {
   addressToKey,
@@ -161,11 +169,9 @@ export class Authorizations<Parent extends Signer> extends Namespace<Parent> {
    * @note uses the middlewareV2
    */
   public async getHistoricalAuthorizations(
-    opts: {
+    opts: MiddlewarePaginationOptions & {
       status?: AuthorizationStatusEnum;
       type?: AuthTypeEnum;
-      size?: BigNumber;
-      start?: BigNumber;
       orderBy?: AuthorizationsOrderBy | AuthorizationsOrderBy[];
     } = {}
   ): Promise<ResultSet<AuthorizationRequest>> {

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -86,14 +86,28 @@ export type SubCallback<T> = (result: T) => void | Promise<void>;
 
 export type UnsubCallback = () => void;
 
+/**
+ * Pagination options for a read that pages the chain. `start` is a storage key, so it is only ever
+ *   a `next` returned by a previous call and cannot be constructed by hand
+ */
 export interface PaginationOptions {
   size: BigNumber;
   start?: string | undefined;
 }
 
+/**
+ * Pagination options for a read that pages the middleware. `start` is an offset, so any page can be
+ *   requested directly
+ */
 export interface MiddlewarePaginationOptions {
-  size: BigNumber;
-  start?: BigNumber;
+  /**
+   * The number of results to return. Defaults to 25
+   */
+  size?: BigNumber | undefined;
+  /**
+   * The number of results to skip
+   */
+  start?: BigNumber | undefined;
 }
 
 export type NextKey = string | BigNumber | null;

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -47,6 +47,7 @@ import {
   DistributionWithDetails,
   ErrorCode,
   MiddlewareMetadata,
+  MiddlewarePaginationOptions,
   ModuleName,
   PolkadotConfig,
   ProtocolFees,
@@ -1084,14 +1085,14 @@ export class Context {
   /**
    * @hidden
    */
-  public async getIdentityClaimsFromMiddleware(args: {
-    targets?: (string | Identity)[] | undefined;
-    trustedClaimIssuers?: (string | Identity)[] | undefined;
-    claimTypes?: ClaimTypeInput[] | undefined;
-    includeExpired?: boolean | undefined;
-    size?: BigNumber | undefined;
-    start?: BigNumber | undefined;
-  }): Promise<ResultSet<ClaimData>> {
+  public async getIdentityClaimsFromMiddleware(
+    args: MiddlewarePaginationOptions & {
+      targets?: (string | Identity)[] | undefined;
+      trustedClaimIssuers?: (string | Identity)[] | undefined;
+      claimTypes?: ClaimTypeInput[] | undefined;
+      includeExpired?: boolean | undefined;
+    }
+  ): Promise<ResultSet<ClaimData>> {
     const {
       targets,
       claimTypes,
@@ -1148,13 +1149,11 @@ export class Context {
    * @note uses the middleware V2 (optional)
    */
   public async issuedClaims(
-    opts: {
+    opts: MiddlewarePaginationOptions & {
       targets?: (string | Identity)[];
       trustedClaimIssuers?: (string | Identity)[];
       claimTypes?: ClaimTypeInput[];
       includeExpired?: boolean;
-      size?: BigNumber;
-      start?: BigNumber;
     } = {}
   ): Promise<ResultSet<ClaimData>> {
     const { targets, trustedClaimIssuers, claimTypes, includeExpired = true, size, start } = opts;
@@ -1435,13 +1434,13 @@ export class Context {
    * @note uses the middleware V2
    * @note supports pagination
    */
-  public async getPolyxTransactions(args: {
-    identity?: string | Identity;
-    accounts?: (string | Account)[];
-    size?: BigNumber;
-    start?: BigNumber;
-    orderBy?: PolyxTransactionsOrderBy | PolyxTransactionsOrderBy[];
-  }): Promise<ResultSet<HistoricPolyxTransaction>> {
+  public async getPolyxTransactions(
+    args: MiddlewarePaginationOptions & {
+      identity?: string | Identity;
+      accounts?: (string | Account)[];
+      orderBy?: PolyxTransactionsOrderBy | PolyxTransactionsOrderBy[];
+    }
+  ): Promise<ResultSet<HistoricPolyxTransaction>> {
     const {
       identity,
       accounts,


### PR DESCRIPTION
### Description

The SDK pages two different things in two different ways, and until now the signatures did not say which was which:

- a read that pages **the chain** takes `PaginationOptions`, whose `start` is a **storage key** — it can only ever be a `next` handed back by a previous call, and cannot be constructed by hand;
- a read that pages **the indexer** takes an **offset**, so any page can be requested directly.

`MiddlewarePaginationOptions` already existed to express the second, but only `Instruction` used it. Every other indexer-backed read spelled out an inline `{ size?: BigNumber; start?: BigNumber }`, so a caller had no way to tell from a signature whether `start` was a cursor they had to be handed or a number they could pick.

This adopts the existing type across all of them, and documents both types at their declaration in `src/api/entities/types.ts`:

```typescript
public async getInvestments(
  opts: MiddlewarePaginationOptions & { orderBy?: InvestmentsOrderBy | InvestmentsOrderBy[] } = {}
): Promise<ResultSet<Investment>>;
```

#### Two changes to the type itself

**`size` is now optional.** It was declared required, which no read enforced — every one of them defaults it to 25 — and which the three `Instruction` methods taking `PaginationOptions | MiddlewarePaginationOptions` could not enforce anyway.

**Both members now admit `undefined` explicitly.** This repo builds with `exactOptionalPropertyTypes: true`, under which `start?: BigNumber` and `start?: BigNumber | undefined` are not the same type — the first rejects an explicitly passed `undefined`. Since `ResultSet.next` is nullable, forwarding one page's `next` straight into the next call is the ordinary way to use these methods, and it did not type-check. Now it does.

#### Scope

17 files, +130/−113. No call site changes and no runtime behaviour changes: `size` and `start` mean exactly what they meant before, and `size` still defaults to 25. The type is structurally identical to the inline shape it replaces, which is why no tests changed — the existing suites already cover it.

| File | Reads |
|---|---|
| `src/base/Context.ts` | `issuedClaims`, `getPolyxTransactions`, `getIdentityClaimsFromMiddleware` (`@hidden`) |
| `src/api/client/Claims.ts` | `getIssuedClaims`, `getIdentitiesWithClaims`, `getTargetingClaims`, `getAllCustomClaimTypes` |
| `src/api/entities/Identity/index.ts` | `getHeldAssets`, `getAssetHoldings`, `getHeldNfts` |
| `src/api/entities/Account/index.ts` | `getTransactionHistory`, `getPolyxTransactions` |
| `src/api/client/Network.ts` | `getEventsByIndexedArgs` |
| `src/api/entities/common/namespaces/Authorizations.ts` | `getHistoricalAuthorizations` |
| `src/api/entities/Identity/AssetPermissions.ts` | `getOperationHistory` |
| `src/api/entities/Asset/Fungible/index.ts` | `getTransactionHistory` |
| `src/api/entities/Asset/NonFungible/NftCollection.ts` | `getTransactionHistory` |
| `src/api/entities/Asset/NonFungible/AssetHolders/index.ts` | `get` |
| `src/api/entities/DividendDistribution/index.ts` | `getPaymentHistory` |
| `src/api/entities/Offering/index.ts` | `getInvestments` |
| `src/api/entities/Venue/index.ts` | `getHistoricalInstructions` |
| `src/api/entities/Account/MultiSig/index.ts` | `getHistoricalProposals` |
| `src/api/client/types.ts` | `HistoricalInstructionFilters` now extends the type |

#### Verification

`yarn build:ts` passes. `yarn test:no-cov` over the touched suites passes — 291 tests across `Claims`, `Network`, `Identity`, `Account`, `Context` and `Instruction`.

A changelog entry is included in `changelogs/v31.0.0-next.md`, under the non-breaking improvements rather than under behaviour changes, since nothing observable changes.

### Breaking Changes

None.

`api-snapshot:compare` reports **✅ No breaking API changes detected**. The rendered parameter types change name, but the shape is identical, and the one real difference — `size` going from required to optional — is a widening in input position, so every call that compiled before still compiles.

### JIRA Link

<!-- add issue -->

### Checklist

- [ ] Updated the Readme.md (if required) ?

