### PR TITLE
Account allowances

### DIFF
--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -248,6 +248,16 @@ The chain keys exposure by validator, so this is the inverse of `staking.getEraN
 
 A validator's own self-bond is not included — read that as `own` from `staking.getEraExposure({ validator })`. An era with no exposure recorded throws `DataUnavailable`. It reads every exposure page in the era, so it is a heavier read than the per-validator ones.
 
+### Approve a spender without a limit
+
+`asset.approveAllowance({ spender, unlimited: true })` grants an allowance the chain never deducts from, so it does not run down as it is used and only an explicit revocation ends it.
+
+```typescript
+await asset.approveAllowance({ spender, unlimited: true });
+```
+
+`ApproveAllowanceParams.amount` documented `Balance::MAX = unlimited`, but the value was rejected before it reached the chain: `amount` is converted as a balance, which is capped far below it. `amount` and `unlimited` are now both optional and exactly one must be passed.
+
 ### Read how many validators an Account may nominate
 
 `account.staking.getNominationQuota()` returns the cap the chain will hold `nominate` to.

--- a/changelogs/v31.0.0-next.md
+++ b/changelogs/v31.0.0-next.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Changelog - v31.0.0 to next release
-description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, reading what an Identity holds now with the amount, an optional middleware API key, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission, total issuance, the election schedule, the nomination quota and per-Account exposure. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, the units of the total staked amount, era progress on a chain that has skipped epochs, bond and rebond calls the chain would refuse, and a false "not included" rejection when claiming dividends.
+description: Pending changes since Polymesh SDK v31.0.0. Adds Ethereum wallet signing and address mapping, broadcasting a transaction without waiting for it, issuing NFTs to an Account, connecting from runtimes that disallow WASM compilation, ordering POLYX transaction history, reading what an Identity holds now with the amount, an optional middleware API key, listing the Asset allowances an Account has approved, and staking coverage for chill, rebond, era progress, historical era data, the validator set, commission, total issuance, the election schedule, the nomination quota and per-Account exposure. Fixes BigNumber checks across duplicate package copies, ignored authorization expiry options, unbounded Portfolio scans, on-chain failure reporting, staking permission checks, withdrawing unbonded POLYX where the controller is not the stash, the units of the total staked amount, era progress on a chain that has skipped epochs, bond and rebond calls the chain would refuse, and a false "not included" rejection when claiming dividends.
 sidebar_label: v31.0.0 → next
 id: v31-0-to-next
 tags:
@@ -281,6 +281,21 @@ await sdk.createTransactionBatch({
 ```
 
 Without it, `nominate()` still requires the acting Account to be a controller already.
+
+### List the Asset allowances an Account has approved
+
+`account.getAllowances()` returns every allowance the Account has approved — the spender, the Asset, and what may be transferred. `fungibleAsset.getAllowances({ owner })` narrows that to one Asset.
+
+```typescript
+const { data, next } = await account.getAllowances();
+// [{ asset, spender, amount, unlimited }, ...]
+
+const forThisAsset = await asset.getAllowances({ owner });
+```
+
+Only a single allowance could be read before, and only if the spender was already known — which it usually is not. `unlimited` marks an allowance the chain never deducts from, so `amount` need not be rendered.
+
+Revoking an allowance removes its entry, so every result is live. The Account-level read pages the chain; the Asset-level one does not, because allowances are keyed by owner, spender and Asset in that order, so the Asset can only be filtered after reading. The chain cannot answer the reverse question, "who has approved me", for the same reason.
 
 ### Order POLYX transaction history
 

--- a/src/api/entities/Account/__tests__/index.ts
+++ b/src/api/entities/Account/__tests__/index.ts
@@ -1151,6 +1151,93 @@ describe('Account class', () => {
     });
   });
 
