### PR TITLE
feat: 🎸 read the validators an Account's stake backed

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, reading what an Identity holds now with the amount, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission, total issuance, the election schedule and the nomination quota. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, the units of the total staked amount, era progress on a chain that has skipped epochs, bond and rebond calls the chain would refuse, and a false "not included" rejection when claiming dividends.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, reading what an Identity holds now with the amount, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission, total issuance, the election schedule, the nomination quota and per-Account exposure. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, the units of the total staked amount, era progress on a chain that has skipped epochs, bond and rebond calls the chain would refuse, and a false "not included" rejection when claiming dividends.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -231,6 +231,22 @@ await sdk.staking.chill();
 ```typescript
 await sdk.staking.rebond({ amount: new BigNumber(100) });
 ```
+
+### Read the validators an Account's stake backed
+
+`account.staking.getExposure()` returns the validators an era assigned this Account's stake to, and how much each one carried.
+
+```typescript
+const exposure = await account.staking.getExposure();
+// [{ validator: Account, value: BigNumber }, ...]
+
+// or for a past era
+const exposure = await account.staking.getExposure({ era: new BigNumber(7131) });
+```
+
+The chain keys exposure by validator, so this is the inverse of `staking.getEraNominators()` and could not be asked before. An era's assignments are fixed when it is elected, so the result can name a validator the Account no longer nominates: `getNomination()` reads intent, this reads what the election assigned.
+
+A validator's own self-bond is not included — read that as `own` from `staking.getEraExposure({ validator })`. An era with no exposure recorded throws `DataUnavailable`. It reads every exposure page in the era, so it is a heavier read than the per-validator ones.
 
 ### Read how many validators an Account may nominate
 