+  describe('method: getAllowances', () => {
+    const spenderOne = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+    const spenderTwo = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
+    const assetIdOne = '0x11111111111111111111111111111111';
+    const assetIdTwo = '0x22222222222222222222222222222222';
+    const uuidOne = '11111111-1111-1111-1111-111111111111';
+    const uuidTwo = '22222222-2222-2222-2222-222222222222';
+
+    const allowanceEntry = (
+      spender: string,
+      assetId: string,
+      amount: BigNumber
+    ): [unknown[], unknown] => [
+      [
+        createMockAccountId(address),
+        createMockAccountId(spender),
+        dsMockUtils.createMockAssetId(assetId),
+      ],
+      dsMockUtils.createMockBalance(amount),
+    ];
+
+    it('should return the allowances the Account has approved', async () => {
+      dsMockUtils.createQueryMock('asset', 'allowances', {
+        entries: [
+          allowanceEntry(spenderOne, assetIdOne, new BigNumber(1000).times(10 ** 6)),
+          allowanceEntry(spenderTwo, assetIdTwo, new BigNumber(50).times(10 ** 6)),
+        ],
+      });
+
+      const allowanceAccount = new Account({ address }, context);
+
+      const { data, next } = await allowanceAccount.getAllowances();
+
+      expect(data).toHaveLength(2);
+
+      expect(data[0]!.asset.id).toBe(uuidOne);
+      expect(data[0]!.spender.address).toBe(spenderOne);
+      expect(data[0]!.amount).toEqual(new BigNumber(1000));
+      expect(data[0]!.unlimited).toBe(false);
+
+      expect(data[1]!.asset.id).toBe(uuidTwo);
+      expect(data[1]!.spender.address).toBe(spenderTwo);
+      expect(data[1]!.amount).toEqual(new BigNumber(50));
+
+      expect(next).toBeNull();
+    });
+
+    it('should flag an allowance the chain treats as unlimited', async () => {
+      const max = new BigNumber(2).exponentiatedBy(128).minus(1);
+
+      dsMockUtils.createQueryMock('asset', 'allowances', {
+        entries: [allowanceEntry(spenderOne, assetIdOne, max)],
+      });
+
+      const allowanceAccount = new Account({ address }, context);
+
+      const { data } = await allowanceAccount.getAllowances();
+
+      expect(data[0]!.unlimited).toBe(true);
+    });
+
+    it('should return an empty set where the Account has approved nothing', async () => {
+      dsMockUtils.createQueryMock('asset', 'allowances', { entries: [] });
+
+      const allowanceAccount = new Account({ address }, context);
+
+      const { data, next } = await allowanceAccount.getAllowances();
+
+      expect(data).toEqual([]);
+      expect(next).toBeNull();
+    });
+
+    it('should page the scan when pagination options are passed', async () => {
+      dsMockUtils.createQueryMock('asset', 'allowances', {
+        entries: [allowanceEntry(spenderOne, assetIdOne, new BigNumber(1000).times(10 ** 6))],
+      });
+
+      const allowanceAccount = new Account({ address }, context);
+
+      const { data, next } = await allowanceAccount.getAllowances({ size: new BigNumber(1) });
+
+      expect(data).toHaveLength(1);
+      // a full page means there may be more, so the cursor stays live
+      expect(next).not.toBeNull();
+    });
+  });
+
   describe('method: getCollections', () => {
     it('should return collections held by the Account', async () => {
       const rawAccountId = dsMockUtils.createMockAccountId(address);

--- a/src/api/entities/Account/index.ts
+++ b/src/api/entities/Account/index.ts
@@ -41,6 +41,7 @@ import { ExtrinsicsOrderBy, PolyxTransactionsOrderBy, Query } from '~/middleware
 import {
   AccountBalance,
   AccountCollection,
+  AssetAllowance,
   AssetHolderBalance,
   CheckPermissionsResult,
   ErrorCode,
@@ -48,6 +49,7 @@ import {
   MiddlewarePaginationOptions,
   MultiSigTx,
   NftOwnerStatus,
+  PaginationOptions,
   Permissions,
   PermissionType,
   PortfolioCollection,
@@ -60,7 +62,7 @@ import {
 } from '~/types';
 import { Ensured, tuple } from '~/types/utils';
 import { hexToUuid } from '~/utils';
-import { ASSET_ID_PREFIX } from '~/utils/constants';
+import { ASSET_ID_PREFIX, UNLIMITED_ALLOWANCE } from '~/utils/constants';
 import {
   accountIdToString,
   addressToKey,
@@ -74,6 +76,7 @@ import {
   txTagToExtrinsicIdentifier,
   u32ToBigNumber,
   u64ToBigNumber,
+  u128ToBigNumber,
 } from '~/utils/conversion';
 import {
   ethAddressFromSs58,
@@ -90,6 +93,7 @@ import {
   getIdentityFromKeyRecord,
   getSecondaryAccountPermissions,
   requestMulti,
+  requestPaginated,
 } from '~/utils/internal';
 
 /**
@@ -779,6 +783,52 @@ export class Account extends Entity<UniqueIdentifiers, string> {
     rawBytes[8] = (rawBytesEight & 0x3f) | 0x80;
 
     return hexToUuid(u8aToHex(rawBytes));
+  }
+
+  /**
+   * Retrieve the Asset allowances this Account has approved — what each spender may transfer on
+   *   its behalf, and for which Asset
+   *
+   * @note revoking an allowance removes it, so every entry returned is live. An Account with no
+   *   approvals returns an empty set
+   *
+   * @note the chain cannot be asked the reverse question, "who has approved *me*", because the
+   *   spender is not the key this map is ordered by
+   */
+  public async getAllowances(
+    paginationOpts?: PaginationOptions
+  ): Promise<ResultSet<AssetAllowance>> {
+    const {
+      address,
+      context,
+      context: {
+        polymeshApi: {
+          query: { asset },
+        },
+      },
+    } = this;
+
+    const rawAddress = stringToAccountId(address, context);
+
+    const { entries, lastKey: next } = await requestPaginated(asset.allowances, {
+      arg: rawAddress,
+      paginationOpts,
+    });
+
+    const data = entries.map(([storageKey, rawAmount]) => {
+      const {
+        args: [, rawSpender, rawAssetId],
+      } = storageKey;
+
+      return {
+        asset: new FungibleAsset({ assetId: assetIdToString(rawAssetId) }, context),
+        spender: new Account({ address: accountIdToString(rawSpender) }, context),
+        amount: balanceToBigNumber(rawAmount),
+        unlimited: u128ToBigNumber(rawAmount).eq(UNLIMITED_ALLOWANCE),
+      };
+    });
+
+    return { data, next };
   }
 
   /**

--- a/src/api/entities/Asset/Fungible/index.ts
+++ b/src/api/entities/Asset/Fungible/index.ts
@@ -23,6 +23,7 @@ import { tickerExternalAgentHistoryQuery } from '~/middleware/queries/externalAg
 import { AssetTransactionsOrderBy, Query } from '~/middleware/types';
 import {
   ApproveAllowanceParams,
+  AssetAllowance,
   ControllerTransferParams,
   EventIdentifier,
   HistoricAgentOperation,
@@ -33,13 +34,17 @@ import {
   ResultSet,
 } from '~/types';
 import { Ensured } from '~/types/utils';
+import { UNLIMITED_ALLOWANCE } from '~/utils/constants';
 import {
+  accountIdToString,
+  assetIdToString,
   assetToMeshAssetId,
   balanceToBigNumber,
   middlewareEventDetailsToEventIdentifier,
   middlewarePortfolioToPortfolio,
   portfolioIdStringToPortfolio,
   stringToAccountId,
+  u128ToBigNumber,
 } from '~/utils/conversion';
 import {
   asAccount,
@@ -48,6 +53,7 @@ import {
   getAssetIdForMiddleware,
   getAssetIdFromMiddleware,
   optionize,
+  requestPaginated,
 } from '~/utils/internal';
 
 /**
@@ -305,6 +311,43 @@ export class FungibleAsset extends BaseAsset {
    * On every spend transaction, the spender account's allowance will be decremented by the amount transferred.
    */
   public approveAllowance: ProcedureMethod<ApproveAllowanceParams, void>;
+
+  /**
+   * Retrieve every allowance an Account has approved for this Asset — each spender and what it may
+   *   transfer
+   *
+   * @param args.owner - the Account whose approvals to read
+   *
+   * @note not paginated: allowances are keyed by owner, spender and Asset in that order, so the
+   *   Asset can only be filtered after reading. Bounded by how many approvals the owner has made
+   *   across all Assets
+   */
+  public async getAllowances(args: { owner: AccountLike }): Promise<AssetAllowance[]> {
+    const {
+      context,
+      context: {
+        polymeshApi: {
+          query: { asset },
+        },
+      },
+      id: assetId,
+    } = this;
+
+    const { address: ownerAddress } = asAccount(args.owner, context);
+
+    const rawOwner = stringToAccountId(ownerAddress, context);
+
+    const { entries } = await requestPaginated(asset.allowances, { arg: rawOwner });
+
+    return entries
+      .filter(([{ args: keys }]) => assetIdToString(keys[2]) === assetId)
+      .map(([{ args: keys }, rawAmount]) => ({
+        asset: this,
+        spender: new Account({ address: accountIdToString(keys[1]) }, context),
+        amount: balanceToBigNumber(rawAmount),
+        unlimited: u128ToBigNumber(rawAmount).eq(UNLIMITED_ALLOWANCE),
+      }));
+  }
 
   /**
    * Retrieve the amount of allowance for a spender account as approved by owner

--- a/src/api/entities/Asset/__tests__/Fungible/index.ts
+++ b/src/api/entities/Asset/__tests__/Fungible/index.ts
@@ -1024,4 +1024,52 @@ describe('Fungible class', () => {
       expect(result).toEqual(allowance);
     });
   });
+  describe('method: getAllowances', () => {
+    const owner = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+    const spender = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
+    const thisAssetId = '12341234-1234-1234-1234-123412341234';
+    const thisRawId = '0x12341234123412341234123412341234';
+    const otherRawId = '0x43214321432143214321432143214321';
+
+    const entry = (assetId: string, amount: BigNumber): [unknown[], unknown] => [
+      [
+        dsMockUtils.createMockAccountId(owner),
+        dsMockUtils.createMockAccountId(spender),
+        dsMockUtils.createMockAssetId(assetId),
+      ],
+      dsMockUtils.createMockBalance(amount.shiftedBy(6)),
+    ];
+
+    it('should return only the allowances that name this Asset', async () => {
+      const context = dsMockUtils.getContextInstance();
+      const asset = new FungibleAsset({ assetId: thisAssetId }, context);
+
+      dsMockUtils.createQueryMock('asset', 'allowances', {
+        entries: [
+          entry(otherRawId, new BigNumber(999)),
+          entry(thisRawId, new BigNumber(150)),
+        ],
+      });
+
+      const result = await asset.getAllowances({ owner });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.spender.address).toBe(spender);
+      expect(result[0]!.amount).toEqual(new BigNumber(150));
+      expect(result[0]!.unlimited).toBe(false);
+    });
+
+    it('should return an empty array where the owner has approved nothing for this Asset', async () => {
+      const context = dsMockUtils.getContextInstance();
+      const asset = new FungibleAsset({ assetId: thisAssetId }, context);
+
+      dsMockUtils.createQueryMock('asset', 'allowances', {
+        entries: [entry(otherRawId, new BigNumber(999))],
+      });
+
+      const result = await asset.getAllowances({ owner });
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/src/api/entities/Asset/types.ts
+++ b/src/api/entities/Asset/types.ts
@@ -380,6 +380,29 @@ export interface FungibleAssetHolding {
 }
 
 /**
+ * An allowance an Account has approved, letting a spender transfer an Asset on its behalf
+ */
+export interface AssetAllowance {
+  asset: FungibleAsset;
+  /**
+   * the Account permitted to spend
+   */
+  spender: Account;
+  /**
+   * the most the spender may transfer
+   *
+   * @note where `unlimited` is true this is the chain's maximum balance, which is not a meaningful
+   *   figure to display. Check `unlimited` first
+   */
+  amount: BigNumber;
+  /**
+   * whether the spender may transfer without limit. The chain never deducts from such an
+   *   allowance, so it does not run down as it is used
+   */
+  unlimited: boolean;
+}
+
+/**
  * For all claim types except Jurisdiction - tracks holders with and without the claim
  */
 export type ClaimValue = {

--- a/src/api/procedures/__tests__/approveAllowance.ts
+++ b/src/api/procedures/__tests__/approveAllowance.ts
@@ -13,6 +13,7 @@ import { Context, FungibleAsset, PolymeshError, Procedure } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import { ErrorCode, TxTags } from '~/types';
+import { UNLIMITED_ALLOWANCE } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as utilsInternalModule from '~/utils/internal';
 
@@ -21,6 +22,7 @@ describe('approveAllowance procedure', () => {
   let assetToMeshAssetIdSpy: jest.SpyInstance;
   let stringToAccountIdSpy: jest.SpyInstance;
   let bigNumberToBalanceSpy: jest.SpyInstance;
+  let bigNumberToU128Spy: jest.SpyInstance;
   let asAccountSpy: jest.SpyInstance;
   let asset: FungibleAsset;
   let rawAssetId: PolymeshPrimitivesAssetAssetId;
@@ -34,6 +36,7 @@ describe('approveAllowance procedure', () => {
     assetToMeshAssetIdSpy = jest.spyOn(utilsConversionModule, 'assetToMeshAssetId');
     stringToAccountIdSpy = jest.spyOn(utilsConversionModule, 'stringToAccountId');
     bigNumberToBalanceSpy = jest.spyOn(utilsConversionModule, 'bigNumberToBalance');
+    bigNumberToU128Spy = jest.spyOn(utilsConversionModule, 'bigNumberToU128');
     asAccountSpy = jest.spyOn(utilsInternalModule, 'asAccount');
   });
 
@@ -101,6 +104,66 @@ describe('approveAllowance procedure', () => {
         args: [rawAssetId, rawAccountId, rawBalance],
         resolver: undefined,
       });
+    });
+  });
+
+  describe('prepareApproveAllowance with unlimited', () => {
+    it('should send the chain the maximum balance, bypassing the amount cap', async () => {
+      const spender = 'someSpender';
+
+      const rawU128 = dsMockUtils.createMockU128(UNLIMITED_ALLOWANCE);
+
+      bigNumberToBalanceSpy.mockClear();
+
+      asAccountSpy.mockReturnValue(entityMockUtils.getAccountInstance({ address: spender }));
+      when(stringToAccountIdSpy).calledWith(spender, mockContext).mockReturnValue(rawAccountId);
+      when(bigNumberToU128Spy)
+        .calledWith(UNLIMITED_ALLOWANCE, mockContext)
+        .mockReturnValue(rawU128);
+
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+      const result = await prepareApproveAllowance.call(proc, {
+        asset,
+        spender,
+        unlimited: true,
+      });
+
+      // the ordinary balance conversion caps at MAX_BALANCE, so it must not be used here
+      expect(bigNumberToBalanceSpy).not.toHaveBeenCalled();
+      expect(bigNumberToU128Spy).toHaveBeenCalledWith(UNLIMITED_ALLOWANCE, mockContext);
+      expect(result.args[2]).toBe(rawU128);
+    });
+
+    it('should throw if neither an amount nor unlimited is given', () => {
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'Pass either an allowance amount or `unlimited`, but not both',
+      });
+
+      expect(() =>
+        prepareApproveAllowance.call(proc, { asset, spender: 'someSpender' })
+      ).toThrow(expectedError);
+    });
+
+    it('should throw if both an amount and unlimited are given', () => {
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+      const expectedError = new PolymeshError({
+        code: ErrorCode.UnmetPrerequisite,
+        message: 'Pass either an allowance amount or `unlimited`, but not both',
+      });
+
+      expect(() =>
+        prepareApproveAllowance.call(proc, {
+          asset,
+          spender: 'someSpender',
+          amount: new BigNumber(100),
+          unlimited: true,
+        })
+      ).toThrow(expectedError);
     });
   });
 

--- a/src/api/procedures/approveAllowance.ts
+++ b/src/api/procedures/approveAllowance.ts
@@ -1,7 +1,13 @@
 import { FungibleAsset, PolymeshError, Procedure } from '~/internal';
 import { ApproveAllowanceParams, ErrorCode, TxTags } from '~/types';
 import { ExtrinsicParams, ProcedureAuthorization, TransactionSpec } from '~/types/internal';
-import { assetToMeshAssetId, bigNumberToBalance, stringToAccountId } from '~/utils/conversion';
+import { UNLIMITED_ALLOWANCE } from '~/utils/constants';
+import {
+  assetToMeshAssetId,
+  bigNumberToBalance,
+  bigNumberToU128,
+  stringToAccountId,
+} from '~/utils/conversion';
 import { asAccount } from '~/utils/internal';
 
 /**
@@ -27,9 +33,16 @@ export function prepareApproveAllowance(
     context,
   } = this;
 
-  const { asset, amount, spender } = args;
+  const { asset, amount, spender, unlimited } = args;
 
-  if (amount.lt(0)) {
+  if (!!unlimited === !!amount) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Pass either an allowance amount or `unlimited`, but not both',
+    });
+  }
+
+  if (amount?.lt(0)) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
       message:
@@ -41,13 +54,17 @@ export function prepareApproveAllowance(
 
   const { address: spenderAddress } = asAccount(spender, context);
 
+  /*
+   * an unlimited allowance is `Balance::MAX`, which is far above the balance any real amount may
+   *   take, so it goes straight to a `u128` rather than through the capped balance conversion
+   */
+  const rawAmount = amount
+    ? bigNumberToBalance(amount, context)
+    : bigNumberToU128(UNLIMITED_ALLOWANCE, context);
+
   return Promise.resolve({
     transaction: approve,
-    args: [
-      rawAssetId,
-      stringToAccountId(spenderAddress, context),
-      bigNumberToBalance(amount, context),
-    ],
+    args: [rawAssetId, stringToAccountId(spenderAddress, context), rawAmount],
     resolver: undefined,
   });
 }

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -2086,9 +2086,19 @@ export interface ApproveAllowanceParams {
   spender: AccountLike;
 
   /**
-   * Maximum amount the `spender` may transfer. Passing `0` will revoke the approval. Balance::MAX = unlimited.
+   * Maximum amount the `spender` may transfer. Passing `0` will revoke the approval
+   *
+   * @note required unless `unlimited` is passed
    */
-  amount: BigNumber;
+  amount?: BigNumber;
+
+  /**
+   * Approve the `spender` without a limit. The chain never deducts from such an allowance, so it
+   *   does not run down as it is used and only an explicit revocation ends it
+   *
+   * @note pass this instead of `amount`, not as well as it
+   */
+  unlimited?: boolean;
 }
 
 export type TransferFundsParams = (InstructionFungibleLeg | InstructionNftLeg) & {

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -2675,6 +2675,21 @@ describe('bigNumberToU128', () => {
     expect(result).toBe(fakeResult);
   });
 
+  it('should spell out a value too large for decimal notation', () => {
+    // `Balance::MAX`; `toString` would give "3.40282366920938463463374607431768211455e+38"
+    const value = new BigNumber(2).exponentiatedBy(128).minus(1);
+    const fakeResult = 'max' as unknown as u128;
+    const context = dsMockUtils.getContextInstance();
+
+    when(context.createType)
+      .calledWith('u128', '340282366920938463463374607431768211455')
+      .mockReturnValue(fakeResult);
+
+    const result = bigNumberToU128(value, context);
+
+    expect(result).toBe(fakeResult);
+  });
+
   it('should throw an error if the number is negative', () => {
     const value = new BigNumber(-100);
     const context = dsMockUtils.getContextInstance();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,6 +21,14 @@ export const MAX_ASSET_MEDIATORS = 4;
  * Biggest possible number for on-chain balances
  */
 export const MAX_BALANCE = new BigNumber(Math.pow(10, 12));
+
+/**
+ * @hidden
+ *
+ * The raw allowance the chain reads as unlimited — `Balance::MAX`. `spend_allowance` never deducts
+ *   from an allowance of this size, so it does not run down as it is used
+ */
+export const UNLIMITED_ALLOWANCE = new BigNumber(2).exponentiatedBy(128).minus(1);
 /**
  * Account ID used for certain calls that require it when the SDK is instanced without one
  */

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -664,7 +664,11 @@ export function bigNumberToU64(value: BigNumber, context: Context): u64 {
 export function bigNumberToU128(value: BigNumber, context: Context): u128 {
   assertIsInteger(value);
   assertIsPositive(value);
-  return context.createType('u128', value.toString());
+  /*
+   * `toString` switches to exponential notation from 1e21, which the codec rejects. A `u128` holds
+   *   values far above that, so the digits have to be spelled out
+   */
+  return context.createType('u128', value.toFixed());
 }
 
 /**
@@ -1634,7 +1638,7 @@ export function bigNumberToBalance(value: BigNumber, context: Context, divisible
     });
   }
 
-  return context.createType('Balance', value.shiftedBy(6).toString());
+  return context.createType('Balance', value.shiftedBy(6).toFixed());
 }
 
 /**


### PR DESCRIPTION
### Description

Two commits.

**1. List the Asset allowances an Account has approved**

```typescript
account.getAllowances(paginationOpts?): Promise<ResultSet<AssetAllowance>>
fungibleAsset.getAllowances({ owner }): Promise<AssetAllowance[]>
// AssetAllowance = { asset, spender, amount, unlimited }
```

Only a single allowance could be read before, and only where the spender was already known — which for "what have I approved, and to whom" it is not.

Only the Account-level read pages: allowances are keyed `(owner, spender, assetId)`, so an owner prefix scan is exact, while the Asset-level read can only filter *after* the scan and would otherwise return short pages behind a cursor still claiming more.

No zero filtering — `approve(…, 0)` and a spend that drains an allowance both call `Allowances::remove`, so every result is live.

**2. Allow an unlimited allowance to be set**

`ApproveAllowanceParams.amount` documented `Balance::MAX = unlimited` and the chain honours it, but the value was rejected before it reached the chain — it was converted as a balance, which is capped at `MAX_BALANCE`. `amount` and `unlimited` are now both optional, and exactly one must be passed.

That surfaced a pre-existing bug in `bigNumberToU128`: it stringified with `toString`, which switches to exponential notation from 1e21, and the codec rejects that — so no caller could pass a `u128` above 1e21, not only this one. Now uses `toFixed()`. `bigNumberToBalance` is hardened the same way; it is safe today only because `MAX_BALANCE` keeps values three orders below the threshold.

#### Verification

`yarn build:ts`, `yarn lint` and `yarn test` (**209 suites / 2738 tests**) pass, with 100% coverage on the touched files. `api-snapshot:compare` reports no breaking changes — run locally, because an earlier discriminated-union form of `ApproveAllowanceParams` was flagged as breaking (`interface` → `type` reads as removal).

Exercised against a local dev chain, since testnet has one allowance entry and mainnet none:

| Check | Result |
|---|---|
| Paged, `size: 10` | 4 pages (10/10/10/1), 31 distinct, no repeats or skips |
| `Balance::MAX` | set through the SDK, read back with `unlimited: true` |
| Asset-level filter | 11 of 31, as expected |

The `u128` bug was only found this way — the unit test mocks `bigNumberToU128`, so it encoded the same assumption as the code.

#### Follow-up, not in this PR

`fungibleAsset.getAllowance()` returns a bare `BigNumber` with no `unlimited`, so it disagrees with the new type. Changing it is a return-type break; `getAllowances({ owner })` already carries the flag in the meantime.

### Breaking Changes

None.

### JIRA Link

<!-- add issue -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