--- a/src/api/client/Staking.ts
+++ b/src/api/client/Staking.ts
@@ -55,6 +55,7 @@ import {
 } from '~/utils/conversion';
 import {
   asAccount,
+  asRawEra,
   createProcedureMethod,
   getSlotAtBlock,
   QueryMultiParam,
@@ -816,7 +817,7 @@ export class Staking {
     const era = BigNumber.isBigNumber(eraOrCallback) ? eraOrCallback : undefined;
     const callback = BigNumber.isBigNumber(eraOrCallback) ? maybeCallback : eraOrCallback;
 
-    const rawEra = await this.asRawEra(era);
+    const rawEra = await asRawEra(era, context);
 
     const assembleResult = (rawPoints: PalletStakingEraRewardPoints): EraRewardPoints => {
       const { total, individual } = rawPoints;
@@ -852,12 +853,13 @@ export class Staking {
    */
   public async getEraValidatorReward(era?: BigNumber): Promise<BigNumber | null> {
     const {
+      context,
       context: {
         polymeshApi: { query },
       },
     } = this;
 
-    const rawEra = await this.asRawEra(era);
+    const rawEra = await asRawEra(era, context);
 
     const rawReward = await query.staking.erasValidatorReward(rawEra);
 
@@ -873,12 +875,13 @@ export class Staking {
    */
   public async getEraStartSession(era?: BigNumber): Promise<BigNumber | null> {
     const {
+      context,
       context: {
         polymeshApi: { query },
       },
     } = this;
 
-    const rawEra = await this.asRawEra(era);
+    const rawEra = await asRawEra(era, context);
 
     const rawIndex = await query.staking.erasStartSessionIndex(rawEra);
 
@@ -906,7 +909,7 @@ export class Staking {
 
     const { validator, era } = args;
 
-    const rawEra = await this.asRawEra(era);
+    const rawEra = await asRawEra(era, context);
     const rawAddress = stringToAccountId(asAccount(validator, context).address, context);
 
     const rawOverview = await query.staking.erasStakersOverview(rawEra, rawAddress);
@@ -952,7 +955,7 @@ export class Staking {
 
     const { validator, page = new BigNumber(0), era } = args;
 
-    const rawEra = await this.asRawEra(era);
+    const rawEra = await asRawEra(era, context);
     const rawAddress = stringToAccountId(asAccount(validator, context).address, context);
     const rawPage = bigNumberToU32(page, context);
 
@@ -1120,32 +1123,4 @@ export class Staking {
     return ElectionPhase[rawPhase.type];
   }
 
-  /**
-   * @hidden
-   *
-   * Resolve an optional era argument to the era to query, defaulting to the active one
-   */
-  private async asRawEra(era?: BigNumber): Promise<u32> {
-    const {
-      context,
-      context: {
-        polymeshApi: { query },
-      },
-    } = this;
-
-    if (era) {
-      return bigNumberToU32(era, context);
-    }
-
-    const rawActiveEra = await query.staking.activeEra();
-
-    if (rawActiveEra.isNone) {
-      throw new PolymeshError({
-        code: ErrorCode.DataUnavailable,
-        message: 'There is no active staking era',
-      });
-    }
-
-    return rawActiveEra.unwrap().index;
-  }
 }

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -496,6 +496,18 @@ export interface EraNominators {
   }[];
 }
 
+export interface AccountExposure {
+  /**
+   * The validator the stake was assigned to
+   */
+  validator: Account;
+
+  /**
+   * The POLYX of this Account's stake that backed the validator in the era
+   */
+  value: BigNumber;
+}
+
 /**
  * How far through a period the chain is
  *

--- a/src/api/entities/Account/Staking/index.ts
+++ b/src/api/entities/Account/Staking/index.ts
@@ -3,8 +3,10 @@ import { AccountId, RewardDestination } from '@polkadot/types/interfaces';
 import { PalletStakingNominations } from '@polkadot/types/lookup';
 import BigNumber from 'bignumber.js';
 
-import { Account, Namespace } from '~/internal';
+import { Account, Namespace, PolymeshError } from '~/internal';
 import {
+  AccountExposure,
+  ErrorCode,
   StakingCommission,
   StakingLedger,
   StakingNomination,
@@ -24,6 +26,7 @@ import {
   stringToAccountId,
   u32ToBigNumber,
 } from '~/utils/conversion';
+import { asRawEra, requestPaginated } from '~/utils/internal';
 
 /**
  * Handles Account staking related functionality
@@ -281,6 +284,58 @@ export class Staking extends Namespace<Account> {
       account: this.parent,
       ...commission,
     };
+  }
+
+  /**
+   * Fetch the validators this Account's stake backed in an era, and how much each one carried
+   *
+   * @param args.era - defaults to the active era
+   *
+   * @returns one entry per validator backed, or an empty array where the Account backed none. A
+   *   validator's own self-bond is not included — read that as `own` from
+   *   {@link api/client/Staking!Staking.getEraExposure | getEraExposure}
+   *
+   * @throws if the era has no exposure recorded, such as one outside the chain's history depth
+   *
+   * @note an era's assignments are fixed when it is elected, so this can name a validator the
+   *   Account no longer nominates. {@link getNomination} reads intent; this reads what the election
+   *   assigned
+   *
+   * @note reads every exposure page in the era, so it costs one paged storage request over the
+   *   whole validator set
+   */
+  public async getExposure(args?: { era?: BigNumber }): Promise<AccountExposure[]> {
+    const {
+      context,
+      context: {
+        polymeshApi: { query },
+      },
+      parent: { address },
+    } = this;
+
+    const rawEra = await asRawEra(args?.era, context);
+
+    const { entries } = await requestPaginated(query.staking.erasStakersPaged, { arg: rawEra });
+
+    if (!entries.length) {
+      throw new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'No exposure is recorded for that era',
+        data: { era: rawEra.toString() },
+      });
+    }
+
+    return entries.flatMap(([key, rawPage]) => {
+      const validatorAddress = accountIdToString(key.args[1]);
+
+      return rawPage
+        .unwrap()
+        .others.filter(({ who }) => accountIdToString(who) === address)
+        .map(({ value }) => ({
+          validator: new Account({ address: validatorAddress }, context),
+          value: balanceToBigNumber(value.unwrap()),
+        }));
+    });
   }
 
   /**

--- a/src/api/entities/Account/__tests__/Staking.ts
+++ b/src/api/entities/Account/__tests__/Staking.ts
@@ -2,8 +2,9 @@ import BigNumber from 'bignumber.js';
 import { when } from 'jest-when';
 
 import { Staking } from '~/api/entities/Account/Staking';
-import { Account, Context, Namespace } from '~/internal';
+import { Account, Context, Namespace, PolymeshError } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { ErrorCode } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(
@@ -107,9 +108,7 @@ describe('Staking namespace', () => {
         returnValue: dsMockUtils.createMockOption(
           dsMockUtils.createMockStakingLedger({
             stash: dsMockUtils.createMockAccountId('someId'),
-            total: dsMockUtils.createMockCompact(
-              dsMockUtils.createMockU128(active.times(10 ** 6))
-            ),
+            total: dsMockUtils.createMockCompact(dsMockUtils.createMockU128(active.times(10 ** 6))),
             active: dsMockUtils.createMockCompact(
               dsMockUtils.createMockU128(active.times(10 ** 6))
             ),
@@ -517,6 +516,148 @@ describe('Staking namespace', () => {
       const result = await staking.getCommission({ era: new BigNumber(7131) });
 
       expect(result).toBeNull();
+    });
+  });
+  describe('method: getExposure', () => {
+    const era = new BigNumber(7201);
+    const rawEra = dsMockUtils.createMockU32(era);
+
+    beforeEach(() => {
+      when(jest.spyOn(utilsConversionModule, 'bigNumberToU32'))
+        .calledWith(era, mockContext)
+        .mockReturnValue(rawEra);
+    });
+
+    const exposurePage = (
+      others: { address: string; value: BigNumber }[]
+    ): ReturnType<typeof dsMockUtils.createMockOption> =>
+      dsMockUtils.createMockOption(
+        dsMockUtils.createMockExposurePage({
+          pageTotal: dsMockUtils.createMockCompact(dsMockUtils.createMockU128(new BigNumber(0))),
+          others: others.map(({ address, value }) =>
+            dsMockUtils.createMockIndividualExposure({
+              who: dsMockUtils.createMockAccountId(address),
+              value: dsMockUtils.createMockCompact(
+                dsMockUtils.createMockU128(value.times(10 ** 6))
+              ),
+            })
+          ),
+        })
+      );
+
+    const rawPage = (page: number): ReturnType<typeof dsMockUtils.createMockU32> =>
+      dsMockUtils.createMockU32(new BigNumber(page));
+
+    it('should return the operators the Account is exposed to in the active era', async () => {
+      dsMockUtils.createQueryMock('staking', 'activeEra', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockActiveEraInfo({
+            index: rawEra,
+            start: dsMockUtils.createMockOption(),
+          })
+        ),
+      });
+
+      dsMockUtils.createQueryMock('staking', 'erasStakersPaged', {
+        entries: [
+          [
+            [
+              rawEra,
+              dsMockUtils.createMockAccountId('validatorOne'),
+              dsMockUtils.createMockU32(new BigNumber(0)),
+            ],
+            exposurePage([
+              { address: 'someOtherNominator', value: new BigNumber(7) },
+              { address: account.address, value: new BigNumber(100) },
+            ]),
+          ],
+        ],
+      });
+
+      const result = await staking.getExposure();
+
+      expect(result).toEqual([
+        {
+          validator: expect.objectContaining({ address: 'validatorOne' }),
+          value: new BigNumber(100),
+        },
+      ]);
+    });
+
+    it('should throw if the era has no exposure recorded at all', async () => {
+      dsMockUtils.createQueryMock('staking', 'erasStakersPaged', { entries: [] });
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.DataUnavailable,
+        message: 'No exposure is recorded for that era',
+        data: { era: expect.any(String) },
+      });
+
+      await expect(staking.getExposure({ era })).rejects.toThrow(expectedError);
+    });
+
+    it('should return an empty array where the Account backed nobody in the era', async () => {
+      dsMockUtils.createQueryMock('staking', 'erasStakersPaged', {
+        entries: [
+          [
+            [rawEra, dsMockUtils.createMockAccountId('validatorOne'), rawPage(0)],
+            exposurePage([{ address: 'someOtherNominator', value: new BigNumber(7) }]),
+          ],
+        ],
+      });
+
+      const result = await staking.getExposure({ era });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should find the Account across validators even when it sits on different pages', async () => {
+      dsMockUtils.createQueryMock('staking', 'erasStakersPaged', {
+        entries: [
+          [
+            [rawEra, dsMockUtils.createMockAccountId('validatorOne'), rawPage(0)],
+            exposurePage([{ address: account.address, value: new BigNumber(100) }]),
+          ],
+          [
+            [rawEra, dsMockUtils.createMockAccountId('validatorTwo'), rawPage(0)],
+            exposurePage([{ address: 'someOtherNominator', value: new BigNumber(7) }]),
+          ],
+          [
+            [rawEra, dsMockUtils.createMockAccountId('validatorThree'), rawPage(1)],
+            exposurePage([{ address: account.address, value: new BigNumber(50) }]),
+          ],
+        ],
+      });
+
+      const result = await staking.getExposure({ era });
+
+      expect(result).toEqual([
+        {
+          validator: expect.objectContaining({ address: 'validatorOne' }),
+          value: new BigNumber(100),
+        },
+        {
+          validator: expect.objectContaining({ address: 'validatorThree' }),
+          value: new BigNumber(50),
+        },
+      ]);
+    });
+
+    it('should not read the active era when one is given', async () => {
+      const activeEraMock = dsMockUtils.createQueryMock('staking', 'activeEra');
+
+      dsMockUtils.createQueryMock('staking', 'erasStakersPaged', {
+        entries: [
+          [
+            [rawEra, dsMockUtils.createMockAccountId('validatorOne'), rawPage(0)],
+            exposurePage([{ address: account.address, value: new BigNumber(100) }]),
+          ],
+        ],
+      });
+
+      await staking.getExposure({ era });
+
+      expect(activeEraMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -2553,3 +2553,31 @@ export async function getSlotAtBlock(context: Context, blockNumber: BigNumber): 
 
   return u64ToBigNumber(slot);
 }
+
+/**
+ * @hidden
+ *
+ * Resolve an optional era argument to the era to query, defaulting to the active one
+ *
+ * @throws if no era is given and the chain has no active era
+ */
+export async function asRawEra(era: BigNumber | undefined, context: Context): Promise<u32> {
+  const {
+    polymeshApi: { query },
+  } = context;
+
+  if (era) {
+    return bigNumberToU32(era, context);
+  }
+
+  const rawActiveEra = await query.staking.activeEra();
+
+  if (rawActiveEra.isNone) {
+    throw new PolymeshError({
+      code: ErrorCode.DataUnavailable,
+      message: 'There is no active staking era',
+    });
+  }
+
+  return rawActiveEra.unwrap().index;
+}


### PR DESCRIPTION
### Description

`account.staking.getExposure({ era? })` returns the validators an era assigned this Account's stake to, and how much of it each one carried.

```typescript
const exposure = await account.staking.getExposure();
// [{ validator: Account, value: BigNumber }, ...]

const past = await account.staking.getExposure({ era: new BigNumber(7131) });
```

The chain keys exposure by validator — `erasStakersPaged` is keyed `(era, validator, page)`, and `getEraExposure` and `getEraNominators` both take the validator as a required argument — so a nominator could not ask this at all.

#### Why it is not the nomination list

An era's assignments are fixed when it is elected, so the result can name a validator the Account no longer nominates. `getNomination()` reads intent; this reads what the election assigned.

The two differ even without any change of mind, because the election solver assigns to a subset. Verified against mainnet through the built SDK — an Account nominating 16 validators was exposed to 12:

```
exposed to 12 validator(s):
  2HW34bz2Ue9RicxMGfPH6HaFRQKM416cJivXdciXTYsNz3Dz  6135410.439734 POLYX
  2DTnwmkN1R776C4Dm95V7JL1A9jhcwH556sxs5Q4BRXN8TQT  6801050.138582 POLYX
  ... (10 more)
currently nominates 16
```

#### Cost, and why it is not paginated

There is no chain index from nominator to validator, so this reads every exposure page in the era and filters them. Because the map is keyed with the **era first**, that is one prefix scan rather than a read per validator. Measured on both live chains before building:

| | testnet | mainnet |
|---|---|---|
| elected validators | 23 | 83 |
| storage entries for the era | 24 | 94 |
| full scan | 340 ms | 116 ms |
| operators the most-exposed account backs | 10 | 12 |

The alternative — 83 `erasStakersOverview` reads plus a read per page — is an order of magnitude worse.

It is **deliberately not paginated**, which departs from the original plan. Each storage entry holds up to `maxExposurePageSize` (64) nominators and the Account may sit in any of them, so a page of 25 storage keys can yield **zero** matches while `next` still reports more to come — the same "short pages with a live cursor" failure already fixed elsewhere in this changelog. The complete answer is bounded by the nomination quota (16 on Polymesh) regardless, so there is nothing to page.

#### Behaviour

- `era` defaults to the active era, via the same helper the client's era reads use
- an Account that backed nobody returns `[]`
- an era with **no exposure recorded at all** throws `DataUnavailable`, rather than returning an empty array that cannot be told apart from the case above
- a validator's own self-bond is **not** included; that is `own` from `staking.getEraExposure({ validator })`

#### Commits

1. `refactor: share the era-defaulting helper` — `Staking.asRawEra` was private to the client class; the Account namespace needs the same defaulting, so it moves to `~/utils/internal` as a free function. Five client call sites switch over; behaviour unchanged.
2. `feat: read the validators an Account's stake backed` — the method, its `AccountExposure` type, tests and changelog.

#### Verification

- `yarn build:ts` — passes
- `yarn lint` — passes
- `yarn test` — **209 suites, 2733 tests, all passing**
- **100% statements/branches/functions/lines** on all three touched source files
- exercised against Polymesh mainnet through the built SDK, as above

Tests cover the era default, an explicit era not falling back to the active one, an Account that backed nobody, the `DataUnavailable` throw, and an Account found across several validators **on different pages** — the case a paginated implementation would have broken.

### Breaking Changes

None. One new method, one new exported type, no existing signature changed.

### JIRA Link

<!-- add issue -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
